### PR TITLE
Feature/3626 session pattern and configuration checks

### DIFF
--- a/classes/kohana/session.php
+++ b/classes/kohana/session.php
@@ -13,7 +13,7 @@ abstract class Kohana_Session {
 	/**
 	 * @var  string  default session adapter
 	 */
-	public static $default = null;
+	public static $default = NULL;
 
 	/**
 	 * @var  array  session instances
@@ -31,7 +31,7 @@ abstract class Kohana_Session {
 	 *
 	 * [!!] [Session::write] will automatically be called when the request ends.
 	 *  
-	 * @deprecated deprecated as it doesn't do what it says on the tin. Use getSession instead. Should be removed in next major release.
+	 * @deprecated deprecated as it doesn't do what it says on the tin. Use get_session instead. Should be removed in next major release.
 	 * @param   string   type of session (native, cookie, etc)
 	 * @param   string   session identifier
 	 * @return  Session
@@ -39,7 +39,7 @@ abstract class Kohana_Session {
 	 */
 	public static function instance($type = NULL, $id = NULL)
 	{
-		return Session::getSession($type,$id);
+		return Session::getSession($type, $id);
 	}
 	
 	/**


### PR DESCRIPTION
This patch covers multiple Problems.

== Incorrect Design Pattern ==

_Summary:_ _The current 3.x design has Sessions implementing the Singleton Design Pattern with function instance(). Unfortunately, the Session Class isn't a true singleton as it can return other sessions of a different type._

The patch corrects this by renaming instance() to get_session() which is consistent with the Lazy Initialization pattern (which is exactly what this is). This will help to remove any assumptions and or confusion relating to what this function does (assumptions being the operative problem).

== Issues with @Session::$default@ ==

_Summary:_ _Although it is intended to use Session::$default in a centralized place, it is repeatedly commented that this should be something along the lines of Controller_Base or alike. This removes the nice features of MVC in that you can swap out the controllers at will._

There are two solutions to this, both perfectly valid:
1. Clarify the documentation so that people realise that  under most circumstances bootstrap.php is probably the best place for Session::$default to be set
2.  Provide a mechanism to allow developers to include default selection in the session configuration. This is my personal favourite as it doesn't remove the current option to set Session::$default, however it seems weird that there is no reference to it in the config as everything else is there already.

=== This patch's solution ===

First check if Session::$default is set, if not check configuration session.default, if it is not then set to 'native'.

== Default configuration allows for session cookie name collision. ==

_Summary:_ _Configuration of the session drivers doesn't contain name attributes. The session driver has a default value. As Session isn't a singleton, there is quite a real possibility of session collision occurring where one driver overwrites the session cookie already set by another._

This patch corrects this by removing the option of a default value. It also checks the entire configuration to ensure that the configured drivers have unique cookie names. If either of these problems occur it throws an exception.
