### PR TITLE
Fixed a few bugs in the tutorial custom error pages for Kohana 3.1:

### DIFF
--- a/guide/kohana/tutorials/error-pages.md
+++ b/guide/kohana/tutorials/error-pages.md
@@ -38,7 +38,7 @@ Our custom exception handler is self explanatory.
 					}
 
 					// Error sub-request.
-					echo Request::factory(Route::url('error', $attributes))
+					echo Request::factory(Route::get('error')->uri($attributes))
 					->execute()
 					->send_headers()
 					->body();
@@ -83,7 +83,7 @@ would display an error 500 page.
 
 	Route::set('error', 'error/<action>(/<message>)', array('action' => '[0-9]++', 'message' => '.+'))
 	->defaults(array(
-		'controller' => 'error_handler'
+		'controller' => 'error'
 	));
 
 ## 2. The Error Page Controller
@@ -92,10 +92,10 @@ would display an error 500 page.
 	{
 		parent::before();
 
-		$this->template->page = URL::site(rawurldecode(Request::$instance->uri));
+		$this->template->page = URL::site(rawurldecode(Request::$initial->uri()));
 
 		// Internal request only!
-		if (Request::$instance !== Request::$current)
+		if (Request::$initial !== $this->request)
 		{
 			if ($message = rawurldecode($this->request->param('message')))
 			{


### PR DESCRIPTION
References: Bug Report #3894
1. The original code generates a url with the base_url prepended.
   For apps with non-empty base_url, that produces the error:
   "Unable to find a route to match e.g. 'kohana_test/error/404/message...'
2. The controller name should be consistent in the route.
3. Request::$instance doesn't exist anymore and uri is a method now.
