### PR TITLE
Updated version number

### DIFF
--- a/classes/kohana/core.php
+++ b/classes/kohana/core.php
@@ -16,7 +16,7 @@
 class Kohana_Core {
 
 	// Release version and codename
-	const VERSION  = '3.0.9';
+	const VERSION  = '3.1.0';
 	const CODENAME = 'nya året';
 
 	// Log message types


### PR DESCRIPTION
This is the 3.1.0 (RC2) release, correct? If so, shouldnt the core version constant reflect that?

**If so,**
The stable 3.0.9 release available from http://kohanaframework.org/ also has this constant wrong. It's set to 3.0.8 in that package.
