### PR TITLE
Feature Request #3234 (Text::auto_link() and attributes)

### DIFF
--- a/classes/kohana/html.php
+++ b/classes/kohana/html.php
@@ -341,9 +341,10 @@ class Kohana_HTML {
 	 *     echo '<div'.HTML::attributes($attrs).'>'.$content.'</div>';
 	 *
 	 * @param   array   attribute list
+	 * @param	boolean	escape the attribute values or not
 	 * @return  string
 	 */
-	public static function attributes(array $attributes = NULL)
+	public static function attributes(array $attributes = NULL, $escape_attributes = TRUE)
 	{
 		if (empty($attributes))
 			return '';
@@ -362,22 +363,45 @@ class Kohana_HTML {
 		$attributes = $sorted + $attributes;
 
 		$compiled = '';
-		foreach ($attributes as $key => $value)
+		if ($escape_attributes)
 		{
-			if ($value === NULL)
+			foreach ($attributes as $key => $value)
 			{
-				// Skip attributes that have NULL values
-				continue;
-			}
+				if ($value === NULL)
+				{
+					// Skip attributes that have NULL values
+					continue;
+				}
 
-			if (is_int($key))
+				if (is_int($key))
+				{
+					// Assume non-associative keys are mirrored attributes
+					$key = $value;
+				}
+
+				// Escape and add the attribute value
+				$compiled .= ' '.$key.'="'.HTML::chars($value).'"';
+			}
+		}
+		else
+		{
+			foreach ($attributes as $key => $value)
 			{
-				// Assume non-associative keys are mirrored attributes
-				$key = $value;
-			}
+				if ($value === NULL)
+				{
+					// Skip attributes that have NULL values
+					continue;
+				}
 
-			// Add the attribute value
-			$compiled .= ' '.$key.'="'.HTML::chars($value).'"';
+				if (is_int($key))
+				{
+					// Assume non-associative keys are mirrored attributes
+					$key = $value;
+				}
+
+				// Escape and add the attribute value without escaping
+				$compiled .= ' '.$key.'="'.$value.'"';
+			}
 		}
 
 		return $compiled;

--- a/classes/kohana/text.php
+++ b/classes/kohana/text.php
@@ -47,6 +47,13 @@ class Kohana_Text {
 		1  => 'one',
 	);
 	
+	/**
+	 * Anchor attribute holder for Text::auto_link_urls() between callback calls.
+	 * 
+	 * Not intended to be used for anything else.
+	 * 
+	 * @var	array	attributes for the generated HTML anchors.
+	 */
 	protected static $anchor_attributes;
 
 	/**

--- a/tests/kohana/HTMLTest.php
+++ b/tests/kohana/HTMLTest.php
@@ -45,6 +45,11 @@ class Kohana_HTMLTest extends Unittest_TestCase
 				array('name' => 'field', 'checked'),
 				' name="field" checked="checked"',
 			),
+			array(
+				array('name' => 'unes"caped'),
+				' name="unes"caped"',
+				FALSE
+			)
 		);
 	}
 
@@ -56,11 +61,11 @@ class Kohana_HTMLTest extends Unittest_TestCase
 	 * @param array  $attributes  Attributes to use
 	 * @param string $expected    Expected output
 	 */
-	public function test_attributes($attributes, $expected)
+	public function test_attributes($attributes, $expected, $escape_attributes = TRUE)
 	{
 		$this->assertSame(
 			$expected,
-			HTML::attributes($attributes)
+			HTML::attributes($attributes, $escape_attributes)
 		);
 	}
 


### PR DESCRIPTION
issue: http://dev.kohanaframework.org/issues/3234

I used a static attribute for internally storing the anchor attributes. It may be a bit messy, but it's the best solution imho
