### PR TITLE
Fixes a problem with redirect when you have Kohana::$index_file set.

### DIFF
--- a/classes/kohana/request.php
+++ b/classes/kohana/request.php
@@ -936,13 +936,13 @@ class Kohana_Request implements HTTP_Request {
 
 		if (strpos($referrer, '://') === FALSE)
 		{
-			$referrer = URL::site($referrer, TRUE, Kohana::$index_file);
+			$referrer = URL::site($referrer, TRUE, (bool)Kohana::$index_file);
 		}
 
 		if (strpos($url, '://') === FALSE)
 		{
 			// Make the URI into a URL
-			$url = URL::site($url, TRUE, Kohana::$index_file);
+			$url = URL::site($url, TRUE, (bool)Kohana::$index_file);
 		}
 
 		if (($response = $this->response()) === NULL)


### PR DESCRIPTION
For whatever reason, whenever I use Request::current()->redirect and I
have Kohana::$index_file set to index.php, the framework refuses to
attach 'index.php' onto the base url.  If I cast the third argument to
bool, it fixes the problem without messing you up if you happen to have
Kohana::$index_file set to FALSE.
