### PR TITLE
#3436 - Text::auto_link_urls() breaks between tags

### DIFF
--- a/classes/kohana/text.php
+++ b/classes/kohana/text.php
@@ -346,7 +346,7 @@ class Kohana_Text {
 	public static function auto_link_urls($text)
 	{
 		// Find and replace all http/https/ftp/ftps links that are not part of an existing html anchor
-		$text = preg_replace_callback('~\b(?<!href="|">)(?:ht|f)tps?://\S+(?:/|\b)~i', 'Text::_auto_link_urls_callback1', $text);
+		$text = preg_replace_callback('~\b(?<!href="|">)(?:ht|f)tps?://[^<\s]+(?:/|\b)~i', 'Text::_auto_link_urls_callback1', $text);
 
 		// Find and replace all naked www.links.com (without http://)
 		return preg_replace_callback('~\b(?<!://|">)www(?:\.[a-z0-9][-a-z0-9]*+)+\.[a-z]{2,6}\b~i', 'Text::_auto_link_urls_callback2', $text);

--- a/tests/kohana/TextTest.php
+++ b/tests/kohana/TextTest.php
@@ -491,6 +491,11 @@ class Kohana_TextTest extends Kohana_Unittest_TestCase
 				'<a href="http://www.google.com/">www.google.com</a> <a href="http://www.google.com/">http://www.google.com/</a>',
 				'<a href="http://www.google.com/">www.google.com</a> http://www.google.com/',
 			),
+			// @issue 3436
+			array(
+				'<strong><a href="http://www.google.com/">http://www.google.com/</a></strong>',
+				'<strong>http://www.google.com/</strong>',
+			),
 		);
 	}
 


### PR DESCRIPTION
Hello good people, this is my first attempt at a pull request, so please be patient with me.

I'm trying to fix #3436 by stopping the url match on white space or the less-than sign. If there's a less-than sign in the passed url (shouldn't happen, I hope?), this commit will break it.

I'm not quite sure about the branching, but as target is 3.0.12, I'm submitting to 3.0/develop (that okay?).

In case this is accepted, it should probably be merged into both 3.1/develop and 3.2/develop, which suffer from the same.
