### PR TITLE
File upload with Request using HTTP external client

### DIFF
--- a/classes/kohana/request.php
+++ b/classes/kohana/request.php
@@ -729,6 +729,11 @@ class Kohana_Request implements HTTP_Request {
 	 * @var array    cookies to send with the request
 	 */
 	protected $_cookies = array();
+	
+	/**
+	 * @var array   files to upload with the request
+	 */
+	protected $_files = array();
 
 	/**
 	 * @var Kohana_Request_Client
@@ -1543,5 +1548,39 @@ class Kohana_Request implements HTTP_Request {
 
 		return $this;
 	}
+	
+	/**
+	 * Gets or sets HTTP FILE parameters to the request.
+	 *
+	 * @param   mixed  $key   Key or key value pairs to set
+	 * @param   string $file  Value to set to a key
+	 * @return  mixed
+	 */
+    public function files($key = NULL, $file = NULL)
+    {
+        if (is_array($key))
+        {
+            // Act as a setter, replace all files
+            $this->_files = $key;
+            
+            return $this;
+        }
+        
+        if ($key === NULL)
+        {
+            // Act as a getter, all files
+            return $this->_files;
+        }
+        elseif ($file === NULL)
+        {
+            // Act as a getter, single file
+            return Arr::get($this->_files, $key);
+        }
+        
+        // Act as a setter, single file
+        $this->_files[$key] = $file;
+        
+        return $this;
+    }
 
 } // End Request

--- a/classes/kohana/request/client/http.php
+++ b/classes/kohana/request/client/http.php
@@ -80,6 +80,24 @@ class Kohana_Request_Client_HTTP extends Request_Client_External {
 
 		// Set query data (?foo=bar&bar=foo)
 		$http_request->setQueryData($request->query());
+		
+		// Set the files to upload.
+		if ($request->files())
+        {
+            if ($request->method() == HTTP_Request::PUT)
+            {
+                // Only one file can be set for PUT requests.
+                $file = array_pop($request->files());
+                $http_request->setPutFile($file);
+            }
+            elseif ($request->method() == HTTP_Request::POST)
+            {
+                foreach ($request->files() as $key => $file)
+                {
+                    $http_request->addPostFile($key, $file);
+                }
+            }
+        }
 
 		// Set the body
 		if ($request->method() == HTTP_Request::PUT)


### PR DESCRIPTION
Added in the ability to upload files through the HTTP external client class with requests. This requires a new method in the Request class to add files to be sent and additional code written in the Kohana_Request_Client_HTTP class to get those files and to add them in the request.
