### PR TITLE
Feature/3536 args

### DIFF
--- a/classes/kohana/core.php
+++ b/classes/kohana/core.php
@@ -1061,17 +1061,25 @@ class Kohana_Core {
 			} 
 			else
 			{
-				if ($null_pad) 
+				if ($func_param->isDefaultValueAvailable())
 				{
-					// Note that null-padding the array isn't, strictly speaking,
-					// "correct". However, if you *don't* null pad, then parameters
-					// after the missing one can't be assigned. Either way, we're
-					// dealing with undefined behavior, so we have to pick a compromise.
-					$args[] = NULL;
-				} 
+					// use the default value provided in the function signature if it exists
+					$args[] = $func_param->getDefaultValue();
+				}
 				else
 				{
-					break;
+					if ($null_pad)
+					{
+						// Note that null-padding the array isn't, strictly speaking,
+						// "correct". However, if you *don't* null pad, then parameters
+						// after the missing one can't be assigned. Either way, we're
+						// dealing with undefined behavior, so we have to pick a compromise.
+						$args[] = NULL;
+					}
+					else
+					{
+						break;
+					}
 				}
 			}
 		}

--- a/classes/kohana/core.php
+++ b/classes/kohana/core.php
@@ -1037,4 +1037,46 @@ class Kohana_Core {
 		}
 	}
 
+	/**
+	 * A wrapper for invokeArgs which takes an associative array as input
+	 * and assigns parameters by name rather than by order.
+	 *
+	 * @param ReflectionMethod  method to call
+	 * @param array             keyed argument list
+	 * @param mixed             class instance (or null if not an instance method)
+	 * @param boolean           True if we want substitude NULL for missing parameters
+	 * @return mixed            The return value of the method call
+	 */
+	public static function invoke_with_args(ReflectionMethod $method, $parameters, $object=NULL, $null_pad=FALSE)
+	{
+		$func_params = $method->getParameters();
+		$args = array();
+		// Iterate through the function paramters and grab the parameters it calls for
+		foreach ($func_params as $func_param)
+		{
+			if (array_key_exists($func_param->name,$parameters))
+			{
+				// set a reference to make our little re-arrangment transparent
+				$args[] = & $parameters[$func_param->name];
+			} 
+			else
+			{
+				if ($null_pad) 
+				{
+					// Note that null-padding the array isn't, strictly speaking,
+					// "correct". However, if you *don't* null pad, then parameters
+					// after the missing one can't be assigned. Either way, we're
+					// dealing with undefined behavior, so we have to pick a compromise.
+					$args[] = NULL;
+				} 
+				else
+				{
+					break;
+				}
+			}
+		}
+		// even for static methods, you still pass a class object (which can be null)
+		return $method->invokeArgs($object,$args);
+	}
+
 } // End Kohana

--- a/classes/kohana/request/client/internal.php
+++ b/classes/kohana/request/client/internal.php
@@ -126,10 +126,13 @@ class Kohana_Request_Client_Internal extends Request_Client {
 			/**
 			 * Execute the main action with the parameters
 			 *
-			 * @deprecated $params passing is deprecated since version 3.1
-			 *             will be removed in 3.2.
+			 * We choose to null-pad by policy here. Unassigned parameters get
+			 * NULL rather than causing unexpected behavior, which would be
+			 * much more confusing. If you want a parameter to have a default
+			 * value, set the default in your route.
 			 */
-			$method->invokeArgs($controller, $params);
+
+			Kohana::invoke_with_args($method,$params,$controller,TRUE);
 
 			// Execute the "after action" method
 			$class->getMethod('after')->invoke($controller);

--- a/classes/kohana/request/client/internal.php
+++ b/classes/kohana/request/client/internal.php
@@ -125,14 +125,9 @@ class Kohana_Request_Client_Internal extends Request_Client {
 
 			/**
 			 * Execute the main action with the parameters
-			 *
-			 * We choose to null-pad by policy here. Unassigned parameters get
-			 * NULL rather than causing unexpected behavior, which would be
-			 * much more confusing. If you want a parameter to have a default
-			 * value, set the default in your route.
 			 */
 
-			Kohana::invoke_with_args($method,$params,$controller,TRUE);
+			Kohana::invoke_with_args($method,$params,$controller);
 
 			// Execute the "after action" method
 			$class->getMethod('after')->invoke($controller);


### PR DESCRIPTION
Assign arguments by name for controller actions. This works by using reflection to determine the appropriate order of the arguments, and then creating an array that is ordered appropriate for the function call.

This way we don't have to resort to silliness like `$this->request->param('foo')` when simply `$foo` will suffice.
