### PR TITLE
#4012 - Arr::get should use array_key_exists instead of isset

### DIFF
--- a/classes/kohana/arr.php
+++ b/classes/kohana/arr.php
@@ -231,7 +231,7 @@ class Kohana_Arr {
 	 */
 	public static function get($array, $key, $default = NULL)
 	{
-		return isset($array[$key]) ? $array[$key] : $default;
+		return array_key_exists($key, $array) ? $array[$key] : $default;
 	}
 
 	/**

--- a/tests/kohana/ArrTest.php
+++ b/tests/kohana/ArrTest.php
@@ -111,6 +111,7 @@ class Kohana_ArrTest extends Kohana_Unittest_TestCase
 			array(array('we' => 'can', 'make' => 'change'), 'he', NULL, NULL),
 			array(array('we' => 'can', 'make' => 'change'), 'he', 'who', 'who'),
 			array(array('we' => 'can', 'make' => 'change'), 'he', array('arrays'), array('arrays')),
+            array(array('value' => NULL), 'value', "foo", NULL),
 		);
 	}
 


### PR DESCRIPTION
This fixes #4012
