### PR TITLE
Buggy Arr::map()

### DIFF
--- a/classes/kohana/arr.php
+++ b/classes/kohana/arr.php
@@ -363,27 +363,27 @@ class Kohana_Arr {
 	 * @param   array   array of keys to apply to
 	 * @return  array
 	 */
-	public static function map($callback, $array, $keys = NULL)
+	public static function map($callback, $array, array $keys = NULL)
 	{
 		foreach ($array as $key => $val)
 		{
+			if (NULL !== $keys and !in_array($key, $keys))
+				continue;
+
 			if (is_array($val))
 			{
 				$array[$key] = Arr::map($callback, $array[$key]);
 			}
-			elseif ( ! is_array($keys) or in_array($key, $keys))
+			elseif (is_array($callback) && !is_callable($callback))
 			{
-				if (is_array($callback))
+				foreach ($callback as $cb)
 				{
-					foreach ($callback as $cb)
-					{
-						$array[$key] = call_user_func($cb, $array[$key]);
-					}
+					$array[$key] = call_user_func($cb, $array[$key]);
 				}
-				else
-				{
-					$array[$key] = call_user_func($callback, $array[$key]);
-				}
+			}
+			else
+			{
+				$array[$key] = call_user_func($callback, $array[$key]);
 			}
 		}
 

--- a/classes/kohana/arr.php
+++ b/classes/kohana/arr.php
@@ -367,14 +367,14 @@ class Kohana_Arr {
 	{
 		foreach ($array as $key => $val)
 		{
-			if (NULL !== $keys and !in_array($key, $keys))
+			if ($keys !== NULL AND ! in_array($key, $keys))
 				continue;
 
 			if (is_array($val))
 			{
 				$array[$key] = Arr::map($callback, $array[$key]);
 			}
-			elseif (is_array($callback) && !is_callable($callback))
+			elseif (is_array($callback) AND ! is_callable($callback))
 			{
 				foreach ($callback as $cb)
 				{


### PR DESCRIPTION
Arr::map() doesn't work well in those two cases:
1. Passing class functions (`array('class_name', 'function_name')`) or object methods (`array($object, 'method_name'`) is considered an array of callbacks, so 'class_name' and 'function_name' are considered two separate callbacks.
   I added an `!is_callbale()` check for those cases to make it work well. However, its not perfect - if you have `foo()`, `bar()`, and a foo class with a bar function (`foo::bar()`) there's no real way of telling if `array('foo', 'bar')` means `foo()` and `bar()` or `foo::bar()`. In this fix, it'll be considered as `foo::bar()`.
2. When the value of an element is an array, its always replaced - regardless of what was passed in the `$keys`  argument. For example, `Arr::map('strtoupper', array('a'=>array('bar'), 'b' => 'qux'), array())` ignores 'qux', but changes 'bar' to 'BAR'.
