### PR TITLE
Bugfix/validation empty rules

### DIFF
--- a/classes/kohana/validation.php
+++ b/classes/kohana/validation.php
@@ -192,6 +192,25 @@ class Kohana_Validation extends ArrayObject {
 	}
 
 	/**
+	 * Helper method to quickly add 'not_empty' rules to an array of fields
+	 *
+	 *     // This provides a much shorter syntax for not_empty rules
+	 *     $validation->not_empty(array('first_name', 'last_name'));
+	 *
+	 * @param   array  array of fields to apply the 'not_empty' rule to
+	 * @return  $this
+	 */
+	public function not_empty(array $fields)
+	{
+		foreach ($fields as $field)
+		{
+			$this->rule($field, 'not_empty', NULL, TRUE);
+		}
+
+		return $this;
+	}
+
+	/**
 	 * Executes all validation rules. This should
 	 * typically be called within an if/else block.
 	 *

--- a/classes/kohana/validation.php
+++ b/classes/kohana/validation.php
@@ -30,9 +30,6 @@ class Kohana_Validation extends ArrayObject {
 	// Field labels
 	protected $_labels = array();
 
-	// Rules that are executed even when the value is empty
-	protected $_empty_rules = array('not_empty', 'matches');
-
 	// Error list, field => rule
 	protected $_errors = array();
 
@@ -276,7 +273,7 @@ class Kohana_Validation extends ArrayObject {
 				// Rules are defined as array($rule, $params)
 				list($rule, $params) = $array;
 
-				if ( ! in_array($rule, $this->_empty_rules) AND ! Valid::not_empty($value))
+				if ( ! Valid::not_empty($value))
 				{
 					// Skip this rule for empty fields
 					continue;

--- a/classes/kohana/validation.php
+++ b/classes/kohana/validation.php
@@ -114,18 +114,19 @@ class Kohana_Validation extends ArrayObject {
 	 * - :value - the value of the field
 	 *
 	 *     // The "username" must not be empty and have a minimum length of 4
-	 *     $validation->rule('username', 'not_empty')
+	 *     $validation->rule('username', 'not_empty', NULL, TRUE)
 	 *                ->rule('username', 'min_length', array('username', 4));
 	 *
 	 *     // The "password" field must match the "password_repeat" field
-	 *     $validation->rule('password', 'matches', array(':validation', 'password', 'password_repeat'));
+	 *     $validation->rule('password', 'matches', array(':validation', 'password', 'password_repeat'), TRUE);
 	 *
 	 * @param   string    field name
 	 * @param   callback  valid PHP callback
 	 * @param   array     extra parameters for the rule
+	 * @param   bool      whether or not to run the rule on an empty field
 	 * @return  $this
 	 */
-	public function rule($field, $rule, array $params = NULL)
+	public function rule($field, $rule, array $params = NULL, $run_if_empty = FALSE)
 	{
 		if ($params === NULL)
 		{
@@ -140,7 +141,7 @@ class Kohana_Validation extends ArrayObject {
 		}
 
 		// Store the rule and params for this rule
-		$this->_rules[$field][] = array($rule, $params);
+		$this->_rules[$field][] = array($rule, $params, $run_if_empty);
 
 		return $this;
 	}
@@ -156,7 +157,7 @@ class Kohana_Validation extends ArrayObject {
 	{
 		foreach ($rules as $rule)
 		{
-			$this->rule($field, $rule[0], Arr::get($rule, 1));
+			$this->rule($field, $rule[0], Arr::get($rule, 1), Arr::get($rule, 2, FALSE));
 		}
 
 		return $this;
@@ -271,9 +272,9 @@ class Kohana_Validation extends ArrayObject {
 			foreach ($set as $array)
 			{
 				// Rules are defined as array($rule, $params)
-				list($rule, $params) = $array;
+				list($rule, $params, $run_if_empty) = $array;
 
-				if ( ! Valid::not_empty($value))
+				if ( ! $run_if_empty AND ! Valid::not_empty($value))
 				{
 					// Skip this rule for empty fields
 					continue;


### PR DESCRIPTION
http://dev.kohanaframework.org/issues/3552 - Implemented the $run_if_empty parameter to rule()
http://dev.kohanaframework.org/issues/3553 - Implemented Validation::not_empty()

I still need to write unit tests but I have to get some sleep so I will write them tomorrow night if no one else has already.

I really quite like this implementation after trying it because you can do this for example:

```
$validation
    // This field cannot be empty!
    ->rule('field1', 'min_length' array(':value', 5), TRUE)
    // This field can be empty!
    ->rule('field2', 'min_length' array(':value', 5));
```

This feels like another step towards a very powerful, but simple, validation library.
