### PR TITLE
Fix Request::redirect() when using an index_page

### DIFF
--- a/classes/kohana/request.php
+++ b/classes/kohana/request.php
@@ -946,13 +946,13 @@ class Kohana_Request implements HTTP_Request {
 
 		if (strpos($referrer, '://') === FALSE)
 		{
-			$referrer = URL::site($referrer, TRUE, Kohana::$index_file);
+			$referrer = URL::site($referrer, TRUE, !empty(Kohana::$index_file));
 		}
 
 		if (strpos($url, '://') === FALSE)
 		{
 			// Make the URI into a URL
-			$url = URL::site($url, TRUE, Kohana::$index_file);
+			$url = URL::site($url, TRUE, !empty(Kohana::$index_file));
 		}
 
 		if (($response = $this->response()) === NULL)


### PR DESCRIPTION
Commit 035155ef185671deb13c broke request redirection when using an index_page a few days ago, since URL::base() expects the $index parameter to be a boolean, not a string.
