### PR TITLE
3.1/master

### DIFF
--- a/classes/kohana/controller/rest.php
+++ b/classes/kohana/controller/rest.php
@@ -53,6 +53,8 @@ abstract class Kohana_Controller_REST extends Controller {
 	 */
 	public function before()
 	{
+		parent::before();
+		
 		$this->_action_requested = $this->request->action();
 
 		$method = Arr::get($_SERVER, 'HTTP_X_HTTP_METHOD_OVERRIDE', $this->request->method());
@@ -65,8 +67,6 @@ abstract class Kohana_Controller_REST extends Controller {
 		{
 			$this->request->action($this->_action_map[$method]);
 		}
-
-		return parent::before();
 	}
 
 	/**

--- a/classes/kohana/controller/template.php
+++ b/classes/kohana/controller/template.php
@@ -25,13 +25,13 @@ abstract class Kohana_Controller_Template extends Controller {
 	 */
 	public function before()
 	{
+		parent::before();
+		
 		if ($this->auto_render === TRUE)
 		{
 			// Load the template
 			$this->template = View::factory($this->template);
 		}
-
-		return parent::before();
 	}
 
 	/**


### PR DESCRIPTION
It really doesn't make any sense to promote calling the parent's before() action _after_ the child's.

Take an ACL which initiates in Controller_Application for example:

if it doesn't do the job that's supposed to be done on the application level, child controllers extending the Controller_Application will be potentionally vulnerable, at least the stuff being executed in the before() method.
