### PR TITLE
Upgrade guide: Adding Log const changes

### DIFF
--- a/guide/kohana/upgrading.md
+++ b/guide/kohana/upgrading.md
@@ -79,3 +79,11 @@ Kohana now has built in exception support for 404 and other http status codes. I
 ## Form Class
 
 If you used Form::open(), the default behavior has changed. It used to default to the current URI, but now an empty parameter will default to "/" (your home page).
+
+## Logging
+
+The log message level constants now belong to the Log class.  If you are referencing those constants to invoke Kohana::$log->add( ... ) you will need to change the following:
+
+    - Kohana::ERROR -> Log::ERROR
+    - Kohana::DEBUG -> Log::DEBUG
+    - Kohana::INFO  -> Log::INFO


### PR DESCRIPTION
3 constants for log message types have moved from Kohana_Core to Kohana_Log. I've updated upgrading.md in the userguide to mention these changes.

Also, I filed the bug report at http://dev.kohanaframework.org/issues/3723

Thanks,

Stephen
