### PR TITLE
#3996 - Native Session Library floods log

### DIFF
--- a/classes/kohana/session.php
+++ b/classes/kohana/session.php
@@ -316,7 +316,7 @@ abstract class Kohana_Session {
 			}
 			else
 			{
-				Kohana::$log->add(Kohana::ERROR, 'Error reading session data: '.$id);
+				// Ignore these, session is valid, likely no data though.
 			}
 		}
 		catch (Exception $e)


### PR DESCRIPTION
This fixes the problem in 3.0.11 where "Error reading session data:" is added to the logs after every page request.

Based on commit 55fceefb to fix #3964.
