### PR TITLE
Added stack traces to fatal errors

### DIFF
--- a/classes/kohana/core.php
+++ b/classes/kohana/core.php
@@ -998,12 +998,20 @@ class Kohana_Core {
 				$trace = array_reverse(xdebug_get_function_stack());
 				array_shift($trace);
 
-				// xdebug doesn't currently set the call type key
-				// Open feature request: http://bugs.xdebug.org/view.php?id=695
 				foreach ($trace as & $frame)
 				{
+					// xdebug doesn't currently set the call type key
+					// Open feature request: http://bugs.xdebug.org/view.php?id=695
 					if ( ! isset($frame['type']))
+					{
 						$frame['type'] = '??';
+					}
+
+					// xdebug also has a different name for the parameters array
+					if ( isset($frame['params']) && ! isset($frame['args']))
+					{
+						$frame['args'] = $frame['params'];
+					}
 				}
 			}
 

--- a/classes/kohana/core.php
+++ b/classes/kohana/core.php
@@ -990,6 +990,8 @@ class Kohana_Core {
 			// Clean the output buffer
 			ob_get_level() and ob_clean();
 
+			// PHP stack traces from fatal errors are not very useful
+			// use a better source, if possible
 			$trace = NULL;
 			if (function_exists('xdebug_get_function_stack'))
 			{
@@ -997,8 +999,10 @@ class Kohana_Core {
 				array_shift($trace);
 
 				// xdebug doesn't currently set the call type key
-				foreach ($trace as &$frame) {
-					if (!isset($frame['type']))
+				// Open feature request: http://bugs.xdebug.org/view.php?id=695
+				foreach ($trace as & $frame)
+				{
+					if ( ! isset($frame['type']))
 						$frame['type'] = '??';
 				}
 			}

--- a/classes/kohana/core.php
+++ b/classes/kohana/core.php
@@ -990,8 +990,21 @@ class Kohana_Core {
 			// Clean the output buffer
 			ob_get_level() and ob_clean();
 
+			$trace = NULL;
+			if (function_exists('xdebug_get_function_stack'))
+			{
+				$trace = array_reverse(xdebug_get_function_stack());
+				array_shift($trace);
+
+				// xdebug doesn't currently set the call type key
+				foreach ($trace as &$frame) {
+					if (!isset($frame['type']))
+						$frame['type'] = '??';
+				}
+			}
+
 			// Fake an exception for nice debugging
-			Kohana_Exception::handler(new ErrorException($error['message'], $error['type'], 0, $error['file'], $error['line']));
+			Kohana_Exception::handler(new ErrorException($error['message'], $error['type'], 0, $error['file'], $error['line']), $trace);
 
 			// Shutdown now to avoid a "death loop"
 			exit(1);

--- a/classes/kohana/kohana/exception.php
+++ b/classes/kohana/kohana/exception.php
@@ -83,9 +83,10 @@ class Kohana_Kohana_Exception extends Exception {
 	 *
 	 * @uses    Kohana_Exception::text
 	 * @param   Exception   $e
+	 * @param   array   stack trace override array
 	 * @return  boolean
 	 */
-	public static function handler(Exception $e)
+	public static function handler(Exception $e, array $trace = NULL)
 	{
 		try
 		{
@@ -97,7 +98,8 @@ class Kohana_Kohana_Exception extends Exception {
 			$line    = $e->getLine();
 
 			// Get the exception backtrace
-			$trace = $e->getTrace();
+			if (! $trace)
+				$trace = $e->getTrace();
 
 			if ($e instanceof ErrorException)
 			{

--- a/classes/kohana/kohana/exception.php
+++ b/classes/kohana/kohana/exception.php
@@ -97,9 +97,11 @@ class Kohana_Kohana_Exception extends Exception {
 			$file    = $e->getFile();
 			$line    = $e->getLine();
 
-			// Get the exception backtrace
-			if (! $trace)
+			if ( ! $trace)
+			{
+				// Get the exception backtrace
 				$trace = $e->getTrace();
+			}
 
 			if ($e instanceof ErrorException)
 			{


### PR DESCRIPTION
I was annoyed that there were no stack traces for fatal errors, so I did some digging and found that xdebug will give you a stack trace after a fatal error

The corresponding issue is [#4020](http://dev.kohanaframework.org/issues/4020)
