### PR TITLE
Added stack traces from xdebug to fatal errors.

### DIFF
--- a/classes/kohana/core.php
+++ b/classes/kohana/core.php
@@ -1029,8 +1029,21 @@ class Kohana_Core {
 			// Clean the output buffer
 			ob_get_level() and ob_clean();
 
+			$trace = NULL;
+			if (function_exists('xdebug_get_function_stack'))
+			{
+				$trace = array_reverse(xdebug_get_function_stack());
+				array_shift($trace);
+
+				// xdebug doesn't currently set the call type key
+				foreach ($trace as &$frame) {
+					if (!isset($frame['type']))
+						$frame['type'] = '??';
+				}
+			}
+
 			// Fake an exception for nice debugging
-			Kohana_Exception::handler(new ErrorException($error['message'], $error['type'], 0, $error['file'], $error['line']));
+			Kohana_Exception::handler(new ErrorException($error['message'], $error['type'], 0, $error['file'], $error['line']), $trace);
 
 			// Shutdown now to avoid a "death loop"
 			exit(1);

--- a/classes/kohana/kohana/exception.php
+++ b/classes/kohana/kohana/exception.php
@@ -78,9 +78,10 @@ class Kohana_Kohana_Exception extends Exception {
 	 *
 	 * @uses    Kohana_Exception::text
 	 * @param   object   exception object
+	 * @param   object   stack trace override array
 	 * @return  boolean
 	 */
-	public static function handler(Exception $e)
+	public static function handler(Exception $e, array $trace = NULL)
 	{
 		try
 		{
@@ -92,7 +93,8 @@ class Kohana_Kohana_Exception extends Exception {
 			$line    = $e->getLine();
 
 			// Get the exception backtrace
-			$trace = $e->getTrace();
+			if (! $trace)
+				$trace = $e->getTrace();
 
 			if ($e instanceof ErrorException)
 			{


### PR DESCRIPTION
I was annoyed that there were no stack traces for fatal errors, so I did some digging and found that xdebug will give you a stack trace after a fatal error

The corresponding issue is [#4020](http://dev.kohanaframework.org/issues/4020)
