### PR TITLE
3.1/develop

### DIFF
--- a/guide/kohana/upgrading.md
+++ b/guide/kohana/upgrading.md
@@ -12,10 +12,10 @@ This has changed to:
 
 Some properties that existed in the request class have been converted into methods:
 
-	- Request::$controller -> Request::controller()
-	- Request::$action -> Request::action()
-	- Request::$directory -> Request::directory()
-	- Request::$uri -> Request::uri()
+	- $this->request->controller -> $this->request->controller() //Or Request::current()->controller();
+	- $this->request->action -> $this->request->action()
+	- $this->request->directory -> $this->request->directory()
+	- $this->request->uri -> $this->request->uri()
 
 Request::instance() has been replaced by Request::current() and Request::initial(). Normally you'll want to use Request::current(), but if you are sure you want the *original* request (when running hmvc requests), use Request::initial().
 


### PR DESCRIPTION
Clarifying in the migration guide that the new Request::controller(), action(), etc methods are instance methods not statics per [this forum post](http://forum.kohanaframework.org/discussion/comment/55215/#Comment_55215)
