### PR TITLE
Upgrade guide: Adding Log const changes

### DIFF
--- a/classes/kohana/http/header/value.php
+++ b/classes/kohana/http/header/value.php
@@ -129,7 +129,7 @@ class Kohana_Http_Header_Value {
 		// Unrecognised value type
 		else
 		{
-			throw new Http_Exception(__METHOD__.' unknown header value type: :type. array or string allowed.', array(':type' => gettype($value)));
+			throw new Http_Exception_500(__METHOD__.' unknown header value type: :type. array or string allowed.', array(':type' => gettype($value)));
 		}
 	}
 

--- a/classes/kohana/request.php
+++ b/classes/kohana/request.php
@@ -31,7 +31,7 @@ class Kohana_Request implements Http_Request {
 	 */
 	public static $current;
 
-	public static function factory($uri = TRUE, Kohana_Cache $cache = NULL)
+	public static function factory($uri = TRUE, Cache $cache = NULL)
 	{
 		// If this is the initial request
 		if ( ! Request::$initial)
@@ -626,6 +626,9 @@ class Kohana_Request implements Http_Request {
 	 * created using the [Request::instance] or [Request::factory] methods.
 	 *
 	 *     $request = new Request($uri);
+	 * 
+	 * If $cache parameter is set, the response for the request will attempt to
+	 * be retrieved from the cache.
 	 *
 	 * @param   string  $uri URI of the request
 	 * @param   Cache   $cache
@@ -634,7 +637,7 @@ class Kohana_Request implements Http_Request {
 	 * @uses    Route::all
 	 * @uses    Route::matches
 	 */
-	public function __construct($uri, Kohana_Cache $cache = NULL)
+	public function __construct($uri, Cache $cache = NULL)
 	{
 		// Initialise the header
 		$this->_header = new Http_Header(array());

--- a/classes/kohana/request.php
+++ b/classes/kohana/request.php
@@ -959,7 +959,7 @@ class Kohana_Request implements Http_Request {
 	public function execute()
 	{
 		if ( ! $this->_client instanceof Kohana_Request_Client)
-			throw new Kohana_Request_Exception('Unable to execute :uri without a Kohana_Request_Client', array(':uri', $this->uri));
+			throw new Kohana_Request_Exception('Unable to execute :uri without a Kohana_Request_Client', array(':uri', $this->_uri));
 
 		return $this->_client->execute($this);
 	}

--- a/classes/kohana/request/client.php
+++ b/classes/kohana/request/client.php
@@ -156,7 +156,8 @@ abstract class Kohana_Request_Client {
 	 */
 	public function set_cache(Response $response)
 	{
-		if ($response->headers()->offsetExists('cache-control') AND $cache_control = $response->headers()->offsetGet('cache-control'))
+		$headers = (array) $response->headers();
+		if ($cache_control = arr::get($headers, 'cache-control'))
 		{
 			// Parse the cache control
 			$cache_control = Response::parse_cache_control( (string) $cache_control);
@@ -183,7 +184,7 @@ abstract class Kohana_Request_Client {
 				return FALSE;
 		}
 
-		if (($expires = $response->headers('expires')) and ! isset($cache_control['max-age']))
+		if ($expires = arr::get($headers, 'expires') and ! isset($cache_control['max-age']))
 		{
 			if (strtotime( (string) $expires) >= time())
 				return FALSE;

--- a/classes/kohana/request/client.php
+++ b/classes/kohana/request/client.php
@@ -46,7 +46,11 @@ abstract class Kohana_Request_Client {
 			{
 				if (method_exists($this, $key))
 				{
-					$this->$key($value);
+					if (property_exists($this, $key) OR property_exists($this, '_'.$key))
+					{
+						$method = trim($key, '_');
+						$this->$method($value);
+					}
 				}
 			}
 		}
@@ -152,7 +156,7 @@ abstract class Kohana_Request_Client {
 	 */
 	public function set_cache(Response $response)
 	{
-		if ($cache_control = $response->headers()->offsetExists('cache-control'))
+		if ($response->headers()->offsetExists('cache-control') AND $cache_control = $response->headers()->offsetGet('cache-control'))
 		{
 			// Parse the cache control
 			$cache_control = Response::parse_cache_control( (string) $cache_control);
@@ -280,7 +284,7 @@ abstract class Kohana_Request_Client {
 
 			if (isset($cache_control['max-age']))
 			{
-				$ttl = (int) $cache_control['max_age'];
+				$ttl = (int) $cache_control['max-age'];
 			}
 
 			if (isset($cache_control['s-maxage']) AND isset($cache_control['private']) AND $this->_allow_private_cache)

--- a/classes/kohana/request/client.php
+++ b/classes/kohana/request/client.php
@@ -186,7 +186,8 @@ abstract class Kohana_Request_Client {
 
 		if ($expires = arr::get($headers, 'expires') and ! isset($cache_control['max-age']))
 		{
-			if (strtotime( (string) $expires) >= time())
+			// Can't cache things that have expired already
+			if (strtotime( (string) $expires) <= time())
 				return FALSE;
 		}
 

--- a/classes/kohana/request/client/internal.php
+++ b/classes/kohana/request/client/internal.php
@@ -105,7 +105,7 @@ class Kohana_Request_Client_Internal extends Request_Client {
 			}
 
 			// Create a new instance of the controller
-			$controller = $class->newInstance($request, $request->create_response());
+			$controller = $class->newInstance($request, $request->response() ? $request->response() : $request->create_response());
 
 			$class->getMethod('before')->invoke($controller);
 

--- a/classes/kohana/response.php
+++ b/classes/kohana/response.php
@@ -310,7 +310,7 @@ class Kohana_Response implements Http_Response, Serializable {
 		}
 		elseif ($value === NULL)
 		{
-			return $this->_header[$key];
+			return Arr::get($this->_header, $key);
 		}
 		else
 		{

--- a/classes/kohana/response.php
+++ b/classes/kohana/response.php
@@ -568,14 +568,14 @@ class Kohana_Response implements Http_Response, Serializable {
 			}
 
 			// Range of bytes being sent
-			$this->_header['content-tange'] = 'bytes '.$start.'-'.$end.'/'.$size;
+			$this->_header['content-range'] = 'bytes '.$start.'-'.$end.'/'.$size;
 			$this->_header['accept-ranges'] = 'bytes';
 		}
 
 		// Set the headers for a download
 		$this->_header['content-disposition'] = $disposition.'; filename="'.$download.'"';
 		$this->_header['content-type']        = $mime;
-		$this->_header['content-length']      = ($end - $start) + 1;
+		$this->_header['content-length']      = (string) (($end - $start) + 1);
 
 		if (Request::user_agent('browser') === 'Internet Explorer')
 		{

--- a/classes/kohana/response.php
+++ b/classes/kohana/response.php
@@ -810,7 +810,7 @@ class Kohana_Response implements Http_Response, Serializable {
 
 		$serialized = serialize($to_serialize);
 
-		if (is_string($string))
+		if (is_string($serialized))
 		{
 			return $string;
 		}

--- a/guide/kohana/debugging.md
+++ b/guide/kohana/debugging.md
@@ -2,10 +2,10 @@
 
 Kohana includes several tools to help you debug your application.
 
-The most basic of these is [Kohana::debug]. This simple method will display any number of variables, similar to [var_export](http://php.net/var_export) or [print_r](http://php.net/print_r), but using HTML for extra formatting.
+The most basic of these is [Debug::vars]. This simple method will display any number of variables, similar to [var_export](http://php.net/var_export) or [print_r](http://php.net/print_r), but using HTML for extra formatting.
 
     // Display a dump of the $foo and $bar variables
-    echo Debug::dump($foo, $bar);
+    echo Debug::vars($foo, $bar);
 
 Kohana also provides a method to show the source code of a particular file using [Debug::source].
 

--- a/guide/kohana/upgrading.md
+++ b/guide/kohana/upgrading.md
@@ -75,3 +75,7 @@ The main change here is that the request execution has been removed from bootstr
 ## 404 Handling
 
 Kohana now has built in exception support for 404 and other http status codes. If you were using ReflectionException to detect 404s, you should be using Http_Exception_404 instead. For details on how to handle 404s, see [error handling](errors).
+
+## Form Class
+
+If you used Form::open(), the default behavior has changed. It used to default to the current URI, but now an empty parameter will default to "/" (your home page).

--- a/guide/kohana/upgrading.md
+++ b/guide/kohana/upgrading.md
@@ -79,3 +79,11 @@ Kohana now has built in exception support for 404 and other http status codes. I
 ## Form Class
 
 If you used Form::open(), the default behavior has changed. It used to default to the current URI, but now an empty parameter will default to "/" (your home page).
+
+## Logging
+
+The log message level constants now belong to the Log class.  If you are referencing those constants to invoke Kohana::$log->add( ... ) you will need to change the following:
+
+    - Kohana::ERROR -> Log::ERROR
+    - Kohana::DEBUG -> Log::DEBUG
+    - Kohana::INFO  -> Log::INFO

--- a/tests/kohana/Http/Header/ValueTest.php
+++ b/tests/kohana/Http/Header/ValueTest.php
@@ -90,11 +90,11 @@ class Kohana_HTTP_Header_ValueTest extends Unittest_TestCase
 	}
 	/**
 	 * If the constructor is passed a value of type other than string|array then it should
-	 * throw a Kohana_HTTP_Header_Exception
+	 * throw a Http_Exception_500
 	 *
 	 * @test
 	 * @dataProvider provider_constructor_throws_exception_if_header_value_type_not_allowed
-	 * @expectedException Kohana_Exception
+	 * @expectedException Http_Exception_500
 	 * @param mixed The header value to pass to the constructor
 	 */
 	public function test_constructor_throws_exception_if_header_value_type_not_allowed($header)

--- a/tests/kohana/RequestTest.php
+++ b/tests/kohana/RequestTest.php
@@ -220,6 +220,23 @@ class Kohana_RequestTest extends Unittest_TestCase
 	public function test_cache()
 	{
 		/**
+		 * Sets up a mock cache object, asserts that:
+		 * 
+		 *  1. The cache set() method gets called
+		 *  2. The cache get() method will return the response above when called
+		 */
+		$cache = $this->getMock('Cache_File', array('get', 'set'), array(), 'Cache');
+		$cache->expects($this->once())
+			->method('set');
+
+		$foo = Request::factory('', $cache);
+		$response = $foo->create_response(TRUE);
+
+		$response->headers('Cache-Control', 'max-age=100');
+		$foo->response($response);
+		$foo->execute();
+
+		/**
 		 * Set up a mock response object to test with
 		 */
 		$response = $this->getMock('Response');
@@ -227,30 +244,10 @@ class Kohana_RequestTest extends Unittest_TestCase
 			->method('body')
 			->will($this->returnValue('Foo'));
 
-		/**
-		 * Sets up a mock cache object, asserts that:
-		 * 
-		 *  1. The cache set() method gets called
-		 *  2. The cache get() method will return the response above when called
-		 */
-		$cache = $this->getMock(
-			'Cache_File', array('get', 'set'), array(), 'Cache'
-		);
-		$cache->expects($this->once())
-			->method('set');
 		$cache->expects($this->any())
 			->method('get')
 			->will($this->returnValue($response));
 
-		$foo = Request::factory('', $cache);
-		$response = $foo->create_response(TRUE);
-
-		// This will assert that set() is called on the cache object
-		$response->headers('Cache-Control', 'max-age=100');
-		$foo->response($response);
-		$foo->execute();
-
-		// This will return the response from the cache mock
 		$foo = Request::factory('', $cache)->execute();
 		$this->assertSame('Foo', $foo->body());
 	}

--- a/tests/kohana/RequestTest.php
+++ b/tests/kohana/RequestTest.php
@@ -211,4 +211,47 @@ class Kohana_RequestTest extends Unittest_TestCase
 
 		$this->assertEquals(Request::factory($uri)->url($params, $protocol), $expected);
 	}
+
+	/**
+	 * Tests that request caching works
+	 *
+	 * @return null
+	 */
+	public function test_cache()
+	{
+		/**
+		 * Set up a mock response object to test with
+		 */
+		$response = $this->getMock('Response');
+		$response->expects($this->any())
+			->method('body')
+			->will($this->returnValue('Foo'));
+
+		/**
+		 * Sets up a mock cache object, asserts that:
+		 * 
+		 *  1. The cache set() method gets called
+		 *  2. The cache get() method will return the response above when called
+		 */
+		$cache = $this->getMock(
+			'Cache_File', array('get', 'set'), array(), 'Cache'
+		);
+		$cache->expects($this->once())
+			->method('set');
+		$cache->expects($this->any())
+			->method('get')
+			->will($this->returnValue($response));
+
+		$foo = Request::factory('', $cache);
+		$response = $foo->create_response(TRUE);
+
+		// This will assert that set() is called on the cache object
+		$response->headers('Cache-Control', 'max-age=100');
+		$foo->response($response);
+		$foo->execute();
+
+		// This will return the response from the cache mock
+		$foo = Request::factory('', $cache)->execute();
+		$this->assertSame('Foo', $foo->body());
+	}
 }

--- a/tests/kohana/RequestTest.php
+++ b/tests/kohana/RequestTest.php
@@ -290,19 +290,19 @@ class Kohana_RequestTest extends Unittest_TestCase
 				array('private' => NULL, 's-maxage' => '100'),
 				TRUE
 			),
-			array( // We can cache things that expired yesterday (should not be able to?)
+			array(
 				array(
 					'expires' => date('m/d/Y', strtotime('-1 day')),
 				),
 				array(),
-				TRUE
+				FALSE
 			),
-			array( // We can't cache things that expires tomorrow (should be able to?)
+			array(
 				array(
 					'expires' => date('m/d/Y', strtotime('+1 day')),
 				),
 				array(),
-				FALSE
+				TRUE
 			),
 			array(
 				array(),

--- a/tests/kohana/RequestTest.php
+++ b/tests/kohana/RequestTest.php
@@ -251,4 +251,89 @@ class Kohana_RequestTest extends Unittest_TestCase
 		$foo = Request::factory('', $cache)->execute();
 		$this->assertSame('Foo', $foo->body());
 	}
+
+	/**
+	 * Data provider for test_set_cache
+	 *
+	 * @return array
+	 */
+	public function provider_set_cache()
+	{
+		return array(
+			array(
+				array('cache-control' => 'no-cache'),
+				array('no-cache' => NULL),
+				FALSE,
+			),
+			array(
+				array('cache-control' => 'no-store'),
+				array('no-store' => NULL),
+				FALSE,
+			),
+			array(
+				array('cache-control' => 'max-age=100'),
+				array('max-age' => '100'),
+				TRUE
+			),
+			array(
+				array('cache-control' => 'private'),
+				array('private' => NULL),
+				FALSE
+			),
+			array(
+				array('cache-control' => 'private, max-age=100'),
+				array('private' => NULL, 'max-age' => '100'),
+				FALSE
+			),
+			array(
+				array('cache-control' => 'private, s-maxage=100'),
+				array('private' => NULL, 's-maxage' => '100'),
+				TRUE
+			),
+			array( // We can cache things that expired yesterday (should not be able to?)
+				array(
+					'expires' => date('m/d/Y', strtotime('-1 day')),
+				),
+				array(),
+				TRUE
+			),
+			array( // We can't cache things that expires tomorrow (should be able to?)
+				array(
+					'expires' => date('m/d/Y', strtotime('+1 day')),
+				),
+				array(),
+				FALSE
+			),
+			array(
+				array(),
+				array(),
+				TRUE
+			),
+		);
+	}
+
+	/**
+	 * Tests the set_cache() method
+	 *
+	 * @test
+	 * @dataProvider provider_set_cache
+	 * 
+	 * @return null
+	 */
+	public function test_set_cache($headers, $cache_control, $expected)
+	{
+		/**
+		 * Set up a mock response object to test with
+		 */
+		$response = $this->getMock('Response');
+		$response->expects($this->any())
+			->method('parse_cache_control')
+			->will($this->returnValue($cache_control));
+		$response->expects($this->any())
+			->method('headers')
+			->will($this->returnValue($headers));
+
+		$request = new Request_Client_Internal;
+		$this->assertEquals($request->set_cache($response), $expected);
+	}
 }

--- a/tests/kohana/ResponseTest.php
+++ b/tests/kohana/ResponseTest.php
@@ -37,4 +37,40 @@ class Kohana_ResponseTest extends Unittest_TestCase
 		$headers = $response->send_headers()->headers();
 		$this->assertArrayNotHasKey('x-powered-by', (array) $headers);
 	}
+
+	/**
+	 * Provider for test_body
+	 *
+	 * @return array
+	 */
+	public function provider_body()
+	{
+		$view = $this->getMock('View');
+		$view->expects($this->any())
+			->method('__toString')
+			->will($this->returnValue('foo'));
+
+		return array(
+			array('unit test', 'unit test'),
+			array($view, 'foo'),
+		);
+	}
+
+	/**
+	 * Tests that we can set and read a body of a response
+	 * 
+	 * @test
+	 * @dataProvider provider_body
+	 *
+	 * @return null
+	 */
+	public function test_body($source, $expected)
+	{
+		$response = new Response;
+		$response->body($source);
+		$this->assertSame($response->body(), $expected);
+
+		$response = (string) $response;
+		$this->assertSame($response, $expected);
+	}
 }


### PR DESCRIPTION
3 constants for log message types have moved from Kohana_Core to Kohana_Log. I've updated upgrading.md in the userguide to mention these changes.

Also, I filed the bug report at http://dev.kohanaframework.org/issues/3723

Thanks,

Stephen
