### PR TITLE
#4013 - Arr::get should use array_key_exists instead of isset

### DIFF
--- a/classes/kohana/arr.php
+++ b/classes/kohana/arr.php
@@ -274,7 +274,7 @@ class Kohana_Arr {
 	 */
 	public static function get($array, $key, $default = NULL)
 	{
-		return isset($array[$key]) ? $array[$key] : $default;
+		return array_key_exists($key, $array) ? $array[$key] : $default;
 	}
 
 	/**

--- a/tests/kohana/ArrTest.php
+++ b/tests/kohana/ArrTest.php
@@ -149,6 +149,7 @@ class Kohana_ArrTest extends Unittest_TestCase
 			array(array('we' => 'can', 'make' => 'change'), 'he', NULL, NULL),
 			array(array('we' => 'can', 'make' => 'change'), 'he', 'who', 'who'),
 			array(array('we' => 'can', 'make' => 'change'), 'he', array('arrays'), array('arrays')),
+            array(array('value' => NULL), 'value', "foo", NULL),
 		);
 	}
 


### PR DESCRIPTION
This fixes #4013.
