### PR TITLE
3.2/feature/3902 date formatted time timezones

### DIFF
--- a/classes/kohana/date.php
+++ b/classes/kohana/date.php
@@ -579,8 +579,9 @@ class Kohana_Date {
 	 *     $time = Date::formatted_time('5 minutes ago');
 	 *
 	 * @see     http://php.net/manual/en/datetime.construct.php
-	 * @param   string  datetime_str     datetime string
-	 * @param   string  timestamp_format timestamp format
+	 * @param   string  datetime string
+	 * @param   string  timestamp format
+	 * @param   string  timezone identifier
 	 * @return  string
 	 */
 	public static function formatted_time($datetime_str = 'now', $timestamp_format = NULL, $timezone = NULL)
@@ -588,9 +589,13 @@ class Kohana_Date {
 		$timestamp_format = ($timestamp_format == NULL) ? Date::$timestamp_format : $timestamp_format;
 		$timezone         = ($timezone === NULL) ? Date::$timezone : $timezone;
 
-		$time = new DateTime($datetime_str, new DateTimeZone(
-			$timezone ? $timezone : date_default_timezone_get()
-		));
+		$tz   = new DateTimeZone($timezone ? $timezone : date_default_timezone_get());
+		$time = new DateTime($datetime_str, $tz);
+
+		if ($time->getTimeZone()->getName() !== $tz->getName())
+		{
+			$time->setTimeZone($tz);
+		}
 
 		return $time->format($timestamp_format);
 	}

--- a/tests/kohana/DateTest.php
+++ b/tests/kohana/DateTest.php
@@ -248,6 +248,10 @@ class Kohana_DateTest extends Unittest_TestCase
 			// Now we use our own format
 			// Binary date!
 			array('01/01/2010 01:00', '1AM 1st January 2010', 'd/m/Y H:i'),
+			// Timezones (see #3902)
+			array('2011-04-01 01:23:45 Antarctica/South_Pole', '2011-04-01 01:23:45', 'Y-m-d H:i:s e', 'Antarctica/South_Pole'),
+			array('2011-04-01 01:23:45 Antarctica/South_Pole', '2011-03-31 14:23:45 Europe/Paris', 'Y-m-d H:i:s e', 'Antarctica/South_Pole'),
+			array('2011-04-01 01:23:45 Antarctica/South_Pole', '@1301574225', 'Y-m-d H:i:s e', 'Antarctica/South_Pole'),
 		);
 	}
 
@@ -257,14 +261,15 @@ class Kohana_DateTest extends Unittest_TestCase
 	 * @test
 	 * @dataProvider provider_formatted_time
 	 * @covers Date::formatted_time
-	 * @ticket 3035
+	 * @ticket 3035 3902
 	 * @param string         $expected         Expected output
 	 * @param string|integer $datetime_str     The datetime timestamp / string
 	 * @param string|null    $timestamp_format The output format
+	 * @param string|null    $timezone         The timezone identifier
 	 */
-	public function test_formatted_time($expected, $datetime_str, $timestamp_format = NULL)
+	public function test_formatted_time($expected, $datetime_str, $timestamp_format = NULL, $timezone = NULL)
 	{
-		$timestamp = Date::formatted_time($datetime_str, $timestamp_format);
+		$timestamp = Date::formatted_time($datetime_str, $timestamp_format, $timezone);
 
 		$this->assertSame($expected, $timestamp);
 	}


### PR DESCRIPTION
Make Date::formatted_time()'s timezone parameter work even if the input date/time string has a timezone. 

http://dev.kohanaframework.org/issues/3902
