### PR TITLE
3.0.x: fall-through routes

### DIFF
--- a/classes/kohana/request.php
+++ b/classes/kohana/request.php
@@ -636,11 +636,13 @@ class Kohana_Request {
 				$controller = $this->controller;
 				$directory = $this->directory;
 				$action = $this->action;
+				$non_func_args = 1;
 
 				if (isset($params['directory']))
 				{
 					// Controllers are in a sub-directory
 					$directory = $params['directory'];
+					++$non_func_args;
 				}
 
 				// Store the controller
@@ -650,6 +652,7 @@ class Kohana_Request {
 				{
 					// Store the action
 					$action = $params['action'];
+					++$non_func_args;
 				}
 				else
 				{
@@ -659,25 +662,21 @@ class Kohana_Request {
 
 				if ($route->fall_through)
 				{
+					// Perform same substitution found in execute()
+					$prefix = 'controller_';
+					if ($directory) 
+					{
+						$prefix .= str_replace(array('\\', '/'), '_', trim($directory, '/')).'_';
+					}
+
 					try
 					{
-						// Perform same substitution found in execute()
-						$prefix = 'controller_';
-						if ($directory) 
-						{
-							$prefix .= str_replace(array('\\', '/'), '_', trim($directory, '/')).'_';
-						}
 						// Fetch controller and method
 						$class = new ReflectionClass($prefix.$controller);
+						
 						$method = $class->getMethod('action_'.$action);
-						// check to make sure there are enough arguments
-						$number_of_args = count(array_diff_key($params,
-							array(
-								'directory'=>NULL,
-								'controller'=>NULL,
-								'action'=>NULL
-							)));
-						if ($number_of_args < $method->getNumberOfRequiredParameters())
+						
+						if ((count($params) - $non_func_args) < $method->getNumberOfRequiredParameters())
 						{
 							// Not enough args passed to run method
 							continue;

--- a/classes/kohana/request.php
+++ b/classes/kohana/request.php
@@ -667,17 +667,25 @@ class Kohana_Request {
 						{
 							$prefix .= str_replace(array('\\', '/'), '_', trim($directory, '/')).'_';
 						}
+						// Fetch controller and method
 						$class = new ReflectionClass($prefix.$controller);
-
-
-						if ( ! $class->getMethod('action_'.$action)) {
-							// Action not found -- on to next route
+						$method = $class->getMethod('action_'.$action);
+						// check to make sure there are enough arguments
+						$number_of_args = count(array_diff_key($params,
+							array(
+								'directory'=>NULL,
+								'controller'=>NULL,
+								'action'=>NULL
+							)));
+						if ($number_of_args < $method->getNumberOfRequiredParameters())
+						{
+							// Not enough args passed to run method
 							continue;
 						}
 					} 
 					catch (ReflectionException $e)
 					{
-						// failed to load controller class -- skip to next route
+						// failed to load controller or method -- skip to next route
 						continue;
 					}
 					// Controller and method exist: continue with processing

--- a/classes/kohana/route.php
+++ b/classes/kohana/route.php
@@ -187,6 +187,11 @@ class Kohana_Route {
 	protected $_route_regex;
 
 	/**
+	 * @var  boolean  use next route if not found
+	 */
+	public $fall_through = FALSE;
+
+	/**
 	 * Creates a new route. Sets the URI and regular expressions for keys.
 	 * Routes should always be created with [Route::set] or they will not
 	 * be properly stored.
@@ -234,6 +239,21 @@ class Kohana_Route {
 	{
 		$this->_defaults = $defaults;
 
+		return $this;
+	}
+
+	/**
+	 * Sets the "fall-through" property of this route. A fall-through route
+	 * will be skipped if either the controller or action do not exist.
+	 *
+	 *     $route->fall_through(TRUE);
+	 *
+	 * @param   boolean  Fall-through setting
+	 * @return  $this
+	 */
+	public function fall_through($fall_through=TRUE)
+	{
+		$this->fall_through = $fall_through;
 		return $this;
 	}
 


### PR DESCRIPTION
# Fall-Through Routes

**Summary:** _Optionally allows the request engine to detect whether or not a controller and action exist before committing to a specific route choice. This in turn allows users to continue to employ "catch-all" routes while still easily detecting invalid URLs and routing invalid requests to an appropriate error page._

This patch adds a potential solution to the problem people are experiencing getting proper 404-handling working. Because proper 404 handling is so difficult to set up correctly, many sites do not implement it properly and instead end up showing a 500 error when a 404 is appropriate. Such a site is less user-friendly and less search-engine-friendly than it could have otherwise been.

**Case in point:  http://kohanaframework.org/foo**

The primary problem relates to catch-all "default" routing rules. These allow the controller and action to be specified dynamically with no further route customization; but unfortunately such a routing rule greedily accepts many URL patterns that it cannot process. These invalid URLs show up as 500 errors with a stack trace, as seen in the **kahonaframework.org** link above.
## How this problem is solved

The solution is simple: Routes can now optionally be marked as "`fall_through`" in the bootstrap.php file. If a route is a "`fall_through`" route, then extra checking is done during the construction of the `Request` object. For such routes, the framework now verifies that the controller exists, and that it has a method matching the action that will be used to process the request. If that check fails, the framework skips that route and "falls through" to the next route in the list.

This allows for a route listing as follows. Note that this is better for a novice user than the [wingsc](http://github.com/shadowhand/wingsc/blob/master/application/bootstrap.php) solution in that the user is allowed to take advantage of dynamic catch-all routing, and the user isn't expected to write complex error handling logic. Furthermore, the _wingsc_ solution incorrectly treats **ALL** exceptions as 404 errors, not just those triggered by an invalid URL.

```
Route::set('default', '(<controller>(/<action>(/<id>)))')
    ->defaults(array(
        'controller' => 'welcome',
        'action'     => 'index',
    ))->fall_through();

Route::set('404', '<path>')
    ->defaults(array(
        'controller' => 'error',
        'action'     => '404',
    ));
```

A route is marked as being a "fall-through" route using the `fall_through()` member function as follows:

```
$route->fall_through(TRUE);
```

or simply

```
$route->fall_through(); // the default is TRUE 
```

I implemented this feature as a core modification rather than as a module because it changes the core behavior in such a way that would make maintaining separate module needlessly complex and error-prone. The feature causes no change in performance or behavior when not explicitly enabled. And the feature is useful in very nearly every Kohana installation and dramatically simplifies and improves the user's experience.

Contact me at devel@tlarson.com if you have any questions. I'm new to working on this project, and while I've tried to follow all the coding standards, if you see any spaces out of place or other minor errors, please just fix the small detail rather than rejecting the pull request.

Thanks!
-Tyler
