### PR TITLE
3.2/develop

### DIFF
--- a/classes/kohana/arr.php
+++ b/classes/kohana/arr.php
@@ -24,7 +24,7 @@ class Kohana_Arr {
 	 *     // Returns FALSE
 	 *     Arr::is_assoc('foo', 'bar');
 	 *
-	 * @param   array   array to check
+	 * @param   array   $array  array to check
 	 * @return  boolean
 	 */
 	public static function is_assoc(array $array)
@@ -49,7 +49,7 @@ class Kohana_Arr {
 	 *     Arr::is_array('not an array!');
 	 *     Arr::is_array(Database::instance());
 	 *
-	 * @param   mixed    value to check
+	 * @param   mixed   $value  value to check
 	 * @return  boolean
 	 */
 	public static function is_array($value)
@@ -80,10 +80,10 @@ class Kohana_Arr {
 	 *     // Using an array of keys
 	 *     $colors = Arr::path($array, array('theme', '*', 'color'));
 	 *
-	 * @param   array   array to search
-	 * @param   mixed   key path string (delimiter separated) or array of keys
-	 * @param   mixed   default value if the path is not set
-	 * @param   string  key path delimiter
+	 * @param   array   $array      array to search
+	 * @param   mixed   $path       key path string (delimiter separated) or array of keys
+	 * @param   mixed   $default    default value if the path is not set
+	 * @param   string  $delimiter  key path delimiter
 	 * @return  mixed
 	 */
 	public static function path($array, $path, $default = NULL, $delimiter = NULL)
@@ -239,8 +239,8 @@ class Kohana_Arr {
 	 *     // Fill an array with values 5, 10, 15, 20
 	 *     $values = Arr::range(5, 20);
 	 *
-	 * @param   integer  stepping
-	 * @param   integer  ending number
+	 * @param   integer $step   stepping
+	 * @param   integer $max    ending number
 	 * @return  array
 	 */
 	public static function range($step = 10, $max = 100)
@@ -267,9 +267,9 @@ class Kohana_Arr {
 	 *     // Get the value "sorting" from $_GET, if it exists
 	 *     $sorting = Arr::get($_GET, 'sorting');
 	 *
-	 * @param   array   array to extract from
-	 * @param   string  key name
-	 * @param   mixed   default value
+	 * @param   array   $array      array to extract from
+	 * @param   string  $key        key name
+	 * @param   mixed   $default    default value
 	 * @return  mixed
 	 */
 	public static function get($array, $key, $default = NULL)
@@ -284,9 +284,9 @@ class Kohana_Arr {
 	 *     // Get the values "username", "password" from $_POST
 	 *     $auth = Arr::extract($_POST, array('username', 'password'));
 	 *
-	 * @param   array   array to extract keys from
-	 * @param   array   list of key names
-	 * @param   mixed   default value
+	 * @param   array   $array      array to extract keys from
+	 * @param   array   $keys       list of key names
+	 * @param   mixed   $default    default value
 	 * @return  array
 	 */
 	public static function extract($array, array $keys, $default = NULL)
@@ -308,8 +308,8 @@ class Kohana_Arr {
 	 *
 	 * [!!] A list of arrays is an array that contains arrays, eg: array(array $a, array $b, array $c, ...)
 	 *
-	 * @param   array   list of arrays to check
-	 * @param   string  key to pluck
+	 * @param   array   $array  list of arrays to check
+	 * @param   string  $key    key to pluck
 	 * @return  array
 	 */
 	public static function pluck($array, $key)
@@ -334,9 +334,9 @@ class Kohana_Arr {
 	 *     // Add an empty value to the start of a select list
 	 *     Arr::unshift($array, 'none', 'Select a value');
 	 *
-	 * @param   array   array to modify
-	 * @param   string  array key name
-	 * @param   mixed   array value
+	 * @param   array   $array  array to modify
+	 * @param   string  $key    array key name
+	 * @param   mixed   $val    array value
 	 * @return  array
 	 */
 	public static function unshift( array & $array, $key, $val)
@@ -358,9 +358,9 @@ class Kohana_Arr {
 	 * [!!] Unlike `array_map`, this method requires a callback and will only map
 	 * a single array.
 	 *
-	 * @param   mixed   callback applied to every element in the array
-	 * @param   array   array to map
-	 * @param   array   array of keys to apply to
+	 * @param   mixed   $callback   callback applied to every element in the array
+	 * @param   array   $array      array to map
+	 * @param   array   $keys       array of keys to apply to
 	 * @return  array
 	 */
 	public static function map($callback, $array, $keys = NULL)
@@ -403,9 +403,8 @@ class Kohana_Arr {
 	 *     // The output of $john will now be:
 	 *     array('name' => 'mary', 'children' => array('fred', 'paul', 'sally', 'jane'))
 	 *
-	 * @param   array  initial array
-	 * @param   array  array to merge
-	 * @param   array  ...
+	 * @param   array  $a1      initial array
+	 * @param   array  $a2,...  array to merge
 	 * @return  array
 	 */
 	public static function merge(array $a1, array $a2)
@@ -477,8 +476,8 @@ class Kohana_Arr {
 	 *     // The output of $array will now be:
 	 *     array('name' => 'jack', 'mood' => 'happy', 'food' => 'tacos')
 	 *
-	 * @param   array   master array
-	 * @param   array   input arrays that will overwrite existing values
+	 * @param   array   $array1 master array
+	 * @param   array   $array2 input arrays that will overwrite existing values
 	 * @return  array
 	 */
 	public static function overwrite($array1, $array2)
@@ -512,7 +511,7 @@ class Kohana_Arr {
 	 *     // Get the result of the callback
 	 *     $result = call_user_func_array($func, $params);
 	 *
-	 * @param   string  callback string
+	 * @param   string  $str    callback string
 	 * @return  array   function, params
 	 */
 	public static function callback($str)
@@ -561,7 +560,7 @@ class Kohana_Arr {
 	 *
 	 * [!!] The keys of array values will be discarded.
 	 *
-	 * @param   array   array to flatten
+	 * @param   array   $array  array to flatten
 	 * @return  array
 	 * @since   3.0.6
 	 */

--- a/classes/kohana/cli.php
+++ b/classes/kohana/cli.php
@@ -19,8 +19,7 @@ class Kohana_CLI {
 	 *     // Get the values of "username" and "password"
 	 *     $auth = CLI::options('username', 'password');
 	 *
-	 * @param   string  option name
-	 * @param   ...
+	 * @param   string  $options,...    option name
 	 * @return  array
 	 */
 	public static function options($options)

--- a/classes/kohana/config.php
+++ b/classes/kohana/config.php
@@ -28,8 +28,8 @@ class Kohana_Config {
 	 *     $config->attach($reader);        // Try first
 	 *     $config->attach($reader, FALSE); // Try last
 	 *
-	 * @param   object   Kohana_Config_Source instance
-	 * @param   boolean  add the reader as the first used object
+	 * @param   Kohana_Config_Source    $source instance
+	 * @param   boolean                 $first  add the reader as the first used object
 	 * @return  $this
 	 */
 	public function attach(Kohana_Config_Source $source, $first = TRUE)
@@ -53,7 +53,7 @@ class Kohana_Config {
 	 *
 	 *     $config->detach($reader);
 	 *
-	 * @param   object  Kohana_Config_Source instance
+	 * @param   Kohana_Config_Source    $source instance
 	 * @return  $this
 	 */
 	public function detach(Kohana_Config_Source $source)
@@ -76,8 +76,8 @@ class Kohana_Config {
 	 *
 	 * See [Kohana_Config_Group] for more info
 	 *
-	 * @param   string  configuration group name
-	 * @return  object  Kohana_Config_Group
+	 * @param   string  $group  configuration group name
+	 * @return  Kohana_Config_Group
 	 * @throws  Kohana_Exception
 	 */
 	public function load($group)
@@ -143,7 +143,7 @@ class Kohana_Config {
 	 * 
 	 *     $config->copy($name);
 	 *
-	 * @param   string   configuration group name
+	 * @param   string  $group  configuration group name
 	 * @return  $this
 	 */
 	public function copy($group)
@@ -162,9 +162,9 @@ class Kohana_Config {
 	/**
 	 * Callback used by the config group to store changes made to configuration
 	 *
-	 * @param string         Group name
-	 * @param string         Variable name
-	 * @param mixed          The new value
+	 * @param string    $group  Group name
+	 * @param string    $key    Variable name
+	 * @param mixed     $value  The new value
 	 * @return Kohana_Config Chainable instance
 	 */
 	public function _write_config($group, $key, $value)

--- a/classes/kohana/config/file/reader.php
+++ b/classes/kohana/config/file/reader.php
@@ -20,7 +20,7 @@ class Kohana_Config_File_Reader implements Kohana_Config_Reader {
 	/**
 	 * Creates a new file reader using the given directory as a config source
 	 *
-	 * @param string Configuration directory to search
+	 * @param string    $directory  Configuration directory to search
 	 */
 	public function __construct($directory = 'config')
 	{
@@ -33,7 +33,7 @@ class Kohana_Config_File_Reader implements Kohana_Config_Reader {
 	 *
 	 *     $config->load($name);
 	 *
-	 * @param   string  configuration group name
+	 * @param   string  $group  configuration group name
 	 * @return  $this   current object
 	 * @uses    Kohana::load
 	 */

--- a/classes/kohana/config/group.php
+++ b/classes/kohana/config/group.php
@@ -83,8 +83,8 @@ class Kohana_Config_Group extends ArrayObject {
 	 *
 	 *     $value = $config->get($key);
 	 *
-	 * @param   string   array key
-	 * @param   mixed    default value
+	 * @param   string  $key        array key
+	 * @param   mixed   $default    default value
 	 * @return  mixed
 	 */
 	public function get($key, $default = NULL)
@@ -97,8 +97,8 @@ class Kohana_Config_Group extends ArrayObject {
 	 *
 	 *     $config->set($key, $new_value);
 	 *
-	 * @param   string   array key
-	 * @param   mixed    array value
+	 * @param   string  $key    array key
+	 * @param   mixed   $value  array value
 	 * @return  $this
 	 */
 	public function set($key, $value)

--- a/classes/kohana/cookie.php
+++ b/classes/kohana/cookie.php
@@ -48,8 +48,8 @@ class Kohana_Cookie {
 	 *     // Get the "theme" cookie, or use "blue" if the cookie does not exist
 	 *     $theme = Cookie::get('theme', 'blue');
 	 *
-	 * @param   string  cookie name
-	 * @param   mixed   default value to return
+	 * @param   string  $key        cookie name
+	 * @param   mixed   $default    default value to return
 	 * @return  string
 	 */
 	public static function get($key, $default = NULL)
@@ -91,9 +91,9 @@ class Kohana_Cookie {
 	 *     // Set the "theme" cookie
 	 *     Cookie::set('theme', 'red');
 	 *
-	 * @param   string   name of cookie
-	 * @param   string   value of cookie
-	 * @param   integer  lifetime in seconds
+	 * @param   string  $name       name of cookie
+	 * @param   string  $value      value of cookie
+	 * @param   integer $expiration lifetime in seconds
 	 * @return  boolean
 	 * @uses    Cookie::salt
 	 */
@@ -122,7 +122,7 @@ class Kohana_Cookie {
 	 *
 	 *     Cookie::delete('theme');
 	 *
-	 * @param   string   cookie name
+	 * @param   string  $name   cookie name
 	 * @return  boolean
 	 * @uses    Cookie::set
 	 */
@@ -140,8 +140,8 @@ class Kohana_Cookie {
 	 *
 	 *     $salt = Cookie::salt('theme', 'red');
 	 *
-	 * @param   string   name of cookie
-	 * @param   string   value of cookie
+	 * @param   string  $name   name of cookie
+	 * @param   string  $value  value of cookie
 	 * @return  string
 	 */
 	public static function salt($name, $value)

--- a/classes/kohana/core.php
+++ b/classes/kohana/core.php
@@ -183,7 +183,7 @@ class Kohana_Core {
 	 * `boolean` | profile    | Whether to enable the [Profiler](kohana/profiling). <br /> <br />Recommended setting: `TRUE` while developing, `FALSE` on production servers. | `TRUE`	 * `boolean` | caching    | Cache file locations to speed up [Kohana::find_file].  This has nothing to do with [Kohana::cache], [Fragments](kohana/fragments) or the [Cache module](cache).  <br /> <br />  Recommended setting: `FALSE` while developing, `TRUE` on production servers. | `FALSE`
 	 *
 	 * @throws  Kohana_Exception
-	 * @param   array   Array of settings.  See above.
+	 * @param   array   $settings   Array of settings.  See above.
 	 * @return  void
 	 * @uses    Kohana::globals
 	 * @uses    Kohana::sanitize
@@ -431,8 +431,8 @@ class Kohana_Core {
 	 * - Strips slashes if magic quotes are enabled
 	 * - Normalizes all newlines to LF
 	 *
-	 * @param   mixed  any variable
-	 * @return  mixed  sanitized variable
+	 * @param   mixed   $value  any variable
+	 * @return  mixed   sanitized variable
 	 */
 	public static function sanitize($value)
 	{
@@ -480,7 +480,7 @@ class Kohana_Core {
 	 *
 	 *     spl_autoload_register(array('Kohana', 'auto_load'));
 	 *
-	 * @param   string   class name
+	 * @param   string  $class  class name
 	 * @return  boolean
 	 */
 	public static function auto_load($class)
@@ -515,8 +515,8 @@ class Kohana_Core {
 	 *
 	 *     Kohana::modules(array('modules/foo', MODPATH.'bar'));
 	 *
-	 * @param   array  list of module paths
-	 * @return  array  enabled modules
+	 * @param   array   $modules    list of module paths
+	 * @return  array   enabled modules
 	 */
 	public static function modules(array $modules = NULL)
 	{
@@ -602,12 +602,12 @@ class Kohana_Core {
 	 *     // Returns an array of all the "mimes" configuration files
 	 *     Kohana::find_file('config', 'mimes');
 	 *
-	 * @param   string   directory name (views, i18n, classes, extensions, etc.)
-	 * @param   string   filename with subdirectory
-	 * @param   string   extension to search for
-	 * @param   boolean  return an array of files?
-	 * @return  array    a list of files when $array is TRUE
-	 * @return  string   single file path
+	 * @param   string  $dir    directory name (views, i18n, classes, extensions, etc.)
+	 * @param   string  $file   filename with subdirectory
+	 * @param   string  $ext    extension to search for
+	 * @param   boolean $array  return an array of files?
+	 * @return  array   a list of files when $array is TRUE
+	 * @return  string  single file path
 	 */
 	public static function find_file($dir, $file, $ext = NULL, $array = FALSE)
 	{
@@ -703,8 +703,8 @@ class Kohana_Core {
 	 *     // Find all view files.
 	 *     $views = Kohana::list_files('views');
 	 *
-	 * @param   string  directory name
-	 * @param   array   list of paths to search
+	 * @param   string  $directory  directory name
+	 * @param   array   $paths      list of paths to search
 	 * @return  array
 	 */
 	public static function list_files($directory = NULL, array $paths = NULL)
@@ -784,7 +784,7 @@ class Kohana_Core {
 	 *
 	 *     $foo = Kohana::load('foo.php');
 	 *
-	 * @param   string
+	 * @param   string  $file
 	 * @return  mixed
 	 */
 	public static function load($file)
@@ -810,9 +810,9 @@ class Kohana_Core {
 	 * [ref-var]: http://php.net/var_export
 	 *
 	 * @throws  Kohana_Exception
-	 * @param   string   name of the cache
-	 * @param   mixed    data to cache
-	 * @param   integer  number of seconds the cache is valid for
+	 * @param   string  $name       name of the cache
+	 * @param   mixed   $data       data to cache
+	 * @param   integer $lifetime   number of seconds the cache is valid for
 	 * @return  mixed    for getting
 	 * @return  boolean  for setting
 	 */
@@ -898,9 +898,9 @@ class Kohana_Core {
 	 *     // Get "username" from messages/text.php
 	 *     $username = Kohana::message('text', 'username');
 	 *
-	 * @param   string  file name
-	 * @param   string  key path to get
-	 * @param   mixed   default value if the path does not exist
+	 * @param   string  $file       file name
+	 * @param   string  $path       key path to get
+	 * @param   mixed   $default    default value if the path does not exist
 	 * @return  string  message string for the given path
 	 * @return  array   complete message list, when no path is specified
 	 * @uses    Arr::merge

--- a/classes/kohana/core.php
+++ b/classes/kohana/core.php
@@ -16,8 +16,8 @@
 class Kohana_Core {
 
 	// Release version and codename
-	const VERSION  = '3.1.3.1';
-	const CODENAME = 'araea';
+	const VERSION  = '3.1.4';
+	const CODENAME = 'fasciinucha';
 
 	// Common environment type constants for consistency and convenience
 	const PRODUCTION  = 1;

--- a/classes/kohana/date.php
+++ b/classes/kohana/date.php
@@ -578,7 +578,7 @@ class Kohana_Date {
 	 *
 	 *     $time = Date::formatted_time('5 minutes ago');
 	 *
-	 * @see     http://php.net/manual/en/datetime.construct.php
+	 * @link    http://www.php.net/manual/datetime.construct
 	 * @param   string  datetime_str     datetime string
 	 * @param   string  timestamp_format timestamp format
 	 * @return  string

--- a/classes/kohana/date.php
+++ b/classes/kohana/date.php
@@ -44,9 +44,9 @@ class Kohana_Date {
 	 * [!!] A list of time zones that PHP supports can be found at
 	 * <http://php.net/timezones>.
 	 *
-	 * @param   string   timezone that to find the offset of
-	 * @param   string   timezone used as the baseline
-	 * @param   mixed    UNIX timestamp or date string
+	 * @param   string  $remote timezone that to find the offset of
+	 * @param   string  $local  timezone used as the baseline
+	 * @param   mixed   $now    UNIX timestamp or date string
 	 * @return  integer
 	 */
 	public static function offset($remote, $local = NULL, $now = NULL)
@@ -83,10 +83,10 @@ class Kohana_Date {
 	 *
 	 *     $seconds = Date::seconds(); // 01, 02, 03, ..., 58, 59, 60
 	 *
-	 * @param   integer  amount to increment each step by, 1 to 30
-	 * @param   integer  start value
-	 * @param   integer  end value
-	 * @return  array    A mirrored (foo => foo) array from 1-60.
+	 * @param   integer $step   amount to increment each step by, 1 to 30
+	 * @param   integer $start  start value
+	 * @param   integer $end    end value
+	 * @return  array   A mirrored (foo => foo) array from 1-60.
 	 */
 	public static function seconds($step = 1, $start = 0, $end = 60)
 	{
@@ -110,8 +110,8 @@ class Kohana_Date {
 	 *     $minutes = Date::minutes(); // 05, 10, 15, ..., 50, 55, 60
 	 *
 	 * @uses    Date::seconds
-	 * @param   integer  amount to increment each step by, 1 to 30
-	 * @return  array    A mirrored (foo => foo) array from 1-60.
+	 * @param   integer $step   amount to increment each step by, 1 to 30
+	 * @return  array   A mirrored (foo => foo) array from 1-60.
 	 */
 	public static function minutes($step = 5)
 	{
@@ -128,10 +128,10 @@ class Kohana_Date {
 	 *
 	 *     $hours = Date::hours(); // 01, 02, 03, ..., 10, 11, 12
 	 *
-	 * @param   integer  amount to increment each step by
-	 * @param   boolean  use 24-hour time
-	 * @param   integer  the hour to start at
-	 * @return  array    A mirrored (foo => foo) array from start-12 or start-23.
+	 * @param   integer $step   amount to increment each step by
+	 * @param   boolean $long   use 24-hour time
+	 * @param   integer $start  the hour to start at
+	 * @return  array   A mirrored (foo => foo) array from start-12 or start-23.
 	 */
 	public static function hours($step = 1, $long = FALSE, $start = NULL)
 	{
@@ -165,7 +165,7 @@ class Kohana_Date {
 	 *     $type = Date::ampm(12); // PM
 	 *     $type = Date::ampm(1);  // AM
 	 *
-	 * @param   integer  number of the hour
+	 * @param   integer $hour   number of the hour
 	 * @return  string
 	 */
 	public static function ampm($hour)
@@ -181,8 +181,8 @@ class Kohana_Date {
 	 *
 	 *     $hour = Date::adjust(3, 'pm'); // 15
 	 *
-	 * @param   integer  hour to adjust
-	 * @param   string   AM or PM
+	 * @param   integer $hour   hour to adjust
+	 * @param   string  $ampm   AM or PM
 	 * @return  string
 	 */
 	public static function adjust($hour, $ampm)
@@ -215,9 +215,9 @@ class Kohana_Date {
 	 *
 	 *     Date::days(4, 2010); // 1, 2, 3, ..., 28, 29, 30
 	 *
-	 * @param   integer  number of month
-	 * @param   integer  number of year to check month, defaults to the current year
-	 * @return  array    A mirrored (foo => foo) array of the days.
+	 * @param   integer $month  number of month
+	 * @param   integer $year   number of year to check month, defaults to the current year
+	 * @return  array   A mirrored (foo => foo) array of the days.
 	 */
 	public static function days($month, $year = FALSE)
 	{
@@ -270,8 +270,8 @@ class Kohana_Date {
 	 *     // array(1 => 'Jan', 2 => 'Feb', ..., 12 => 'Dec')
 	 *
 	 * @uses    Date::hours
-	 * @param   string The format to use for months
-	 * @return  array  An array of months based on the specified format
+	 * @param   string  $format The format to use for months
+	 * @return  array   An array of months based on the specified format
 	 */
 	public static function months($format = NULL)
 	{
@@ -299,8 +299,8 @@ class Kohana_Date {
 	 *
 	 *     $years = Date::years(2000, 2010); // 2000, 2001, ..., 2009, 2010
 	 *
-	 * @param   integer  starting year (default is current year - 5)
-	 * @param   integer  ending year (default is current year + 5)
+	 * @param   integer $start  starting year (default is current year - 5)
+	 * @param   integer $end    ending year (default is current year + 5)
 	 * @return  array
 	 */
 	public static function years($start = FALSE, $end = FALSE)
@@ -327,9 +327,9 @@ class Kohana_Date {
 	 *     $span = Date::span(60, 182, 'minutes,seconds'); // array('minutes' => 2, 'seconds' => 2)
 	 *     $span = Date::span(60, 182, 'minutes'); // 2
 	 *
-	 * @param   integer  timestamp to find the span of
-	 * @param   integer  timestamp to use as the baseline
-	 * @param   string   formatting string
+	 * @param   integer $remote timestamp to find the span of
+	 * @param   integer $local  timestamp to use as the baseline
+	 * @param   string  $output formatting string
 	 * @return  string   when only a single output is requested
 	 * @return  array    associative list of all outputs requested
 	 */
@@ -419,8 +419,8 @@ class Kohana_Date {
 	 * however this parameter shouldn't be needed in normal usage and is only
 	 * included for unit tests
 	 *
-	 * @param   integer  "remote" timestamp
-	 * @param   integer  "local" timestamp, defaults to time()
+	 * @param   integer $timestamp          "remote" timestamp
+	 * @param   integer $local_timestamp    "local" timestamp, defaults to time()
 	 * @return  string
 	 */
 	public static function fuzzy_span($timestamp, $local_timestamp = NULL)
@@ -530,7 +530,7 @@ class Kohana_Date {
 	 *
 	 *     $dos = Date::unix2dos($unix);
 	 *
-	 * @param   integer  UNIX timestamp
+	 * @param   integer $timestamp  UNIX timestamp
 	 * @return  integer
 	 */
 	public static function unix2dos($timestamp = FALSE)
@@ -558,7 +558,7 @@ class Kohana_Date {
 	 *
 	 *     $unix = Date::dos2unix($dos);
 	 *
-	 * @param   integer  DOS timestamp
+	 * @param   integer $timestamp  DOS timestamp
 	 * @return  integer
 	 */
 	public static function dos2unix($timestamp = FALSE)
@@ -579,8 +579,8 @@ class Kohana_Date {
 	 *     $time = Date::formatted_time('5 minutes ago');
 	 *
 	 * @link    http://www.php.net/manual/datetime.construct
-	 * @param   string  datetime_str     datetime string
-	 * @param   string  timestamp_format timestamp format
+	 * @param   string  $datetime_str       datetime string
+	 * @param   string  $timestamp_format   timestamp format
 	 * @return  string
 	 */
 	public static function formatted_time($datetime_str = 'now', $timestamp_format = NULL, $timezone = NULL)

--- a/classes/kohana/debug.php
+++ b/classes/kohana/debug.php
@@ -17,8 +17,7 @@ class Kohana_Debug {
 	 *     // Displays the type and value of each variable
 	 *     echo Debug::vars($foo, $bar, $baz);
 	 *
-	 * @param   mixed   variable to debug
-	 * @param   ...
+	 * @param   mixed   $var,...    variable to debug
 	 * @return  string
 	 */
 	public static function vars()
@@ -43,9 +42,9 @@ class Kohana_Debug {
 	 *
 	 * Borrows heavily on concepts from the Debug class of [Nette](http://nettephp.com/).
 	 *
-	 * @param   mixed    variable to dump
-	 * @param   integer  maximum length of strings
-	 * @param   integer  recursion limit
+	 * @param   mixed   $value              variable to dump
+	 * @param   integer $length             maximum length of strings
+	 * @param   integer $level_recursion    recursion limit
 	 * @return  string
 	 */
 	public static function dump($value, $length = 128, $level_recursion = 10)
@@ -56,10 +55,10 @@ class Kohana_Debug {
 	/**
 	 * Helper for Debug::dump(), handles recursion in arrays and objects.
 	 *
-	 * @param   mixed    variable to dump
-	 * @param   integer  maximum length of strings
-	 * @param   integer  recursion limit
-	 * @param   integer  current recursion level (internal usage only!)
+	 * @param   mixed   $var    variable to dump
+	 * @param   integer $length maximum length of strings
+	 * @param   integer $limit  recursion limit
+	 * @param   integer $level  current recursion level (internal usage only!)
 	 * @return  string
 	 */
 	protected static function _dump( & $var, $length = 128, $limit = 10, $level = 0)
@@ -244,7 +243,7 @@ class Kohana_Debug {
 	 *     // Displays SYSPATH/classes/kohana.php
 	 *     echo Debug::path(Kohana::find_file('classes', 'kohana'));
 	 *
-	 * @param   string  path to debug
+	 * @param   string  $file   path to debug
 	 * @return  string
 	 */
 	public static function path($file)
@@ -276,9 +275,9 @@ class Kohana_Debug {
 	 *     // Highlights the current line of the current file
 	 *     echo Debug::source(__FILE__, __LINE__);
 	 *
-	 * @param   string   file to open
-	 * @param   integer  line number to highlight
-	 * @param   integer  number of padding lines
+	 * @param   string  $file           file to open
+	 * @param   integer $line_number    line number to highlight
+	 * @param   integer $padding        number of padding lines
 	 * @return  string   source of file
 	 * @return  FALSE    file is unreadable
 	 */
@@ -342,7 +341,7 @@ class Kohana_Debug {
 	 *     // Displays the entire current backtrace
 	 *     echo implode('<br/>', Debug::trace());
 	 *
-	 * @param   string  path to debug
+	 * @param   array   $trace
 	 * @return  string
 	 */
 	public static function trace(array $trace = NULL)

--- a/classes/kohana/encrypt.php
+++ b/classes/kohana/encrypt.php
@@ -46,7 +46,7 @@ class Kohana_Encrypt {
 	 *
 	 *     $encrypt = Encrypt::instance();
 	 *
-	 * @param   string  configuration group name
+	 * @param   string  $name   configuration group name
 	 * @return  Encrypt
 	 */
 	public static function instance($name = NULL)
@@ -91,9 +91,9 @@ class Kohana_Encrypt {
 	/**
 	 * Creates a new mcrypt wrapper.
 	 *
-	 * @param   string   encryption key
-	 * @param   string   mcrypt mode
-	 * @param   string   mcrypt cipher
+	 * @param   string  $key    encryption key
+	 * @param   string  $mode   mcrypt mode
+	 * @param   string  $cipher mcrypt cipher
 	 */
 	public function __construct($key, $mode, $cipher)
 	{
@@ -124,7 +124,7 @@ class Kohana_Encrypt {
 	 * to convert it to a string. This string can be stored in a database,
 	 * displayed, and passed using most other means without corruption.
 	 *
-	 * @param   string  data to be encrypted
+	 * @param   string  $data   data to be encrypted
 	 * @return  string
 	 */
 	public function encode($data)
@@ -179,7 +179,7 @@ class Kohana_Encrypt {
 	 *
 	 *     $data = $encrypt->decode($data);
 	 *
-	 * @param   string  encoded string to be decrypted
+	 * @param   string  $data   encoded string to be decrypted
 	 * @return  FALSE   if decryption fails
 	 * @return  string
 	 */

--- a/classes/kohana/feed.php
+++ b/classes/kohana/feed.php
@@ -13,8 +13,8 @@ class Kohana_Feed {
 	/**
 	 * Parses a remote feed into an array.
 	 *
-	 * @param   string   remote feed URL
-	 * @param   integer  item limit to fetch
+	 * @param   string  $feed   remote feed URL
+	 * @param   integer $limit  item limit to fetch
 	 * @return  array
 	 */
 	public static function parse($feed, $limit = 0)
@@ -70,10 +70,10 @@ class Kohana_Feed {
 	/**
 	 * Creates a feed from the given parameters.
 	 *
-	 * @param   array   feed information
-	 * @param   array   items to add to the feed
-	 * @param   string  define which format to use (only rss2 is supported)
-	 * @param   string  define which encoding to use
+	 * @param   array   $info       feed information
+	 * @param   array   $items      items to add to the feed
+	 * @param   string  $format     define which format to use (only rss2 is supported)
+	 * @param   string  $encoding   define which encoding to use
 	 * @return  string
 	 */
 	public static function create($info, $items, $format = 'rss2', $encoding = 'UTF-8')

--- a/classes/kohana/file.php
+++ b/classes/kohana/file.php
@@ -17,7 +17,7 @@ class Kohana_File {
 	 *
 	 *     $mime = File::mime($file);
 	 *
-	 * @param   string  file name or path
+	 * @param   string  $filename   file name or path
 	 * @return  string  mime type on success
 	 * @return  FALSE   on failure
 	 */
@@ -66,7 +66,7 @@ class Kohana_File {
 	 *
 	 *     $mime = File::mime_by_ext('png'); // "image/png"
 	 *
-	 * @param   string  extension: php, pdf, txt, etc
+	 * @param   string  $extension  php, pdf, txt, etc
 	 * @return  string  mime type on success
 	 * @return  FALSE   on failure
 	 */
@@ -148,10 +148,9 @@ class Kohana_File {
 	 *
 	 *     $count = File::split($file);
 	 *
-	 * @param   string   file to be split
-	 * @param   string   directory to output to, defaults to the same directory as the file
-	 * @param   integer  size, in MB, for each piece to be
-	 * @return  integer  The number of pieces that were created
+	 * @param   string  $filename   file to be split
+	 * @param   integer $piece_size size, in MB, for each piece to be
+	 * @return  integer The number of pieces that were created
 	 */
 	public static function split($filename, $piece_size = 10)
 	{
@@ -204,9 +203,8 @@ class Kohana_File {
 	 *
 	 *     $count = File::join($file);
 	 *
-	 * @param   string   split filename, without .000 extension
-	 * @param   string   output filename, if different then an the filename
-	 * @return  integer  The number of pieces that were joined.
+	 * @param   string  $filename   split filename, without .000 extension
+	 * @return  integer The number of pieces that were joined.
 	 */
 	public static function join($filename)
 	{

--- a/classes/kohana/form.php
+++ b/classes/kohana/form.php
@@ -25,8 +25,8 @@ class Kohana_Form {
 	 *     // When "file" inputs are present, you must include the "enctype"
 	 *     echo Form::open(NULL, array('enctype' => 'multipart/form-data'));
 	 *
-	 * @param   mixed   form action, defaults to the current request URI, or [Request] class to use
-	 * @param   array   html attributes
+	 * @param   mixed   $action     form action, defaults to the current request URI, or [Request] class to use
+	 * @param   array   $attributes html attributes
 	 * @return  string
 	 * @uses    Request::instance
 	 * @uses    URL::site
@@ -84,9 +84,9 @@ class Kohana_Form {
 	 *
 	 *     echo Form::input('username', $username);
 	 *
-	 * @param   string  input name
-	 * @param   string  input value
-	 * @param   array   html attributes
+	 * @param   string  $name       input name
+	 * @param   string  $value      input value
+	 * @param   array   $attributes html attributes
 	 * @return  string
 	 * @uses    HTML::attributes
 	 */
@@ -112,9 +112,9 @@ class Kohana_Form {
 	 *
 	 *     echo Form::hidden('csrf', $token);
 	 *
-	 * @param   string  input name
-	 * @param   string  input value
-	 * @param   array   html attributes
+	 * @param   string  $name       input name
+	 * @param   string  $value      input value
+	 * @param   array   $attributes html attributes
 	 * @return  string
 	 * @uses    Form::input
 	 */
@@ -130,9 +130,9 @@ class Kohana_Form {
 	 *
 	 *     echo Form::password('password');
 	 *
-	 * @param   string  input name
-	 * @param   string  input value
-	 * @param   array   html attributes
+	 * @param   string  $name       input name
+	 * @param   string  $value      input value
+	 * @param   array   $attributes html attributes
 	 * @return  string
 	 * @uses    Form::input
 	 */
@@ -148,8 +148,8 @@ class Kohana_Form {
 	 *
 	 *     echo Form::file('image');
 	 *
-	 * @param   string  input name
-	 * @param   array   html attributes
+	 * @param   string  $name       input name
+	 * @param   array   $attributes html attributes
 	 * @return  string
 	 * @uses    Form::input
 	 */
@@ -165,10 +165,10 @@ class Kohana_Form {
 	 *
 	 *     echo Form::checkbox('remember_me', 1, (bool) $remember);
 	 *
-	 * @param   string   input name
-	 * @param   string   input value
-	 * @param   boolean  checked status
-	 * @param   array    html attributes
+	 * @param   string  $name       input name
+	 * @param   string  $value      input value
+	 * @param   boolean $checked    checked status
+	 * @param   array   $attributes html attributes
 	 * @return  string
 	 * @uses    Form::input
 	 */
@@ -191,10 +191,10 @@ class Kohana_Form {
 	 *     echo Form::radio('like_cats', 1, $cats);
 	 *     echo Form::radio('like_cats', 0, ! $cats);
 	 *
-	 * @param   string   input name
-	 * @param   string   input value
-	 * @param   boolean  checked status
-	 * @param   array    html attributes
+	 * @param   string  $name       input name
+	 * @param   string  $value      input value
+	 * @param   boolean $checked    checked status
+	 * @param   array   $attributes html attributes
 	 * @return  string
 	 * @uses    Form::input
 	 */
@@ -216,10 +216,10 @@ class Kohana_Form {
 	 *
 	 *     echo Form::textarea('about', $about);
 	 *
-	 * @param   string   textarea name
-	 * @param   string   textarea body
-	 * @param   array    html attributes
-	 * @param   boolean  encode existing HTML characters
+	 * @param   string  $name           textarea name
+	 * @param   string  $body           textarea body
+	 * @param   array   $attributes     html attributes
+	 * @param   boolean $double_encode  encode existing HTML characters
 	 * @return  string
 	 * @uses    HTML::attributes
 	 * @uses    HTML::chars
@@ -242,10 +242,10 @@ class Kohana_Form {
 	 *
 	 * [!!] Support for multiple selected options was added in v3.0.7.
 	 *
-	 * @param   string   input name
-	 * @param   array    available options
-	 * @param   mixed    selected option string, or an array of selected options
-	 * @param   array    html attributes
+	 * @param   string  $name       input name
+	 * @param   array   $options    available options
+	 * @param   mixed   $selected   selected option string, or an array of selected options
+	 * @param   array   $attributes html attributes
 	 * @return  string
 	 * @uses    HTML::attributes
 	 */
@@ -345,9 +345,9 @@ class Kohana_Form {
 	 *
 	 *     echo Form::submit(NULL, 'Login');
 	 *
-	 * @param   string  input name
-	 * @param   string  input value
-	 * @param   array   html attributes
+	 * @param   string  $name       input name
+	 * @param   string  $value      input value
+	 * @param   array   $attributes html attributes
 	 * @return  string
 	 * @uses    Form::input
 	 */
@@ -363,10 +363,10 @@ class Kohana_Form {
 	 *
 	 *     echo Form::image(NULL, NULL, array('src' => 'media/img/login.png'));
 	 *
-	 * @param   string   input name
-	 * @param   string   input value
-	 * @param   array    html attributes
-	 * @param   boolean  add index file to URL?
+	 * @param   string  $name       input name
+	 * @param   string  $value      input value
+	 * @param   array   $attributes html attributes
+	 * @param   boolean $index      add index file to URL?
 	 * @return  string
 	 * @uses    Form::input
 	 */
@@ -392,9 +392,9 @@ class Kohana_Form {
 	 *
 	 *     echo Form::button('save', 'Save Profile', array('type' => 'submit'));
 	 *
-	 * @param   string  input name
-	 * @param   string  input value
-	 * @param   array   html attributes
+	 * @param   string  $name       input name
+	 * @param   string  $body       input value
+	 * @param   array   $attributes html attributes
 	 * @return  string
 	 * @uses    HTML::attributes
 	 */
@@ -411,9 +411,9 @@ class Kohana_Form {
 	 *
 	 *     echo Form::label('username', 'Username');
 	 *
-	 * @param   string  target input
-	 * @param   string  label text
-	 * @param   array   html attributes
+	 * @param   string  $input      target input
+	 * @param   string  $text       label text
+	 * @param   array   $attributes html attributes
 	 * @return  string
 	 * @uses    HTML::attributes
 	 */

--- a/classes/kohana/fragment.php
+++ b/classes/kohana/fragment.php
@@ -39,8 +39,8 @@ class Kohana_Fragment {
 	 *
 	 *     $key = Fragment::_cache_key('footer', TRUE);
 	 *
-	 * @param   string   fragment name
-	 * @param   boolean  multilingual fragment support
+	 * @param   string  $name   fragment name
+	 * @param   boolean $i18n   multilingual fragment support
 	 * @return  string
 	 * @uses    I18n::lang
 	 * @since   3.0.4
@@ -69,9 +69,9 @@ class Kohana_Fragment {
 	 *         Fragment::save();
 	 *     }
 	 *
-	 * @param   string   fragment name
-	 * @param   integer  fragment cache lifetime
-	 * @param   boolean  multilingual fragment support
+	 * @param   string  $name       fragment name
+	 * @param   integer $lifetime   fragment cache lifetime
+	 * @param   boolean $i18n       multilingual fragment support
 	 * @return  boolean
 	 */
 	public static function load($name, $lifetime = NULL, $i18n = NULL)
@@ -134,8 +134,8 @@ class Kohana_Fragment {
 	 *
 	 *     Fragment::delete($key);
 	 *
-	 * @param   string   fragment name
-	 * @param   boolean  multilingual fragment support
+	 * @param   string  $name   fragment name
+	 * @param   boolean $i18n   multilingual fragment support
 	 * @return  void
 	 */
 	public static function delete($name, $i18n = NULL)

--- a/classes/kohana/html.php
+++ b/classes/kohana/html.php
@@ -57,8 +57,8 @@ class Kohana_HTML {
 	 *
 	 *     echo HTML::chars($username);
 	 *
-	 * @param   string   string to convert
-	 * @param   boolean  encode existing entities
+	 * @param   string  $value          string to convert
+	 * @param   boolean $double_encode  encode existing entities
 	 * @return  string
 	 */
 	public static function chars($value, $double_encode = TRUE)
@@ -73,8 +73,8 @@ class Kohana_HTML {
 	 *
 	 *     echo HTML::entities($username);
 	 *
-	 * @param   string   string to convert
-	 * @param   boolean  encode existing entities
+	 * @param   string  $value          string to convert
+	 * @param   boolean $double_encode  encode existing entities
 	 * @return  string
 	 */
 	public static function entities($value, $double_encode = TRUE)
@@ -88,11 +88,11 @@ class Kohana_HTML {
 	 *
 	 *     echo HTML::anchor('/user/profile', 'My Profile');
 	 *
-	 * @param   string   URL or URI string
-	 * @param   string   link text
-	 * @param   array    HTML anchor attributes
-	 * @param   mixed    protocol to pass to URL::base()
-	 * @param   boolean  include the index page
+	 * @param   string  $uri        URL or URI string
+	 * @param   string  $title      link text
+	 * @param   array   $attributes HTML anchor attributes
+	 * @param   mixed   $protocol   protocol to pass to URL::base()
+	 * @param   boolean $index      include the index page
 	 * @return  string
 	 * @uses    URL::base
 	 * @uses    URL::site
@@ -140,11 +140,11 @@ class Kohana_HTML {
 	 *
 	 *     echo HTML::file_anchor('media/doc/user_guide.pdf', 'User Guide');
 	 *
-	 * @param   string  name of file to link to
-	 * @param   string  link text
-	 * @param   array   HTML anchor attributes
-	 * @param   mixed    protocol to pass to URL::base()
-	 * @param   boolean  include the index page
+	 * @param   string  $file       name of file to link to
+	 * @param   string  $title      link text
+	 * @param   array   $attributes HTML anchor attributes
+	 * @param   mixed   $protocol   protocol to pass to URL::base()
+	 * @param   boolean $index      include the index page
 	 * @return  string
 	 * @uses    URL::base
 	 * @uses    HTML::attributes
@@ -169,9 +169,9 @@ class Kohana_HTML {
 	 *
 	 *     echo HTML::mailto($address);
 	 *
-	 * @param   string  email address to send to
-	 * @param   string  link text
-	 * @param   array   HTML anchor attributes
+	 * @param   string  $email      email address to send to
+	 * @param   string  $title      link text
+	 * @param   array   $attributes HTML anchor attributes
 	 * @return  string
 	 * @uses    HTML::attributes
 	 */
@@ -191,10 +191,10 @@ class Kohana_HTML {
 	 *
 	 *     echo HTML::style('media/css/screen.css');
 	 *
-	 * @param   string   file name
-	 * @param   array    default attributes
-	 * @param   mixed    protocol to pass to URL::base()
-	 * @param   boolean  include the index page
+	 * @param   string  $file       file name
+	 * @param   array   $attributes default attributes
+	 * @param   mixed   $protocol   protocol to pass to URL::base()
+	 * @param   boolean $index      include the index page
 	 * @return  string
 	 * @uses    URL::base
 	 * @uses    HTML::attributes
@@ -224,10 +224,10 @@ class Kohana_HTML {
 	 *
 	 *     echo HTML::script('media/js/jquery.min.js');
 	 *
-	 * @param   string   file name
-	 * @param   array    default attributes
-	 * @param   mixed    protocol to pass to URL::base()
-	 * @param   boolean  include the index page
+	 * @param   string  $file       file name
+	 * @param   array   $attributes default attributes
+	 * @param   mixed   $protocol   protocol to pass to URL::base()
+	 * @param   boolean $index      include the index page
 	 * @return  string
 	 * @uses    URL::base
 	 * @uses    HTML::attributes
@@ -254,10 +254,10 @@ class Kohana_HTML {
 	 *
 	 *     echo HTML::image('media/img/logo.png', array('alt' => 'My Company'));
 	 *
-	 * @param   string   file name
-	 * @param   array    default attributes
-	 * @param   mixed    protocol to pass to URL::base()
-	 * @param   boolean  include the index page
+	 * @param   string  $file       file name
+	 * @param   array   $attributes default attributes
+	 * @param   mixed   $protocol   protocol to pass to URL::base()
+	 * @param   boolean $index      include the index page
 	 * @return  string
 	 * @uses    URL::base
 	 * @uses    HTML::attributes
@@ -282,7 +282,7 @@ class Kohana_HTML {
 	 *
 	 *     echo '<div'.HTML::attributes($attrs).'>'.$content.'</div>';
 	 *
-	 * @param   array   attribute list
+	 * @param   array   $attributes attribute list
 	 * @return  string
 	 */
 	public static function attributes(array $attributes = NULL)

--- a/classes/kohana/http/cache.php
+++ b/classes/kohana/http/cache.php
@@ -37,8 +37,8 @@ class Kohana_HTTP_Cache {
 	 *      );
 	 *
 	 * @uses    [Cache]
-	 * @param   mixed    cache engine to use
-	 * @param   array    options to set to this class
+	 * @param   mixed   $cache      cache engine to use
+	 * @param   array   $options    options to set to this class
 	 * @return  HTTP_Cache
 	 */
 	public static function factory($cache, array $options = array())
@@ -61,7 +61,7 @@ class Kohana_HTTP_Cache {
 	 *      // Generate cache key
 	 *      $cache_key = HTTP_Cache::basic_cache_key_generator($request);
 	 *
-	 * @param   Request   request 
+	 * @param   Request $request
 	 * @return  string
 	 */
 	public static function basic_cache_key_generator(Request $request)
@@ -129,8 +129,8 @@ class Kohana_HTTP_Cache {
 	 * cache completely and ensure the response is not cached. All other
 	 * Request methods will allow caching, if the rules are met.
 	 *
-	 * @param   Request_Client  client to execute with Cache-Control
-	 * @param   Request   request to execute with client
+	 * @param   Request_Client  $client     client to execute with Cache-Control
+	 * @param   Request         $request    request to execute with client
 	 * @return  [Response]
 	 */
 	public function execute(Request_Client $client, Request $request)
@@ -205,7 +205,7 @@ class Kohana_HTTP_Cache {
 	 * Getter and setter for the internal caching engine,
 	 * used to cache responses if available and valid.
 	 *
-	 * @param   Kohana_Cache  cache engine to use for caching
+	 * @param   Kohana_Cache  $cache    engine to use for caching
 	 * @return  Kohana_Cache
 	 * @return  Kohana_Request_Client
 	 */
@@ -224,7 +224,7 @@ class Kohana_HTTP_Cache {
 	 * that have the `private` setting.
 	 *
 	 * @link    http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9
-	 * @param   boolean  allow caching of privately marked responses
+	 * @param   boolean $setting    allow caching of privately marked responses
 	 * @return  boolean
 	 * @return  [Request_Client]
 	 */
@@ -259,7 +259,7 @@ class Kohana_HTTP_Cache {
 	 *            return sha1($request->render());
 	 *      });
 	 *
-	 * @param   callback  callback 
+	 * @param   callback    $callback
 	 * @return  mixed
 	 * @throws  HTTP_Exception
 	 */
@@ -282,8 +282,8 @@ class Kohana_HTTP_Cache {
 	 * This is the default cache key generating logic, but can be overridden
 	 * by setting [HTTP_Cache::cache_key_callback()].
 	 *
-	 * @param   Request   request to create key for
-	 * @param   callback  optional callback to use instead of built-in method
+	 * @param   Request     $request    request to create key for
+	 * @param   callback    $callback   optional callback to use instead of built-in method
 	 * @return  string
 	 */
 	public function create_cache_key(Request $request, $callback = FALSE)
@@ -347,9 +347,9 @@ class Kohana_HTTP_Cache {
 	 * If not response is supplied, the cache will be checked for an existing
 	 * one that is available.
 	 *
-	 * @param   string    the cache key to use
-	 * @param   Request   the HTTP Request
-	 * @param   Response  the HTTP Response
+	 * @param   string      $key        the cache key to use
+	 * @param   Request     $request    the HTTP Request
+	 * @param   Response    $response   the HTTP Response
 	 * @return  mixed
 	 */
 	public function cache_response($key, Request $request, Response $response = NULL)

--- a/classes/kohana/http/cache.php
+++ b/classes/kohana/http/cache.php
@@ -86,7 +86,7 @@ class Kohana_HTTP_Cache {
 
 	/**
 	 * @var    boolean   Defines whether this client should cache `private` cache directives
-	 * @see    http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9
+	 * @link   http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9
 	 */
 	protected $_allow_private_cache = FALSE;
 
@@ -223,7 +223,7 @@ class Kohana_HTTP_Cache {
 	 * If set to `TRUE`, the client will also cache cache-control directives
 	 * that have the `private` setting.
 	 *
-	 * @see     http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9
+	 * @link    http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9
 	 * @param   boolean  allow caching of privately marked responses
 	 * @return  boolean
 	 * @return  [Request_Client]

--- a/classes/kohana/http/exception.php
+++ b/classes/kohana/http/exception.php
@@ -13,9 +13,9 @@ class Kohana_HTTP_Exception extends Kohana_Exception {
 	 *     throw new Kohana_Exception('Something went terrible wrong, :user',
 	 *         array(':user' => $user));
 	 *
-	 * @param   string   status message, custom content to display with error
-	 * @param   array    translation variables
-	 * @param   integer  the http status code
+	 * @param   string  $message    status message, custom content to display with error
+	 * @param   array   $variables  translation variables
+	 * @param   integer $code       the http status code
 	 * @return  void
 	 */
 	public function __construct($message = NULL, array $variables = NULL, $code = 0)

--- a/classes/kohana/http/header.php
+++ b/classes/kohana/http/header.php
@@ -62,7 +62,7 @@ class Kohana_HTTP_Header extends ArrayObject {
 	 * Parses the accept header to provide the correct quality values
 	 * for each supplied accept type.
 	 *
-	 * @see     http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.1
+	 * @link    http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.1
 	 * @param   string   accept content header string to parse
 	 * @return  array
 	 * @since   3.2.0

--- a/classes/kohana/http/header.php
+++ b/classes/kohana/http/header.php
@@ -20,7 +20,7 @@ class Kohana_HTTP_Header extends ArrayObject {
 	/**
 	 * Parses an Accept(-*) header and detects the quality
 	 *
-	 * @param   array    accept header parts
+	 * @param   array   $parts  accept header parts
 	 * @return  array
 	 * @since   3.2.0
 	 */
@@ -63,7 +63,7 @@ class Kohana_HTTP_Header extends ArrayObject {
 	 * for each supplied accept type.
 	 *
 	 * @link    http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.1
-	 * @param   string   accept content header string to parse
+	 * @param   string  $accepts    accept content header string to parse
 	 * @return  array
 	 * @since   3.2.0
 	 */
@@ -103,7 +103,7 @@ class Kohana_HTTP_Header extends ArrayObject {
 	 * the charset and associated quality.
 	 *
 	 * @link    http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.2
-	 * @param   string   charset string to parse
+	 * @param   string  $charset    charset string to parse
 	 * @return  array 
 	 * @since   3.2.0
 	 */
@@ -122,7 +122,7 @@ class Kohana_HTTP_Header extends ArrayObject {
 	 * the charsets and associated quality.
 	 *
 	 * @link    http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.3
-	 * @param   string   charset string to parse
+	 * @param   string  $encoding   charset string to parse
 	 * @return  array 
 	 * @since   3.2.0
 	 */
@@ -148,7 +148,7 @@ class Kohana_HTTP_Header extends ArrayObject {
 	 * the languages and associated quality.
 	 *
 	 * @link    http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4
-	 * @param   string   charset string to parse
+	 * @param   string  $language   charset string to parse
 	 * @return  array 
 	 * @since   3.2.0
 	 */
@@ -199,7 +199,7 @@ class Kohana_HTTP_Header extends ArrayObject {
 	 *     $response->headers('Cache-Control', HTTP_Header::create_cache_control($cache_control);
 	 *
 	 * @link    http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13
-	 * @param   array     Cache-Control to render to string
+	 * @param   array   $cache_control  Cache-Control to render to string
 	 * @return  string
 	 */
 	public static function create_cache_control(array $cache_control)
@@ -283,9 +283,9 @@ class Kohana_HTTP_Header extends ArrayObject {
 	 *
 	 *     $header_object = new HTTP_Header(array('x-powered-by' => 'Kohana 3.1.x', 'expires' => '...'));
 	 *
-	 * @param   mixed    Input array
-	 * @param   int      Flags
-	 * @param   string   The iterator class to use
+	 * @param   mixed   $input          Input array
+	 * @param   int     $flags          Flags
+	 * @param   string  $iterator_class The iterator class to use
 	 */
 	public function __construct(array $input = array(), $flags = NULL, $iterator_class = 'ArrayIterator')
 	{
@@ -336,9 +336,9 @@ class Kohana_HTTP_Header extends ArrayObject {
 	 * is `FALSE`, the header will be appended rather than replacing the
 	 * original setting.
 	 *
-	 * @param   mixed     index to set `$newval` to
-	 * @param   mixed     new value to set
-	 * @param   boolean   replace existing value
+	 * @param   mixed   $index      index to set `$newval` to
+	 * @param   mixed   $newval     new value to set
+	 * @param   boolean $replace    replace existing value
 	 * @return  void
 	 * @since   3.2.0
 	 */
@@ -371,7 +371,7 @@ class Kohana_HTTP_Header extends ArrayObject {
 	 * Overloads the `ArrayObject::offsetExists()` method to ensure keys
 	 * are lowercase.
 	 *
-	 * @param   string $index 
+	 * @param   string  $index
 	 * @return  boolean
 	 * @since   3.2.0
 	 */
@@ -384,7 +384,7 @@ class Kohana_HTTP_Header extends ArrayObject {
 	 * Overloads the `ArrayObject::offsetUnset()` method to ensure keys
 	 * are lowercase.
 	 *
-	 * @param   string   index 
+	 * @param   string  $index
 	 * @return  void
 	 * @since   3.2.0
 	 */
@@ -397,7 +397,7 @@ class Kohana_HTTP_Header extends ArrayObject {
 	 * Overload the `ArrayObject::offsetGet()` method to ensure that all
 	 * keys passed to it are formatted correctly for this object.
 	 *
-	 * @param   string   index to retrieve
+	 * @param   string  $index  index to retrieve
 	 * @return  mixed
 	 * @since   3.2.0
 	 */
@@ -410,7 +410,7 @@ class Kohana_HTTP_Header extends ArrayObject {
 	 * Overloads the `ArrayObject::exchangeArray()` method to ensure that
 	 * all keys are changed to lowercase.
 	 *
-	 * @param   mixed    input 
+	 * @param   mixed   $input
 	 * @return  array
 	 * @since   3.2.0
 	 */
@@ -432,8 +432,8 @@ class Kohana_HTTP_Header extends ArrayObject {
 	 *     $header = $response->headers();
 	 *     $header->parse_header_string(NULL, 'content-type: application/json');
 	 *
-	 * @param   resource  the resource (required by Curl API)
-	 * @param   string    the line from the header to parse
+	 * @param   resource    $resource       the resource (required by Curl API)
+	 * @param   string      $header_line    the line from the header to parse
 	 * @return  int
 	 * @since   3.2.0
 	 */
@@ -467,8 +467,8 @@ class Kohana_HTTP_Header extends ArrayObject {
 	 *     // $quality_explicit = FALSE
 	 *     $quality_explicit = $request->headers()->accepts_at_quality('text/plain', TRUE);
 	 *
-	 * @param   string   type 
-	 * @param   boolean  explicit check, excludes `*`
+	 * @param   string  $type
+	 * @param   boolean $explicit   explicit check, excludes `*`
 	 * @return  mixed
 	 * @since   3.2.0
 	 */
@@ -554,9 +554,9 @@ class Kohana_HTTP_Header extends ArrayObject {
 	 *     ), TRUE); // $result = FALSE (none matched explicitly)
 	 * 
 	 *
-	 * @param   array    the content types to examine
-	 * @param   boolean  only allow explicit references, no wildcards
-	 * @return  string   name of the preferred content type
+	 * @param   array   $types      the content types to examine
+	 * @param   boolean $explicit   only allow explicit references, no wildcards
+	 * @return  string  name of the preferred content type
 	 * @since   3.2.0
 	 */
 	public function preferred_accept(array $types, $explicit = FALSE)
@@ -587,8 +587,8 @@ class Kohana_HTTP_Header extends ArrayObject {
 	 *      $quality = $header->accepts_charset_at_quality('utf-8');
 	 *            // $quality = (float) 1
 	 *
-	 * @param   string   charset to examine
-	 * @return  float    the quality of the charset 
+	 * @param   string  $charset    charset to examine
+	 * @return  float   the quality of the charset
 	 * @since   3.2.0
 	 */
 	public function accepts_charset_at_quality($charset)
@@ -633,8 +633,8 @@ class Kohana_HTTP_Header extends ArrayObject {
 	 *          'utf-10', 'ascii', 'utf-16', 'utf-8'
 	 *      )); // $charset = 'utf-8'
 	 *
-	 * @param   array    charsets to test
-	 * @return  mixed    preferred charset or `FALSE`
+	 * @param   array   $charsets   charsets to test
+	 * @return  mixed   preferred charset or `FALSE`
 	 * @since   3.2.0
 	 */
 	public function preferred_charset(array $charsets)
@@ -666,8 +666,8 @@ class Kohana_HTTP_Header extends ArrayObject {
 	 *      $encoding = $header->accepts_encoding_at_quality('gzip');
 	 *      // $encoding = (float) 1.0s
 	 *
-	 * @param   string    encoding type to interrogate
-	 * @param   boolean   explicit check, ignoring wildcards and `identity`
+	 * @param   string  $encoding   encoding type to interrogate
+	 * @param   boolean $explicit   explicit check, ignoring wildcards and `identity`
 	 * @return  float
 	 * @since   3.2.0
 	 */
@@ -721,8 +721,8 @@ class Kohana_HTTP_Header extends ArrayObject {
 	 *     ));
 	 *     // $encoding = 'gzip';
 	 *
-	 * @param   array    encodings to test against
-	 * @param   boolean  explicit check, if `TRUE` wildcards are excluded
+	 * @param   array   $encodings  encodings to test against
+	 * @param   boolean $explicit   explicit check, if `TRUE` wildcards are excluded
 	 * @return  mixed
 	 * @since   3.2.0
 	 */
@@ -760,8 +760,8 @@ class Kohana_HTTP_Header extends ArrayObject {
 	 *     $lang3 = $header->accepts_language_at_quality('en-au', TRUE);
 	 *     // $lang3 = (float) 0.0
 	 *
-	 * @param   string    language to interrogate
-	 * @param   boolean   explicit interrogation, `TRUE` ignores wildcards
+	 * @param   string  $language   language to interrogate
+	 * @param   boolean $explicit   explicit interrogation, `TRUE` ignores wildcards
 	 * @return  float
 	 * @since   3.2.0
 	 */
@@ -820,8 +820,8 @@ class Kohana_HTTP_Header extends ArrayObject {
 	 *          'en-gb', 'en-au', 'fr', 'es'
 	 *      )); // $lang = 'en-gb'
 	 *
-	 * @param   array     languages 
-	 * @param   boolean   explicit 
+	 * @param   array   $languages
+	 * @param   boolean $explicit
 	 * @return  mixed
 	 * @since   3.2.0
 	 */
@@ -852,9 +852,9 @@ class Kohana_HTTP_Header extends ArrayObject {
 	 * [!!] if you supply a custom header handler via `$callback`, it is
 	 *  recommended that `$response` is returned
 	 *
-	 * @param   HTTP_Response header to send
-	 * @param   boolean   replace existing value
-	 * @param   callback  optional callback to replace PHP header function
+	 * @param   HTTP_Response   $response   header to send
+	 * @param   boolean         $replace    replace existing value
+	 * @param   callback        $callback   optional callback to replace PHP header function
 	 * @return  mixed
 	 * @since   3.2.0
 	 */
@@ -919,8 +919,8 @@ class Kohana_HTTP_Header extends ArrayObject {
 	 * Sends the supplied headers to the PHP output buffer. If cookies
 	 * are included in the message they will be handled appropriately.
 	 *
-	 * @param   array     headers to send to php
-	 * @param   boolean   replace existing headers
+	 * @param   array   $headers    headers to send to php
+	 * @param   boolean $replace    replace existing headers
 	 * @return  self
 	 * @since   3.2.0
 	 */

--- a/classes/kohana/http/header.php
+++ b/classes/kohana/http/header.php
@@ -294,7 +294,7 @@ class Kohana_HTTP_Header extends ArrayObject {
 		 *
 		 * HTTP header declarations should be treated as case-insensitive
 		 */
-		$input = array_change_key_case($input, CASE_LOWER);
+		$input = array_change_key_case((array) $input, CASE_LOWER);
 
 		parent::__construct($input, $flags, $iterator_class);
 	}
@@ -404,6 +404,26 @@ class Kohana_HTTP_Header extends ArrayObject {
 	public function offsetGet($index)
 	{
 		return parent::offsetGet(strtolower($index));
+	}
+
+	/**
+	 * Overloads the `ArrayObject::exchangeArray()` method to ensure that
+	 * all keys are changed to lowercase.
+	 *
+	 * @param   mixed    input 
+	 * @return  array
+	 * @since   3.2.0
+	 */
+	public function exchangeArray($input)
+	{
+		/**
+		 * @link http://www.w3.org/Protocols/rfc2616/rfc2616.html
+		 *
+		 * HTTP header declarations should be treated as case-insensitive
+		 */
+		$input = array_change_key_case((array) $input, CASE_LOWER);
+
+		return parent::exchangeArray($input);
 	}
 
 	/**

--- a/classes/kohana/i18n.php
+++ b/classes/kohana/i18n.php
@@ -44,7 +44,7 @@ class Kohana_I18n {
 	 *     // Change the current language to Spanish
 	 *     I18n::lang('es-es');
 	 *
-	 * @param   string   new language setting
+	 * @param   string  $lang   new language setting
 	 * @return  string
 	 * @since   3.0.2
 	 */
@@ -65,8 +65,8 @@ class Kohana_I18n {
 	 *
 	 *     $hello = I18n::get('Hello friends, my name is :name');
 	 *
-	 * @param   string   text to translate
-	 * @param   string   target language
+	 * @param   string  $string text to translate
+	 * @param   string  $lang   target language
 	 * @return  string
 	 */
 	public static function get($string, $lang = NULL)
@@ -90,7 +90,7 @@ class Kohana_I18n {
 	 *     // Get all defined Spanish messages
 	 *     $messages = I18n::load('es-es');
 	 *
-	 * @param   string   language to load
+	 * @param   string  $lang   language to load
 	 * @return  array
 	 */
 	public static function load($lang)
@@ -147,9 +147,9 @@ if ( ! function_exists('__'))
 	 * [!!] The target language is defined by [I18n::$lang].
 	 * 
 	 * @uses    I18n::get
-	 * @param   string  text to translate
-	 * @param   array   values to replace in the translated text
-	 * @param   string  source language
+	 * @param   string  $string text to translate
+	 * @param   array   $values values to replace in the translated text
+	 * @param   string  $lang   source language
 	 * @return  string
 	 */
 	function __($string, array $values = NULL, $lang = 'en-us')

--- a/classes/kohana/inflector.php
+++ b/classes/kohana/inflector.php
@@ -39,7 +39,7 @@ class Kohana_Inflector {
 	 * been defined as uncountable in `config/inflector.php`. If this is the
 	 * case, please report [an issue](http://dev.kohanaphp.com/projects/kohana3/issues).
 	 *
-	 * @param   string   word to check
+	 * @param   string  $str    word to check
 	 * @return  boolean
 	 */
 	public static function uncountable($str)
@@ -70,8 +70,8 @@ class Kohana_Inflector {
 	 *
 	 * [!!] Special inflections are defined in `config/inflector.php`.
 	 *
-	 * @param   string   word to singularize
-	 * @param   integer  count of thing
+	 * @param   string  $str    word to singularize
+	 * @param   integer $count  count of thing
 	 * @return  string
 	 * @uses    Inflector::uncountable
 	 */
@@ -144,8 +144,8 @@ class Kohana_Inflector {
 	 *
 	 * [!!] Special inflections are defined in `config/inflector.php`.
 	 *
-	 * @param   string   word to pluralize
-	 * @param   integer  count of thing
+	 * @param   string  $str    word to pluralize
+	 * @param   integer $count  count of thing
 	 * @return  string
 	 * @uses    Inflector::uncountable
 	 */
@@ -213,7 +213,7 @@ class Kohana_Inflector {
 	 *     $str = Inflector::camelize('mother cat');     // "motherCat"
 	 *     $str = Inflector::camelize('kittens in bed'); // "kittensInBed"
 	 *
-	 * @param   string  phrase to camelize
+	 * @param   string  $str    phrase to camelize
 	 * @return  string
 	 */
 	public static function camelize($str)
@@ -230,8 +230,8 @@ class Kohana_Inflector {
 	 *     $str = Inflector::decamelize('houseCat');    // "house cat"
 	 *     $str = Inflector::decamelize('kingAllyCat'); // "king ally cat"
 	 *
-	 * @param   string   phrase to camelize
-	 * @param   string   word separator
+	 * @param   string  $str    phrase to camelize
+	 * @param   string  $sep    word separator
 	 * @return  string
 	 */
 	public static function decamelize($str, $sep = ' ')
@@ -244,7 +244,7 @@ class Kohana_Inflector {
 	 *
 	 *     $str = Inflector::underscore('five cats'); // "five_cats";
 	 *
-	 * @param   string  phrase to underscore
+	 * @param   string  $str    phrase to underscore
 	 * @return  string
 	 */
 	public static function underscore($str)
@@ -258,7 +258,7 @@ class Kohana_Inflector {
 	 *     $str = Inflector::humanize('kittens-are-cats'); // "kittens are cats"
 	 *     $str = Inflector::humanize('dogs_as_well');     // "dogs as well"
 	 *
-	 * @param   string  phrase to make human-readable
+	 * @param   string  $str    phrase to make human-readable
 	 * @return  string
 	 */
 	public static function humanize($str)

--- a/classes/kohana/kohana/exception.php
+++ b/classes/kohana/kohana/exception.php
@@ -109,8 +109,9 @@ class Kohana_Kohana_Exception extends Exception {
 
 				if (version_compare(PHP_VERSION, '5.3', '<'))
 				{
-					// Workaround for a bug in ErrorException::getTrace() that exists in
-					// all PHP 5.2 versions. @see http://bugs.php.net/bug.php?id=45895
+					// Workaround for a bug in ErrorException::getTrace() that
+					// exists in all PHP 5.2 versions.
+					// @link http://bugs.php.net/45895
 					for ($i = count($trace) - 1; $i > 0; --$i)
 					{
 						if (isset($trace[$i - 1]['args']))

--- a/classes/kohana/kohana/exception.php
+++ b/classes/kohana/kohana/exception.php
@@ -40,9 +40,9 @@ class Kohana_Kohana_Exception extends Exception {
 	 *     throw new Kohana_Exception('Something went terrible wrong, :user',
 	 *         array(':user' => $user));
 	 *
-	 * @param   string          error message
-	 * @param   array           translation variables
-	 * @param   integer|string  the exception code
+	 * @param   string          $message    error message
+	 * @param   array           $variables  translation variables
+	 * @param   integer|string  $code       the exception code
 	 * @return  void
 	 */
 	public function __construct($message, array $variables = NULL, $code = 0)
@@ -82,7 +82,7 @@ class Kohana_Kohana_Exception extends Exception {
 	 * exception, and the stack trace of the error.
 	 *
 	 * @uses    Kohana_Exception::text
-	 * @param   object   exception object
+	 * @param   Exception   $e
 	 * @return  boolean
 	 */
 	public static function handler(Exception $e)
@@ -203,7 +203,7 @@ class Kohana_Kohana_Exception extends Exception {
 	 *
 	 * Error [ Code ]: Message ~ File [ Line ]
 	 *
-	 * @param   object  Exception
+	 * @param   Exception   $e
 	 * @return  string
 	 */
 	public static function text(Exception $e)

--- a/classes/kohana/log.php
+++ b/classes/kohana/log.php
@@ -80,9 +80,9 @@ class Kohana_Log {
 	 *
 	 *     $log->attach($writer);
 	 *
-	 * @param   object   Log_Writer instance
-	 * @param   mixed    array of messages levels to write OR max level to write
-	 * @param   integer  min level to write IF $levels is not an array
+	 * @param   Log_Writer  $writer     instance
+	 * @param   mixed       $levels     array of messages levels to write OR max level to write
+	 * @param   integer     $min_level  min level to write IF $levels is not an array
 	 * @return  Log
 	 */
 	public function attach(Log_Writer $writer, $levels = array(), $min_level = 0)
@@ -106,7 +106,7 @@ class Kohana_Log {
 	 *
 	 *     $log->detach($writer);
 	 *
-	 * @param   object  Log_Writer instance
+	 * @param   Log_Writer  $writer instance
 	 * @return  Log
 	 */
 	public function detach(Log_Writer $writer)
@@ -125,9 +125,9 @@ class Kohana_Log {
 	 *         ':user' => $username,
 	 *     ));
 	 *
-	 * @param   string  level of message
-	 * @param   string  message body
-	 * @param   array   values to replace in the message
+	 * @param   string  $level      level of message
+	 * @param   string  $message    message body
+	 * @param   array   $values     values to replace in the message
 	 * @return  Log
 	 */
 	public function add($level, $message, array $values = NULL)

--- a/classes/kohana/log/file.php
+++ b/classes/kohana/log/file.php
@@ -21,7 +21,7 @@ class Kohana_Log_File extends Log_Writer {
 	 *
 	 *     $writer = new Log_File($directory);
 	 *
-	 * @param   string  log directory
+	 * @param   string  $directory  log directory
 	 * @return  void
 	 */
 	public function __construct($directory)
@@ -43,7 +43,7 @@ class Kohana_Log_File extends Log_Writer {
 	 *
 	 *     $writer->write($messages);
 	 *
-	 * @param   array   messages
+	 * @param   array   $messages
 	 * @return  void
 	 */
 	public function write(array $messages)

--- a/classes/kohana/log/stderr.php
+++ b/classes/kohana/log/stderr.php
@@ -14,7 +14,7 @@ class Kohana_Log_StdErr extends Log_Writer {
 	 *
 	 *     $writer->write($messages);
 	 *
-	 * @param   array   messages
+	 * @param   array   $messages
 	 * @return  void
 	 */
 	public function write(array $messages)

--- a/classes/kohana/log/stdout.php
+++ b/classes/kohana/log/stdout.php
@@ -14,7 +14,7 @@ class Kohana_Log_StdOut extends Log_Writer {
 	 *
 	 *     $writer->write($messages);
 	 *
-	 * @param   array   messages
+	 * @param   array   $messages
 	 * @return  void
 	 */
 	public function write(array $messages)

--- a/classes/kohana/log/syslog.php
+++ b/classes/kohana/log/syslog.php
@@ -28,7 +28,7 @@ class Kohana_Log_Syslog extends Log_Writer {
 	/**
 	 * Creates a new syslog logger.
 	 *
-	 * @see http://us2.php.net/openlog
+	 * @link    http://www.php.net/manual/function.openlog
 	 *
 	 * @param   string  syslog identifier
 	 * @param   int     facility to log to

--- a/classes/kohana/log/syslog.php
+++ b/classes/kohana/log/syslog.php
@@ -30,8 +30,8 @@ class Kohana_Log_Syslog extends Log_Writer {
 	 *
 	 * @link    http://www.php.net/manual/function.openlog
 	 *
-	 * @param   string  syslog identifier
-	 * @param   int     facility to log to
+	 * @param   string  $ident      syslog identifier
+	 * @param   int     $facility   facility to log to
 	 * @return  void
 	 */
 	public function __construct($ident = 'KohanaPHP', $facility = LOG_USER)
@@ -45,7 +45,7 @@ class Kohana_Log_Syslog extends Log_Writer {
 	/**
 	 * Writes each of the messages into the syslog.
 	 *
-	 * @param   array   messages
+	 * @param   array   $messages
 	 * @return  void
 	 */
 	public function write(array $messages)

--- a/classes/kohana/log/writer.php
+++ b/classes/kohana/log/writer.php
@@ -31,7 +31,7 @@ abstract class Kohana_Log_Writer {
 	 *
 	 *     $writer->write($messages);
 	 *
-	 * @param   array  messages
+	 * @param   array   $messages
 	 * @return  void
 	 */
 	abstract public function write(array $messages);

--- a/classes/kohana/model.php
+++ b/classes/kohana/model.php
@@ -15,7 +15,7 @@ abstract class Kohana_Model {
 	 *
 	 *     $model = Model::factory($name);
 	 *
-	 * @param   string   model name
+	 * @param   string  $name   model name
 	 * @return  Model
 	 */
 	public static function factory($name)

--- a/classes/kohana/num.php
+++ b/classes/kohana/num.php
@@ -63,7 +63,7 @@ class Kohana_Num {
 	 *     echo 10, Num::ordinal(10); // "10th"
 	 *     echo 33, Num::ordinal(33); // "33rd"
 	 *
-	 * @param   integer  number
+	 * @param   integer $number
 	 * @return  string
 	 */
 	public static function ordinal($number)
@@ -99,9 +99,9 @@ class Kohana_Num {
 	 *     // In Portuguese, "1.200.05"
 	 *     echo Num::format(1200.05, 2, TRUE);
 	 *
-	 * @param   float    number to format
-	 * @param   integer  decimal places
-	 * @param   boolean  monetary formatting?
+	 * @param   float   $number     number to format
+	 * @param   integer $places     decimal places
+	 * @param   boolean $monetary   monetary formatting?
 	 * @return  string
 	 * @since   3.0.2
 	 */
@@ -199,7 +199,7 @@ class Kohana_Num {
 	 *     echo Num::bytes('1000');  // 1000
 	 *     echo Num::bytes('2.5GB'); // 2684354560
 	 *
-	 * @param   string   file size in SB format
+	 * @param   string  $bytes  file size in SB format
 	 * @return  float
 	 */
 	public static function bytes($size)

--- a/classes/kohana/profiler.php
+++ b/classes/kohana/profiler.php
@@ -29,8 +29,8 @@ class Kohana_Profiler {
 	 *
 	 *     $token = Profiler::start('test', 'profiler');
 	 *
-	 * @param   string  group name
-	 * @param   string  benchmark name
+	 * @param   string  $group  group name
+	 * @param   string  $name   benchmark name
 	 * @return  string
 	 */
 	public static function start($group, $name)
@@ -62,7 +62,7 @@ class Kohana_Profiler {
 	 *
 	 *     Profiler::stop($token);
 	 *
-	 * @param   string  token
+	 * @param   string  $token
 	 * @return  void
 	 */
 	public static function stop($token)
@@ -79,7 +79,7 @@ class Kohana_Profiler {
 	 *
 	 *     Profiler::delete($token);
 	 *
-	 * @param   string  token
+	 * @param   string  $token
 	 * @return  void
 	 */
 	public static function delete($token)
@@ -113,8 +113,8 @@ class Kohana_Profiler {
 	 *
 	 *     $stats = Profiler::stats($tokens);
 	 *
-	 * @param   array  profiler tokens
-	 * @return  array  min, max, average, total
+	 * @param   array   $tokens profiler tokens
+	 * @return  array   min, max, average, total
 	 * @uses    Profiler::total
 	 */
 	public static function stats(array $tokens)
@@ -185,8 +185,8 @@ class Kohana_Profiler {
 	 *
 	 *     $stats = Profiler::group_stats('test');
 	 *
-	 * @param   mixed  single group name string, or array with group names; all groups by default
-	 * @return  array  min, max, average, total
+	 * @param   mixed   $groups single group name string, or array with group names; all groups by default
+	 * @return  array   min, max, average, total
 	 * @uses    Profiler::groups
 	 * @uses    Profiler::stats
 	 */
@@ -271,7 +271,7 @@ class Kohana_Profiler {
 	 *
 	 *     list($time, $memory) = Profiler::total($token);
 	 *
-	 * @param   string  token
+	 * @param   string  $token
 	 * @return  array   execution time, memory
 	 */
 	public static function total($token)

--- a/classes/kohana/request.php
+++ b/classes/kohana/request.php
@@ -943,7 +943,7 @@ class Kohana_Request implements HTTP_Request {
 		if (strpos($url, '://') === FALSE)
 		{
 			// Make the URI into a URL
-			$url = URL::site($url, $protocol, Kohana::$index_file);
+			$url = URL::site($url, TRUE, Kohana::$index_file);
 		}
 
 		if (($response = $this->response()) === NULL)

--- a/classes/kohana/request.php
+++ b/classes/kohana/request.php
@@ -1292,7 +1292,7 @@ class Kohana_Request implements HTTP_Request {
 	 * Getter/Setter to the security settings for this request. This
 	 * method should be treated as immutable.
 	 *
-	 * @param   boolean   is this request secure?
+	 * @param   boolean $secure is this request secure?
 	 * @return  mixed
 	 */
 	public function secure($secure = NULL)

--- a/classes/kohana/request.php
+++ b/classes/kohana/request.php
@@ -942,23 +942,29 @@ class Kohana_Request implements HTTP_Request {
 	 */
 	public function redirect($url = '', $code = 302)
 	{
+		$referrer = $this->uri();
+
+		if (strpos($referrer, '://') === FALSE)
+		{
+			$referrer = URL::site($referrer, TRUE, Kohana::$index_file);
+		}
+
 		if (strpos($url, '://') === FALSE)
 		{
 			// Make the URI into a URL
-			$url = URL::site($url, TRUE);
+			$url = URL::site($url, TRUE, Kohana::$index_file);
 		}
 
-		// Redirect
-		$response = $this->create_response();
+		if (($response = $this->response()) === NULL)
+		{
+			$response = $this->create_response();
+		}
 
-		// Set the response status
-		$response->status($code);
-
-		// Set the location header
-		$response->headers('Location', $url);
-
-		// Send headers
-		$response->send_headers();
+		echo $response->status($code)
+			->headers('Location', $url)
+			->headers('Referer', $referrer)
+			->send_headers()
+			->body();
 
 		// Stop execution
 		exit;

--- a/classes/kohana/request.php
+++ b/classes/kohana/request.php
@@ -933,16 +933,17 @@ class Kohana_Request implements HTTP_Request {
 	public function redirect($url = '', $code = 302)
 	{
 		$referrer = $this->uri();
+		$protocol = ($this->secure()) ? 'https' : TRUE;
 
 		if (strpos($referrer, '://') === FALSE)
 		{
-			$referrer = URL::site($referrer, TRUE, Kohana::$index_file);
+			$referrer = URL::site($referrer, $protocol, Kohana::$index_file);
 		}
 
 		if (strpos($url, '://') === FALSE)
 		{
 			// Make the URI into a URL
-			$url = URL::site($url, TRUE, Kohana::$index_file);
+			$url = URL::site($url, $protocol, Kohana::$index_file);
 		}
 
 		if (($response = $this->response()) === NULL)

--- a/classes/kohana/request.php
+++ b/classes/kohana/request.php
@@ -937,13 +937,13 @@ class Kohana_Request implements HTTP_Request {
 
 		if (strpos($referrer, '://') === FALSE)
 		{
-			$referrer = URL::site($referrer, $protocol, Kohana::$index_file);
+			$referrer = URL::site($referrer, $protocol, ! empty(Kohana::$index_file));
 		}
 
 		if (strpos($url, '://') === FALSE)
 		{
 			// Make the URI into a URL
-			$url = URL::site($url, TRUE, Kohana::$index_file);
+			$url = URL::site($url, TRUE, ! empty(Kohana::$index_file));
 		}
 
 		if (($response = $this->response()) === NULL)

--- a/classes/kohana/request.php
+++ b/classes/kohana/request.php
@@ -195,7 +195,7 @@ class Kohana_Request implements HTTP_Request {
 			}
 
 			// Create the instance singleton
-			Request::$initial = $request = new Request($uri, $cache);
+			Request::$initial = $request = new Request($uri, $cache, $injected_routes);
 
 			// Store global GET and POST data in the initial request only
 			$request->protocol($protocol)
@@ -758,7 +758,7 @@ class Kohana_Request implements HTTP_Request {
 		$this->_header = new HTTP_Header(array());
 
 		// Assign injected routes
-		$this->_injected_routes = $injected_routes;
+		$this->_routes = $injected_routes;
 
 		// Cleanse query parameters from URI (faster that parse_url())
 		$split_uri = explode('?', $uri);
@@ -782,7 +782,7 @@ class Kohana_Request implements HTTP_Request {
 			// Remove trailing slashes from the URI
 			$uri = trim($uri, '/');
 
-			$processed_uri = Request::process_uri($uri, $this->_injected_routes);
+			$processed_uri = Request::process_uri($uri, $this->_routes);
 
 			// Return here rather than throw exception. This will allow
 			// use of Request object even with unmatched route

--- a/classes/kohana/request/client.php
+++ b/classes/kohana/request/client.php
@@ -70,7 +70,7 @@ abstract class Kohana_Request_Client {
 	 * 
 	 * This method must be implemented by all clients.
 	 *
-	 * @param   Request   request to execute by client
+	 * @param   Request $request    request to execute by client
 	 * @return  Response
 	 * @since   3.2.0
 	 */
@@ -80,9 +80,9 @@ abstract class Kohana_Request_Client {
 	 * Getter and setter for the internal caching engine,
 	 * used to cache responses if available and valid.
 	 *
-	 * @param   [HTTP_Cache] cache engine to use for caching
-	 * @return  [HTTP_Cache]
-	 * @return  [Request_Client]
+	 * @param   HTTP_Cache  $cache  engine to use for caching
+	 * @return  HTTP_Cache
+	 * @return  Request_Client
 	 */
 	public function cache(HTTP_Cache $cache = NULL)
 	{

--- a/classes/kohana/request/client/curl.php
+++ b/classes/kohana/request/client/curl.php
@@ -16,7 +16,7 @@ class Kohana_Request_Client_Curl extends Request_Client_External {
 	 * Sends the HTTP message [Request] to a remote server and processes
 	 * the response.
 	 *
-	 * @param   Request   request to send
+	 * @param   Request $request    request to send
 	 * @return  Response
 	 */
 	public function _send_message(Request $request)

--- a/classes/kohana/request/client/curl.php
+++ b/classes/kohana/request/client/curl.php
@@ -62,7 +62,7 @@ class Kohana_Request_Client_Curl extends Request_Client_External {
 		$this->_options[CURLOPT_HEADER]         = FALSE;
 
 		// Apply any additional options set to 
-		$options += $this->_options;
+		$options = Arr::merge($options, $this->_options);
 
 		$uri = $request->uri();
 

--- a/classes/kohana/request/client/external.php
+++ b/classes/kohana/request/client/external.php
@@ -48,8 +48,8 @@ abstract class Kohana_Request_Client_External extends Request_Client {
 	 * 
 	 * Request_Client_External::$client can be set in the application bootstrap.
 	 *
-	 * @param   array     parameters to pass to the client
-	 * @param   string    external client to use
+	 * @param   array   $params parameters to pass to the client
+	 * @param   string  $client external client to use
 	 * @return  Request_Client_External
 	 * @throws  Request_Exception
 	 */
@@ -197,7 +197,7 @@ abstract class Kohana_Request_Client_External extends Request_Client {
 	 * Sends the HTTP message [Request] to a remote server and processes
 	 * the response.
 	 *
-	 * @param   Request   request to send
+	 * @param   Request $request    request to send
 	 * @return  Response
 	 */
 	abstract protected function _send_message(Request $request);

--- a/classes/kohana/request/client/external.php
+++ b/classes/kohana/request/client/external.php
@@ -72,8 +72,8 @@ abstract class Kohana_Request_Client_External extends Request_Client {
 
 	/**
 	 * @var     array     curl options
-	 * @see     [http://www.php.net/manual/en/function.curl-setopt.php]
-	 * @see     [http://www.php.net/manual/en/http.request.options.php]
+	 * @link    http://www.php.net/manual/function.curl-setopt
+	 * @link    http://www.php.net/manual/http.request.options
 	 */
 	protected $_options = array();
 

--- a/classes/kohana/request/client/http.php
+++ b/classes/kohana/request/client/http.php
@@ -39,7 +39,7 @@ class Kohana_Request_Client_HTTP extends Request_Client_External {
 
 	/**
 	 * @var     array     curl options
-	 * @see     [http://www.php.net/manual/en/function.curl-setopt.php]
+	 * @link    http://www.php.net/manual/function.curl-setopt
 	 */
 	protected $_options = array();
 

--- a/classes/kohana/request/client/http.php
+++ b/classes/kohana/request/client/http.php
@@ -47,7 +47,7 @@ class Kohana_Request_Client_HTTP extends Request_Client_External {
 	 * Sends the HTTP message [Request] to a remote server and processes
 	 * the response.
 	 *
-	 * @param   Request   request to send
+	 * @param   Request $request    request to send
 	 * @return  Response
 	 */
 	public function _send_message(Request $request)

--- a/classes/kohana/request/client/stream.php
+++ b/classes/kohana/request/client/stream.php
@@ -22,7 +22,7 @@ class Kohana_Request_Client_Stream extends Request_Client_External {
 	 * Sends the HTTP message [Request] to a remote server and processes
 	 * the response.
 	 *
-	 * @param   Request   request to send
+	 * @param   Request $request    request to send
 	 * @return  Response
 	 * @uses    [PHP cURL](http://php.net/manual/en/book.curl.php)
 	 */

--- a/classes/kohana/response.php
+++ b/classes/kohana/response.php
@@ -280,8 +280,8 @@ class Kohana_Response implements HTTP_Response {
 	 *          'expiration' => 12352234
 	 *     ));
 	 *
-	 * @param   mixed     cookie name, or array of cookie values
-	 * @param   string    value to set to cookie
+	 * @param   mixed   $key    cookie name, or array of cookie values
+	 * @param   string  $value  value to set to cookie
 	 * @return  string
 	 * @return  void
 	 * @return  [Response]
@@ -326,7 +326,7 @@ class Kohana_Response implements HTTP_Response {
 	/**
 	 * Deletes a cookie set to the response
 	 *
-	 * @param   string   name
+	 * @param   string  $name
 	 * @return  Response
 	 */
 	public function delete_cookie($name)
@@ -349,8 +349,8 @@ class Kohana_Response implements HTTP_Response {
 	/**
 	 * Sends the response status and all set headers.
 	 *
-	 * @param   boolean   replace existing headers
-	 * @param   callback  function to handle header output
+	 * @param   boolean     $replace    replace existing headers
+	 * @param   callback    $callback   function to handle header output
 	 * @return  mixed
 	 */
 	public function send_headers($replace = FALSE, $callback = NULL)
@@ -381,9 +381,9 @@ class Kohana_Response implements HTTP_Response {
 	 *
 	 * [!!] No further processing can be done after this method is called!
 	 *
-	 * @param   string   filename with path, or TRUE for the current response
-	 * @param   string   downloaded file name
-	 * @param   array    additional options
+	 * @param   string  $filename   filename with path, or TRUE for the current response
+	 * @param   string  $download   downloaded file name
+	 * @param   array   $options    additional options
 	 * @return  void
 	 * @throws  Kohana_Exception
 	 * @uses    File::mime_by_ext

--- a/classes/kohana/response.php
+++ b/classes/kohana/response.php
@@ -704,7 +704,7 @@ class Kohana_Response implements HTTP_Response {
 	 * Parse the byte ranges from the HTTP_RANGE header used for
 	 * resumable downloads.
 	 *
-	 * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35
+	 * @link   http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35
 	 * @return array|FALSE
 	 */
 	protected function _parse_byte_range()

--- a/classes/kohana/route.php
+++ b/classes/kohana/route.php
@@ -80,9 +80,9 @@ class Kohana_Route {
 	 *             'controller' => 'welcome',
 	 *         ));
 	 *
-	 * @param   string   route name
-	 * @param   string   URI pattern
-	 * @param   array    regex patterns for route keys
+	 * @param   string  $name           route name
+	 * @param   string  $uri_callback   URI pattern
+	 * @param   array   $regex          regex patterns for route keys
 	 * @return  Route
 	 */
 	public static function set($name, $uri_callback = NULL, $regex = NULL)
@@ -95,7 +95,7 @@ class Kohana_Route {
 	 *
 	 *     $route = Route::get('default');
 	 *
-	 * @param   string  route name
+	 * @param   string  $name   route name
 	 * @return  Route
 	 * @throws  Kohana_Exception
 	 */
@@ -127,7 +127,7 @@ class Kohana_Route {
 	 *
 	 *     $name = Route::name($route)
 	 *
-	 * @param   object  Route instance
+	 * @param   Route   $route  instance
 	 * @return  string
 	 */
 	public static function name(Route $route)
@@ -146,9 +146,9 @@ class Kohana_Route {
 	 *         Route::cache(TRUE);
 	 *     }
 	 *
-	 * @param   boolean   cache the current routes
-	 * @return  void      when saving routes
-	 * @return  boolean   when loading routes
+	 * @param   boolean $save   cache the current routes
+	 * @return  void    when saving routes
+	 * @return  boolean when loading routes
 	 * @uses    Kohana::cache
 	 */
 	public static function cache($save = FALSE)
@@ -180,9 +180,9 @@ class Kohana_Route {
 	 *
 	 *     echo URL::site(Route::get($name)->uri($params), $protocol);
 	 *
-	 * @param   string   route name
-	 * @param   array    URI parameters
-	 * @param   mixed   protocol string or boolean, adds protocol and domain
+	 * @param   string  $name       route name
+	 * @param   array   $params     URI parameters
+	 * @param   mixed   $protocol   protocol string or boolean, adds protocol and domain
 	 * @return  string
 	 * @since   3.0.7
 	 * @uses    URL::site
@@ -299,8 +299,8 @@ class Kohana_Route {
 	 *     	'foo/bar/<id>'
 	 *     });
 	 *
-	 * @param   mixed    route URI pattern or lambda/callback function
-	 * @param   array    key patterns
+	 * @param   mixed   $uri    route URI pattern or lambda/callback function
+	 * @param   array   $regex  key patterns
 	 * @return  void
 	 * @uses    Route::_compile
 	 */
@@ -343,7 +343,7 @@ class Kohana_Route {
 	 * 
 	 * If no parameter is passed, this method will act as a getter.
 	 *
-	 * @param   array  key values
+	 * @param   array   $defaults   key values
 	 * @return  $this or array
 	 */
 	public function defaults(array $defaults = NULL)
@@ -373,7 +373,7 @@ class Kohana_Route {
 	 *         // Parse the parameters
 	 *     }
 	 *
-	 * @param   string  URI to match
+	 * @param   string  $uri    URI to match
 	 * @return  array   on success
 	 * @return  FALSE   on failure
 	 */
@@ -439,7 +439,7 @@ class Kohana_Route {
 	 *         'id'         => '10'
 	 *     ));
 	 *
-	 * @param   array   URI parameters
+	 * @param   array   $params URI parameters
 	 * @return  string
 	 * @throws  Kohana_Exception
 	 * @uses    Route::REGEX_Key

--- a/classes/kohana/security.php
+++ b/classes/kohana/security.php
@@ -34,7 +34,7 @@ class Kohana_Security {
 	 *
 	 * This provides a basic, but effective, method of preventing CSRF attacks.
 	 *
-	 * @param   boolean  force a new token to be generated?
+	 * @param   boolean $new    force a new token to be generated?
 	 * @return  string
 	 * @uses    Session::instance
 	 */
@@ -65,7 +65,7 @@ class Kohana_Security {
 	 *         // Pass
 	 *     }
 	 *
-	 * @param   string   token to check
+	 * @param   string  $token  token to check
 	 * @return  boolean
 	 * @uses    Security::token
 	 */
@@ -79,7 +79,7 @@ class Kohana_Security {
 	 *
 	 *     $str = Security::strip_image_tags($str);
 	 *
-	 * @param   string  string to sanitize
+	 * @param   string  $str    string to sanitize
 	 * @return  string
 	 */
 	public static function strip_image_tags($str)
@@ -92,7 +92,7 @@ class Kohana_Security {
 	 *
 	 *     $str = Security::encode_php_tags($str);
 	 *
-	 * @param   string  string to sanitize
+	 * @param   string  $str    string to sanitize
 	 * @return  string
 	 */
 	public static function encode_php_tags($str)

--- a/classes/kohana/session.php
+++ b/classes/kohana/session.php
@@ -29,8 +29,8 @@ abstract class Kohana_Session {
 	 *
 	 * [!!] [Session::write] will automatically be called when the request ends.
 	 *
-	 * @param   string   type of session (native, cookie, etc)
-	 * @param   string   session identifier
+	 * @param   string  $type   type of session (native, cookie, etc)
+	 * @param   string  $id     session identifier
 	 * @return  Session
 	 * @uses    Kohana::$config
 	 */
@@ -90,8 +90,8 @@ abstract class Kohana_Session {
 	 *
 	 * [!!] Sessions can only be created using the [Session::instance] method.
 	 *
-	 * @param   array   configuration
-	 * @param   string  session id
+	 * @param   array   $config configuration
+	 * @param   string  $id     session id
 	 * @return  void
 	 * @uses    Session::read
 	 */
@@ -204,8 +204,8 @@ abstract class Kohana_Session {
 	 *
 	 *     $foo = $session->get('foo');
 	 *
-	 * @param   string   variable name
-	 * @param   mixed    default value to return
+	 * @param   string  $key        variable name
+	 * @param   mixed   $default    default value to return
 	 * @return  mixed
 	 */
 	public function get($key, $default = NULL)
@@ -218,8 +218,8 @@ abstract class Kohana_Session {
 	 *
 	 *     $bar = $session->get_once('bar');
 	 *
-	 * @param   string  variable name
-	 * @param   mixed   default value to return
+	 * @param   string  $key        variable name
+	 * @param   mixed   $default    default value to return
 	 * @return  mixed
 	 */
 	public function get_once($key, $default = NULL)
@@ -236,8 +236,8 @@ abstract class Kohana_Session {
 	 *
 	 *     $session->set('foo', 'bar');
 	 *
-	 * @param   string   variable name
-	 * @param   mixed    value
+	 * @param   string  $key    variable name
+	 * @param   mixed   $value  value
 	 * @return  $this
 	 */
 	public function set($key, $value)
@@ -252,8 +252,8 @@ abstract class Kohana_Session {
 	 *
 	 *     $session->bind('foo', $foo);
 	 *
-	 * @param   string  variable name
-	 * @param   mixed   referenced value
+	 * @param   string  $key    variable name
+	 * @param   mixed   $value  referenced value
 	 * @return  $this
 	 */
 	public function bind($key, & $value)
@@ -268,8 +268,7 @@ abstract class Kohana_Session {
 	 *
 	 *     $session->delete('foo');
 	 *
-	 * @param   string  variable name
-	 * @param   ...
+	 * @param   string  $key,...    variable name
 	 * @return  $this
 	 */
 	public function delete($key)
@@ -289,7 +288,7 @@ abstract class Kohana_Session {
 	 *
 	 *     $session->read();
 	 *
-	 * @param   string   session id
+	 * @param   string  $id session id
 	 * @return  void
 	 */
 	public function read($id = NULL)
@@ -427,7 +426,7 @@ abstract class Kohana_Session {
 	/**
 	 * Loads the raw session data string and returns it.
 	 *
-	 * @param   string   session id
+	 * @param   string  $id session id
 	 * @return  string
 	 */
 	abstract protected function _read($id = NULL);

--- a/classes/kohana/text.php
+++ b/classes/kohana/text.php
@@ -52,9 +52,9 @@ class Kohana_Text {
 	 *
 	 *     $text = Text::limit_words($text);
 	 *
-	 * @param   string   phrase to limit words of
-	 * @param   integer  number of words to limit to
-	 * @param   string   end character or entity
+	 * @param   string  $str        phrase to limit words of
+	 * @param   integer $limit      number of words to limit to
+	 * @param   string  $end_char   end character or entity
 	 * @return  string
 	 */
 	public static function limit_words($str, $limit = 100, $end_char = NULL)
@@ -80,10 +80,10 @@ class Kohana_Text {
 	 *
 	 *     $text = Text::limit_chars($text);
 	 *
-	 * @param   string   phrase to limit characters of
-	 * @param   integer  number of characters to limit to
-	 * @param   string   end character or entity
-	 * @param   boolean  enable or disable the preservation of words while limiting
+	 * @param   string  $str            phrase to limit characters of
+	 * @param   integer $limit          number of characters to limit to
+	 * @param   string  $end_char       end character or entity
+	 * @param   boolean $preserve_words enable or disable the preservation of words while limiting
 	 * @return  string
 	 * @uses    UTF8::strlen
 	 */
@@ -120,7 +120,7 @@ class Kohana_Text {
 	 * Note that using multiple iterations of different strings may produce
 	 * unexpected results.
 	 *
-	 * @param   string  strings to alternate between
+	 * @param   string  $str,...    strings to alternate between
 	 * @return  string
 	 */
 	public static function alternate()
@@ -160,8 +160,8 @@ class Kohana_Text {
 	 * You can also create a custom type by providing the "pool" of characters
 	 * as the type.
 	 *
-	 * @param   string   a type of pool, or a string of characters to use as the pool
-	 * @param   integer  length of string to return
+	 * @param   string  $type   a type of pool, or a string of characters to use as the pool
+	 * @param   integer $length length of string to return
 	 * @return  string
 	 * @uses    UTF8::split
 	 */
@@ -238,8 +238,8 @@ class Kohana_Text {
 	 * 
 	 *      $str = Text::ucfirst('content-type'); // returns "Content-Type" 
 	 *
-	 * @param   string    string to transform
-	 * @param   string    delemiter to use
+	 * @param   string  $string     string to transform
+	 * @param   string  $delimiter  delemiter to use
 	 * @return  string
 	 */
 	public static function ucfirst($string, $delimiter = '-')
@@ -253,7 +253,7 @@ class Kohana_Text {
 	 *
 	 *     $str = Text::reduce_slashes('foo//bar/baz'); // "foo/bar/baz"
 	 *
-	 * @param   string  string to reduce slashes of
+	 * @param   string  $str    string to reduce slashes of
 	 * @return  string
 	 */
 	public static function reduce_slashes($str)
@@ -269,10 +269,10 @@ class Kohana_Text {
 	 *         'frick' => '#####',
 	 *     ));
 	 *
-	 * @param   string   phrase to replace words in
-	 * @param   array    words to replace
-	 * @param   string   replacement string
-	 * @param   boolean  replace words across word boundries (space, period, etc)
+	 * @param   string  $str                    phrase to replace words in
+	 * @param   array   $badwords               words to replace
+	 * @param   string  $replacement            replacement string
+	 * @param   boolean $replace_partial_words  replace words across word boundries (space, period, etc)
 	 * @return  string
 	 * @uses    UTF8::strlen
 	 */
@@ -307,7 +307,7 @@ class Kohana_Text {
 	 *
 	 *     $match = Text::similar(array('fred', 'fran', 'free'); // "fr"
 	 *
-	 * @param   array   words to find similar text of
+	 * @param   array   $words  words to find similar text of
 	 * @return  string
 	 */
 	public static function similar(array $words)
@@ -337,7 +337,7 @@ class Kohana_Text {
 	 *
 	 * [!!] This method is not foolproof since it uses regex to parse HTML.
 	 *
-	 * @param   string   text to auto link
+	 * @param   string  $text   text to auto link
 	 * @return  string
 	 * @uses    Text::auto_link_urls
 	 * @uses    Text::auto_link_emails
@@ -355,7 +355,7 @@ class Kohana_Text {
 	 *
 	 * [!!] This method is not foolproof since it uses regex to parse HTML.
 	 *
-	 * @param   string   text to auto link
+	 * @param   string  $text   text to auto link
 	 * @return  string
 	 * @uses    HTML::anchor
 	 */
@@ -386,7 +386,7 @@ class Kohana_Text {
 	 *
 	 * [!!] This method is not foolproof since it uses regex to parse HTML.
 	 *
-	 * @param   string   text to auto link
+	 * @param   string  $text   text to auto link
 	 * @return  string
 	 * @uses    HTML::mailto
 	 */
@@ -411,8 +411,8 @@ class Kohana_Text {
 	 *
 	 * [!!] This method is not foolproof since it uses regex to parse HTML.
 	 *
-	 * @param   string   subject
-	 * @param   boolean  convert single linebreaks to <br />
+	 * @param   string  $str    subject
+	 * @param   boolean $br     convert single linebreaks to <br />
 	 * @return  string
 	 */
 	public static function auto_p($str, $br = TRUE)
@@ -467,10 +467,10 @@ class Kohana_Text {
 	 *
 	 *     echo Text::bytes(filesize($file));
 	 *
-	 * @param   integer  size in bytes
-	 * @param   string   a definitive unit
-	 * @param   string   the return string format
-	 * @param   boolean  whether to use SI prefixes or IEC
+	 * @param   integer $bytes      size in bytes
+	 * @param   string  $force_unit a definitive unit
+	 * @param   string  $format     the return string format
+	 * @param   boolean $si         whether to use SI prefixes or IEC
 	 * @return  string
 	 */
 	public static function bytes($bytes, $force_unit = NULL, $format = NULL, $si = TRUE)
@@ -509,7 +509,7 @@ class Kohana_Text {
 	 *     // Display: five million, six hundred and thirty-two
 	 *     echo Text::number(5000632);
 	 *
-	 * @param   integer   number to format
+	 * @param   integer $number number to format
 	 * @return  string
 	 * @since   3.0.8
 	 */
@@ -587,7 +587,7 @@ class Kohana_Text {
 	 *
 	 *     echo Text::widont($text);
 	 *
-	 * @param   string  text to remove widows from
+	 * @param   string  $str    text to remove widows from
 	 * @return  string
 	 */
 	public static function widont($str)

--- a/classes/kohana/upload.php
+++ b/classes/kohana/upload.php
@@ -42,12 +42,12 @@ class Kohana_Upload {
 	 *         Upload::save($array['file']);
 	 *     }
 	 *
-	 * @param   array    uploaded file data
-	 * @param   string   new filename
-	 * @param   string   new directory
-	 * @param   integer  chmod mask
-	 * @return  string   on success, full path to new file
-	 * @return  FALSE    on failure
+	 * @param   array   $file       uploaded file data
+	 * @param   string  $filename   new filename
+	 * @param   string  $directory  new directory
+	 * @param   integer $chmod      chmod mask
+	 * @return  string  on success, full path to new file
+	 * @return  FALSE   on failure
 	 */
 	public static function save(array $file, $filename = NULL, $directory = NULL, $chmod = 0644)
 	{
@@ -106,7 +106,7 @@ class Kohana_Upload {
 	 *
 	 *     $array->rule('file', 'Upload::valid')
 	 *
-	 * @param   array  $_FILES item
+	 * @param   array   $file   $_FILES item
 	 * @return  bool
 	 */
 	public static function valid($file)
@@ -123,7 +123,7 @@ class Kohana_Upload {
 	 *
 	 *     $array->rule('file', 'Upload::not_empty');
 	 *
-	 * @param   array    $_FILES item
+	 * @param   array   $file   $_FILES item
 	 * @return  bool
 	 */
 	public static function not_empty(array $file)
@@ -139,8 +139,8 @@ class Kohana_Upload {
 	 *
 	 *     $array->rule('file', 'Upload::type', array(':value', array('jpg', 'png', 'gif')));
 	 *
-	 * @param   array    $_FILES item
-	 * @param   array    allowed file extensions
+	 * @param   array   $file       $_FILES item
+	 * @param   array   $allowed    allowed file extensions
 	 * @return  bool
 	 */
 	public static function type(array $file, array $allowed)
@@ -162,8 +162,8 @@ class Kohana_Upload {
 	 *     $array->rule('file', 'Upload::size', array(':value', '1M'))
 	 *     $array->rule('file', 'Upload::size', array(':value', '2.5KiB'))
 	 *
-	 * @param   array    $_FILES item
-	 * @param   string   maximum file size allowed
+	 * @param   array   $file   $_FILES item
+	 * @param   string  $size   maximum file size allowed
 	 * @return  bool
 	 */
 	public static function size(array $file, $size)
@@ -200,10 +200,10 @@ class Kohana_Upload {
 	 *     $array->rule('image', 'Upload::image', array(100, 100, TRUE));
 	 *
 	 *
-	 * @param   array    $_FILES item
-	 * @param   integer  maximum width of image
-	 * @param   integer  maximum height of image
-	 * @param   boolean  match width and height exactly?
+	 * @param   array   $file       $_FILES item
+	 * @param   integer $max_width  maximum width of image
+	 * @param   integer $max_height maximum height of image
+	 * @param   boolean $exact      match width and height exactly?
 	 * @return  boolean
 	 */
 	public static function image(array $file, $max_width = NULL, $max_height = NULL, $exact = FALSE)

--- a/classes/kohana/url.php
+++ b/classes/kohana/url.php
@@ -44,8 +44,15 @@ class Kohana_URL {
 
 		if ($protocol instanceof Request)
 		{
-			// Use the current protocol
-			list($protocol) = explode('/', strtolower($protocol->protocol()));
+			if ( ! $protocol->secure())
+			{
+				// Use the current protocol
+				list($protocol) = explode('/', strtolower($protocol->protocol()));
+			}
+			else
+			{
+				$protocol = 'https';
+			}
 		}
 
 		if ( ! $protocol)

--- a/classes/kohana/utf8.php
+++ b/classes/kohana/utf8.php
@@ -146,7 +146,7 @@ class Kohana_UTF8 {
 	{
 		if ( ! isset(self::$called[__FUNCTION__]))
 		{
-			require SYSPATH.'utf8'.DIRECTORY_SEPARATOR.__FUNCTION__.EXT;
+			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
 			self::$called[__FUNCTION__] = TRUE;
@@ -172,7 +172,7 @@ class Kohana_UTF8 {
 
 		if ( ! isset(self::$called[__FUNCTION__]))
 		{
-			require SYSPATH.'utf8'.DIRECTORY_SEPARATOR.__FUNCTION__.EXT;
+			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
 			self::$called[__FUNCTION__] = TRUE;
@@ -202,7 +202,7 @@ class Kohana_UTF8 {
 
 		if ( ! isset(self::$called[__FUNCTION__]))
 		{
-			require SYSPATH.'utf8'.DIRECTORY_SEPARATOR.__FUNCTION__.EXT;
+			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
 			self::$called[__FUNCTION__] = TRUE;
@@ -232,7 +232,7 @@ class Kohana_UTF8 {
 
 		if ( ! isset(self::$called[__FUNCTION__]))
 		{
-			require SYSPATH.'utf8'.DIRECTORY_SEPARATOR.__FUNCTION__.EXT;
+			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
 			self::$called[__FUNCTION__] = TRUE;
@@ -264,7 +264,7 @@ class Kohana_UTF8 {
 
 		if ( ! isset(self::$called[__FUNCTION__]))
 		{
-			require SYSPATH.'utf8'.DIRECTORY_SEPARATOR.__FUNCTION__.EXT;
+			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
 			self::$called[__FUNCTION__] = TRUE;
@@ -289,7 +289,7 @@ class Kohana_UTF8 {
 	{
 		if ( ! isset(self::$called[__FUNCTION__]))
 		{
-			require SYSPATH.'utf8'.DIRECTORY_SEPARATOR.__FUNCTION__.EXT;
+			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
 			self::$called[__FUNCTION__] = TRUE;
@@ -316,7 +316,7 @@ class Kohana_UTF8 {
 
 		if ( ! isset(self::$called[__FUNCTION__]))
 		{
-			require SYSPATH.'utf8'.DIRECTORY_SEPARATOR.__FUNCTION__.EXT;
+			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
 			self::$called[__FUNCTION__] = TRUE;
@@ -342,7 +342,7 @@ class Kohana_UTF8 {
 
 		if ( ! isset(self::$called[__FUNCTION__]))
 		{
-			require SYSPATH.'utf8'.DIRECTORY_SEPARATOR.__FUNCTION__.EXT;
+			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
 			self::$called[__FUNCTION__] = TRUE;
@@ -365,7 +365,7 @@ class Kohana_UTF8 {
 	{
 		if ( ! isset(self::$called[__FUNCTION__]))
 		{
-			require SYSPATH.'utf8'.DIRECTORY_SEPARATOR.__FUNCTION__.EXT;
+			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
 			self::$called[__FUNCTION__] = TRUE;
@@ -389,7 +389,7 @@ class Kohana_UTF8 {
 	{
 		if ( ! isset(self::$called[__FUNCTION__]))
 		{
-			require SYSPATH.'utf8'.DIRECTORY_SEPARATOR.__FUNCTION__.EXT;
+			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
 			self::$called[__FUNCTION__] = TRUE;
@@ -415,7 +415,7 @@ class Kohana_UTF8 {
 	{
 		if ( ! isset(self::$called[__FUNCTION__]))
 		{
-			require SYSPATH.'utf8'.DIRECTORY_SEPARATOR.__FUNCTION__.EXT;
+			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
 			self::$called[__FUNCTION__] = TRUE;
@@ -444,7 +444,7 @@ class Kohana_UTF8 {
 	{
 		if ( ! isset(self::$called[__FUNCTION__]))
 		{
-			require SYSPATH.'utf8'.DIRECTORY_SEPARATOR.__FUNCTION__.EXT;
+			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
 			self::$called[__FUNCTION__] = TRUE;
@@ -470,7 +470,7 @@ class Kohana_UTF8 {
 	{
 		if ( ! isset(self::$called[__FUNCTION__]))
 		{
-			require SYSPATH.'utf8'.DIRECTORY_SEPARATOR.__FUNCTION__.EXT;
+			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
 			self::$called[__FUNCTION__] = TRUE;
@@ -496,7 +496,7 @@ class Kohana_UTF8 {
 	{
 		if ( ! isset(self::$called[__FUNCTION__]))
 		{
-			require SYSPATH.'utf8'.DIRECTORY_SEPARATOR.__FUNCTION__.EXT;
+			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
 			self::$called[__FUNCTION__] = TRUE;
@@ -522,7 +522,7 @@ class Kohana_UTF8 {
 	{
 		if ( ! isset(self::$called[__FUNCTION__]))
 		{
-			require SYSPATH.'utf8'.DIRECTORY_SEPARATOR.__FUNCTION__.EXT;
+			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
 			self::$called[__FUNCTION__] = TRUE;
@@ -548,7 +548,7 @@ class Kohana_UTF8 {
 	{
 		if ( ! isset(self::$called[__FUNCTION__]))
 		{
-			require SYSPATH.'utf8'.DIRECTORY_SEPARATOR.__FUNCTION__.EXT;
+			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
 			self::$called[__FUNCTION__] = TRUE;
@@ -572,7 +572,7 @@ class Kohana_UTF8 {
 	{
 		if ( ! isset(self::$called[__FUNCTION__]))
 		{
-			require SYSPATH.'utf8'.DIRECTORY_SEPARATOR.__FUNCTION__.EXT;
+			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
 			self::$called[__FUNCTION__] = TRUE;
@@ -594,7 +594,7 @@ class Kohana_UTF8 {
 	{
 		if ( ! isset(self::$called[__FUNCTION__]))
 		{
-			require SYSPATH.'utf8'.DIRECTORY_SEPARATOR.__FUNCTION__.EXT;
+			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
 			self::$called[__FUNCTION__] = TRUE;
@@ -618,7 +618,7 @@ class Kohana_UTF8 {
 	{
 		if ( ! isset(self::$called[__FUNCTION__]))
 		{
-			require SYSPATH.'utf8'.DIRECTORY_SEPARATOR.__FUNCTION__.EXT;
+			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
 			self::$called[__FUNCTION__] = TRUE;
@@ -642,7 +642,7 @@ class Kohana_UTF8 {
 	{
 		if ( ! isset(self::$called[__FUNCTION__]))
 		{
-			require SYSPATH.'utf8'.DIRECTORY_SEPARATOR.__FUNCTION__.EXT;
+			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
 			self::$called[__FUNCTION__] = TRUE;
@@ -666,7 +666,7 @@ class Kohana_UTF8 {
 	{
 		if ( ! isset(self::$called[__FUNCTION__]))
 		{
-			require SYSPATH.'utf8'.DIRECTORY_SEPARATOR.__FUNCTION__.EXT;
+			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
 			self::$called[__FUNCTION__] = TRUE;
@@ -689,7 +689,7 @@ class Kohana_UTF8 {
 	{
 		if ( ! isset(self::$called[__FUNCTION__]))
 		{
-			require SYSPATH.'utf8'.DIRECTORY_SEPARATOR.__FUNCTION__.EXT;
+			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
 			self::$called[__FUNCTION__] = TRUE;
@@ -719,7 +719,7 @@ class Kohana_UTF8 {
 	{
 		if ( ! isset(self::$called[__FUNCTION__]))
 		{
-			require SYSPATH.'utf8'.DIRECTORY_SEPARATOR.__FUNCTION__.EXT;
+			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
 			self::$called[__FUNCTION__] = TRUE;
@@ -749,7 +749,7 @@ class Kohana_UTF8 {
 	{
 		if ( ! isset(self::$called[__FUNCTION__]))
 		{
-			require SYSPATH.'utf8'.DIRECTORY_SEPARATOR.__FUNCTION__.EXT;
+			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
 			self::$called[__FUNCTION__] = TRUE;

--- a/classes/kohana/utf8.php
+++ b/classes/kohana/utf8.php
@@ -44,8 +44,8 @@ class Kohana_UTF8 {
 	 *
 	 * [!!] This method requires [Iconv](http://php.net/iconv)
 	 *
-	 * @param   mixed   variable to clean
-	 * @param   string  character set, defaults to Kohana::$charset
+	 * @param   mixed   $var        variable to clean
+	 * @param   string  $charset    character set, defaults to Kohana::$charset
 	 * @return  mixed
 	 * @uses    UTF8::strip_ascii_ctrl
 	 * @uses    UTF8::is_ascii
@@ -93,7 +93,7 @@ class Kohana_UTF8 {
 	 *
 	 *     $ascii = UTF8::is_ascii($str);
 	 *
-	 * @param   mixed    string or array of strings to check
+	 * @param   mixed   $str    string or array of strings to check
 	 * @return  boolean
 	 */
 	public static function is_ascii($str)
@@ -111,7 +111,7 @@ class Kohana_UTF8 {
 	 *
 	 *     $str = UTF8::strip_ascii_ctrl($str);
 	 *
-	 * @param   string  string to clean
+	 * @param   string  $str    string to clean
 	 * @return  string
 	 */
 	public static function strip_ascii_ctrl($str)
@@ -124,7 +124,7 @@ class Kohana_UTF8 {
 	 *
 	 *     $str = UTF8::strip_non_ascii($str);
 	 *
-	 * @param   string  string to clean
+	 * @param   string  $str    string to clean
 	 * @return  string
 	 */
 	public static function strip_non_ascii($str)
@@ -138,8 +138,8 @@ class Kohana_UTF8 {
 	 *     $ascii = UTF8::transliterate_to_ascii($utf8);
 	 *
 	 * @author  Andreas Gohr <andi@splitbrain.org>
-	 * @param   string   string to transliterate
-	 * @param   integer  -1 lowercase only, +1 uppercase only, 0 both cases
+	 * @param   string  $str    string to transliterate
+	 * @param   integer $case   -1 lowercase only, +1 uppercase only, 0 both cases
 	 * @return  string
 	 */
 	public static function transliterate_to_ascii($str, $case = 0)
@@ -161,7 +161,7 @@ class Kohana_UTF8 {
 	 *
 	 *     $length = UTF8::strlen($str);
 	 *
-	 * @param   string   string being measured for length
+	 * @param   string  $str    string being measured for length
 	 * @return  integer
 	 * @uses    UTF8::$server_utf8
 	 */
@@ -188,11 +188,11 @@ class Kohana_UTF8 {
 	 *     $position = UTF8::strpos($str, $search);
 	 *
 	 * @author  Harry Fuecks <hfuecks@gmail.com>
-	 * @param   string   haystack
-	 * @param   string   needle
-	 * @param   integer  offset from which character in haystack to start searching
-	 * @return  integer  position of needle
-	 * @return  boolean  FALSE if the needle is not found
+	 * @param   string  $str    haystack
+	 * @param   string  $search needle
+	 * @param   integer $offset offset from which character in haystack to start searching
+	 * @return  integer position of needle
+	 * @return  boolean FALSE if the needle is not found
 	 * @uses    UTF8::$server_utf8
 	 */
 	public static function strpos($str, $search, $offset = 0)
@@ -218,11 +218,11 @@ class Kohana_UTF8 {
 	 *     $position = UTF8::strrpos($str, $search);
 	 *
 	 * @author  Harry Fuecks <hfuecks@gmail.com>
-	 * @param   string   haystack
-	 * @param   string   needle
-	 * @param   integer  offset from which character in haystack to start searching
-	 * @return  integer  position of needle
-	 * @return  boolean  FALSE if the needle is not found
+	 * @param   string  $str    haystack
+	 * @param   string  $search needle
+	 * @param   integer $offset offset from which character in haystack to start searching
+	 * @return  integer position of needle
+	 * @return  boolean FALSE if the needle is not found
 	 * @uses    UTF8::$server_utf8
 	 */
 	public static function strrpos($str, $search, $offset = 0)
@@ -248,9 +248,9 @@ class Kohana_UTF8 {
 	 *     $sub = UTF8::substr($str, $offset);
 	 *
 	 * @author  Chris Smith <chris@jalakai.co.uk>
-	 * @param   string   input string
-	 * @param   integer  offset
-	 * @param   integer  length limit
+	 * @param   string  $str    input string
+	 * @param   integer $offset offset
+	 * @param   integer $length length limit
 	 * @return  string
 	 * @uses    UTF8::$server_utf8
 	 * @uses    Kohana::$charset
@@ -280,9 +280,9 @@ class Kohana_UTF8 {
 	 *     $str = UTF8::substr_replace($str, $replacement, $offset);
 	 *
 	 * @author  Harry Fuecks <hfuecks@gmail.com>
-	 * @param   string   input string
-	 * @param   string   replacement string
-	 * @param   integer  offset
+	 * @param   string  $str            input string
+	 * @param   string  $replacement    replacement string
+	 * @param   integer $offset         offset
 	 * @return  string
 	 */
 	public static function substr_replace($str, $replacement, $offset, $length = NULL)
@@ -305,7 +305,7 @@ class Kohana_UTF8 {
 	 *     $str = UTF8::strtolower($str);
 	 *
 	 * @author  Andreas Gohr <andi@splitbrain.org>
-	 * @param   string   mixed case string
+	 * @param   string  $str    mixed case string
 	 * @return  string
 	 * @uses    UTF8::$server_utf8
 	 */
@@ -330,7 +330,7 @@ class Kohana_UTF8 {
 	 * of [strtoupper](http://php.net/strtoupper).
 	 *
 	 * @author  Andreas Gohr <andi@splitbrain.org>
-	 * @param   string   mixed case string
+	 * @param   string  $str    mixed case string
 	 * @return  string
 	 * @uses    UTF8::$server_utf8
 	 * @uses    Kohana::$charset
@@ -358,7 +358,7 @@ class Kohana_UTF8 {
 	 *     $str = UTF8::ucfirst($str);
 	 *
 	 * @author  Harry Fuecks <hfuecks@gmail.com>
-	 * @param   string   mixed case string
+	 * @param   string  $str    mixed case string
 	 * @return  string
 	 */
 	public static function ucfirst($str)
@@ -381,7 +381,7 @@ class Kohana_UTF8 {
 	 *     $str = UTF8::ucwords($str);
 	 *
 	 * @author  Harry Fuecks <hfuecks@gmail.com>
-	 * @param   string   mixed case string
+	 * @param   string  $str    mixed case string
 	 * @return  string
 	 * @uses    UTF8::$server_utf8
 	 */
@@ -405,11 +405,11 @@ class Kohana_UTF8 {
 	 *     $compare = UTF8::strcasecmp($str1, $str2);
 	 *
 	 * @author  Harry Fuecks <hfuecks@gmail.com>
-	 * @param   string   string to compare
-	 * @param   string   string to compare
-	 * @return  integer  less than 0 if str1 is less than str2
-	 * @return  integer  greater than 0 if str1 is greater than str2
-	 * @return  integer  0 if they are equal
+	 * @param   string  $str1   string to compare
+	 * @param   string  $str2   string to compare
+	 * @return  integer less than 0 if str1 is less than str2
+	 * @return  integer greater than 0 if str1 is greater than str2
+	 * @return  integer 0 if they are equal
 	 */
 	public static function strcasecmp($str1, $str2)
 	{
@@ -433,12 +433,12 @@ class Kohana_UTF8 {
 	 * using it when possible.
 	 *
 	 * @author  Harry Fuecks <hfuecks@gmail.com
-	 * @param   string|array  text to replace
-	 * @param   string|array  replacement text
-	 * @param   string|array  subject text
-	 * @param   integer       number of matched and replaced needles will be returned via this parameter which is passed by reference
-	 * @return  string        if the input was a string
-	 * @return  array         if the input was an array
+	 * @param   string|array    $search     text to replace
+	 * @param   string|array    $replace    replacement text
+	 * @param   string|array    $str        subject text
+	 * @param   integer         $count      number of matched and replaced needles will be returned via this parameter which is passed by reference
+	 * @return  string  if the input was a string
+	 * @return  array   if the input was an array
 	 */
 	public static function str_ireplace($search, $replace, $str, & $count = NULL)
 	{
@@ -461,8 +461,8 @@ class Kohana_UTF8 {
 	 *     $found = UTF8::stristr($str, $search);
 	 *
 	 * @author Harry Fuecks <hfuecks@gmail.com>
-	 * @param   string  input string
-	 * @param   string  needle
+	 * @param   string  $str    input string
+	 * @param   string  $search needle
 	 * @return  string  matched substring if found
 	 * @return  FALSE   if the substring was not found
 	 */
@@ -486,11 +486,11 @@ class Kohana_UTF8 {
 	 *     $found = UTF8::strspn($str, $mask);
 	 *
 	 * @author Harry Fuecks <hfuecks@gmail.com>
-	 * @param   string   input string
-	 * @param   string   mask for search
-	 * @param   integer  start position of the string to examine
-	 * @param   integer  length of the string to examine
-	 * @return  integer  length of the initial segment that contains characters in the mask
+	 * @param   string  $str    input string
+	 * @param   string  $mask   mask for search
+	 * @param   integer $offset start position of the string to examine
+	 * @param   integer $length length of the string to examine
+	 * @return  integer length of the initial segment that contains characters in the mask
 	 */
 	public static function strspn($str, $mask, $offset = NULL, $length = NULL)
 	{
@@ -512,11 +512,11 @@ class Kohana_UTF8 {
 	 *     $found = UTF8::strcspn($str, $mask);
 	 *
 	 * @author  Harry Fuecks <hfuecks@gmail.com>
-	 * @param   string   input string
-	 * @param   string   mask for search
-	 * @param   integer  start position of the string to examine
-	 * @param   integer  length of the string to examine
-	 * @return  integer  length of the initial segment that contains characters not in the mask
+	 * @param   string  $str    input string
+	 * @param   string  $mask   mask for search
+	 * @param   integer $offset start position of the string to examine
+	 * @param   integer $length length of the string to examine
+	 * @return  integer length of the initial segment that contains characters not in the mask
 	 */
 	public static function strcspn($str, $mask, $offset = NULL, $length = NULL)
 	{
@@ -538,10 +538,10 @@ class Kohana_UTF8 {
 	 *     $str = UTF8::str_pad($str, $length);
 	 *
 	 * @author  Harry Fuecks <hfuecks@gmail.com>
-	 * @param   string   input string
-	 * @param   integer  desired string length after padding
-	 * @param   string   string to use as padding
-	 * @param   string   padding type: STR_PAD_RIGHT, STR_PAD_LEFT, or STR_PAD_BOTH
+	 * @param   string  $str                input string
+	 * @param   integer $final_str_length   desired string length after padding
+	 * @param   string  $pad_str            string to use as padding
+	 * @param   string  $pad_type           padding type: STR_PAD_RIGHT, STR_PAD_LEFT, or STR_PAD_BOTH
 	 * @return  string
 	 */
 	public static function str_pad($str, $final_str_length, $pad_str = ' ', $pad_type = STR_PAD_RIGHT)
@@ -564,8 +564,8 @@ class Kohana_UTF8 {
 	 *     $array = UTF8::str_split($str);
 	 *
 	 * @author  Harry Fuecks <hfuecks@gmail.com>
-	 * @param   string   input string
-	 * @param   integer  maximum length of each chunk
+	 * @param   string  $str            input string
+	 * @param   integer $split_length   maximum length of each chunk
 	 * @return  array
 	 */
 	public static function str_split($str, $split_length = 1)
@@ -587,7 +587,7 @@ class Kohana_UTF8 {
 	 *     $str = UTF8::strrev($str);
 	 *
 	 * @author  Harry Fuecks <hfuecks@gmail.com>
-	 * @param   string   string to be reversed
+	 * @param   string  $str    string to be reversed
 	 * @return  string
 	 */
 	public static function strrev($str)
@@ -610,8 +610,8 @@ class Kohana_UTF8 {
 	 *     $str = UTF8::trim($str);
 	 *
 	 * @author  Andreas Gohr <andi@splitbrain.org>
-	 * @param   string   input string
-	 * @param   string   string of characters to remove
+	 * @param   string  $str        input string
+	 * @param   string  $charlist   string of characters to remove
 	 * @return  string
 	 */
 	public static function trim($str, $charlist = NULL)
@@ -634,8 +634,8 @@ class Kohana_UTF8 {
 	 *     $str = UTF8::ltrim($str);
 	 *
 	 * @author  Andreas Gohr <andi@splitbrain.org>
-	 * @param   string   input string
-	 * @param   string   string of characters to remove
+	 * @param   string  $str        input string
+	 * @param   string  $charlist   string of characters to remove
 	 * @return  string
 	 */
 	public static function ltrim($str, $charlist = NULL)
@@ -658,8 +658,8 @@ class Kohana_UTF8 {
 	 *     $str = UTF8::rtrim($str);
 	 *
 	 * @author  Andreas Gohr <andi@splitbrain.org>
-	 * @param   string   input string
-	 * @param   string   string of characters to remove
+	 * @param   string  $str        input string
+	 * @param   string  $charlist   string of characters to remove
 	 * @return  string
 	 */
 	public static function rtrim($str, $charlist = NULL)
@@ -682,7 +682,7 @@ class Kohana_UTF8 {
 	 *     $digit = UTF8::ord($character);
 	 *
 	 * @author  Harry Fuecks <hfuecks@gmail.com>
-	 * @param   string   UTF-8 encoded character
+	 * @param   string  $chr    UTF-8 encoded character
 	 * @return  integer
 	 */
 	public static function ord($chr)
@@ -711,7 +711,7 @@ class Kohana_UTF8 {
 	 * Ported to PHP by Henri Sivonen <hsivonen@iki.fi>, see <http://hsivonen.iki.fi/php-utf8/>
 	 * Slight modifications to fit with phputf8 library by Harry Fuecks <hfuecks@gmail.com>
 	 *
-	 * @param   string  UTF-8 encoded string
+	 * @param   string  $str    UTF-8 encoded string
 	 * @return  array   unicode code points
 	 * @return  FALSE   if the string is invalid
 	 */
@@ -741,9 +741,9 @@ class Kohana_UTF8 {
 	 * Ported to PHP by Henri Sivonen <hsivonen@iki.fi>, see http://hsivonen.iki.fi/php-utf8/
 	 * Slight modifications to fit with phputf8 library by Harry Fuecks <hfuecks@gmail.com>.
 	 *
-	 * @param   array    unicode code points representing a string
-	 * @return  string   utf8 string of characters
-	 * @return  boolean  FALSE if a code point cannot be found
+	 * @param   array   $str    unicode code points representing a string
+	 * @return  string  utf8 string of characters
+	 * @return  boolean FALSE if a code point cannot be found
 	 */
 	public static function from_unicode($arr)
 	{

--- a/classes/kohana/valid.php
+++ b/classes/kohana/valid.php
@@ -30,8 +30,8 @@ class Kohana_Valid {
 	/**
 	 * Checks a field against a regular expression.
 	 *
-	 * @param   string  value
-	 * @param   string  regular expression to match (including delimiters)
+	 * @param   string  $value      value
+	 * @param   string  $expression regular expression to match (including delimiters)
 	 * @return  boolean
 	 */
 	public static function regex($value, $expression)
@@ -42,8 +42,8 @@ class Kohana_Valid {
 	/**
 	 * Checks that a field is long enough.
 	 *
-	 * @param   string   value
-	 * @param   integer  minimum length required
+	 * @param   string  $value  value
+	 * @param   integer $length minimum length required
 	 * @return  boolean
 	 */
 	public static function min_length($value, $length)
@@ -54,8 +54,8 @@ class Kohana_Valid {
 	/**
 	 * Checks that a field is short enough.
 	 *
-	 * @param   string   value
-	 * @param   integer  maximum length required
+	 * @param   string  $value  value
+	 * @param   integer $length maximum length required
 	 * @return  boolean
 	 */
 	public static function max_length($value, $length)
@@ -66,8 +66,8 @@ class Kohana_Valid {
 	/**
 	 * Checks that a field is exactly the right length.
 	 *
-	 * @param   string   value
-	 * @param   integer|array  exact length required, or array of valid lengths
+	 * @param   string          $value  value
+	 * @param   integer|array   $length exact length required, or array of valid lengths
 	 * @return  boolean
 	 */
 	public static function exact_length($value, $length)
@@ -88,8 +88,8 @@ class Kohana_Valid {
 	/**
 	 * Checks that a field is exactly the value required.
 	 *
-	 * @param   string   value
-	 * @param   string   required value
+	 * @param   string  $value      value
+	 * @param   string  $required   required value
 	 * @return  boolean
 	 */
 	public static function equals($value, $required)
@@ -103,8 +103,8 @@ class Kohana_Valid {
 	 * @link  http://www.iamcal.com/publish/articles/php/parsing_email/
 	 * @link  http://www.w3.org/Protocols/rfc822/
 	 *
-	 * @param   string   email address
-	 * @param   boolean  strict RFC compatibility
+	 * @param   string  $email  email address
+	 * @param   boolean $strict strict RFC compatibility
 	 * @return  boolean
 	 */
 	public static function email($email, $strict = FALSE)
@@ -144,7 +144,7 @@ class Kohana_Valid {
 	 *
 	 * @link  http://php.net/checkdnsrr  not added to Windows until PHP 5.3.0
 	 *
-	 * @param   string   email address
+	 * @param   string  $email  email address
 	 * @return  boolean
 	 */
 	public static function email_domain($email)
@@ -159,7 +159,7 @@ class Kohana_Valid {
 	/**
 	 * Validate a URL.
 	 *
-	 * @param   string   URL
+	 * @param   string  $url    URL
 	 * @return  boolean
 	 */
 	public static function url($url)
@@ -218,8 +218,8 @@ class Kohana_Valid {
 	/**
 	 * Validate an IP.
 	 *
-	 * @param   string   IP address
-	 * @param   boolean  allow private IP networks
+	 * @param   string  $ip             IP address
+	 * @param   boolean $allow_private  allow private IP networks
 	 * @return  boolean
 	 */
 	public static function ip($ip, $allow_private = TRUE)
@@ -239,8 +239,8 @@ class Kohana_Valid {
 	/**
 	 * Validates a credit card number, with a Luhn check if possible.
 	 *
-	 * @param   integer       credit card number
-	 * @param   string|array  card type, or an array of card types
+	 * @param   integer         $number credit card number
+	 * @param   string|array    $type   card type, or an array of card types
 	 * @return  boolean
 	 * @uses    Valid::luhn
 	 */
@@ -297,7 +297,7 @@ class Kohana_Valid {
 	 * Validate a number against the [Luhn](http://en.wikipedia.org/wiki/Luhn_algorithm)
 	 * (mod10) formula.
 	 *
-	 * @param   string   number to check
+	 * @param   string  $number number to check
 	 * @return  boolean
 	 */
 	public static function luhn($number)
@@ -340,7 +340,8 @@ class Kohana_Valid {
 	/**
 	 * Checks if a phone number is valid.
 	 *
-	 * @param   string   phone number to check
+	 * @param   string  $number     phone number to check
+	 * @param   array   $lengths
 	 * @return  boolean
 	 */
 	public static function phone($number, $lengths = NULL)
@@ -360,7 +361,7 @@ class Kohana_Valid {
 	/**
 	 * Tests if a string is a valid date string.
 	 *
-	 * @param   string   date to check
+	 * @param   string  $str    date to check
 	 * @return  boolean
 	 */
 	public static function date($str)
@@ -371,8 +372,8 @@ class Kohana_Valid {
 	/**
 	 * Checks whether a string consists of alphabetical characters only.
 	 *
-	 * @param   string   input string
-	 * @param   boolean  trigger UTF-8 compatibility
+	 * @param   string  $str    input string
+	 * @param   boolean $utf8   trigger UTF-8 compatibility
 	 * @return  boolean
 	 */
 	public static function alpha($str, $utf8 = FALSE)
@@ -392,8 +393,8 @@ class Kohana_Valid {
 	/**
 	 * Checks whether a string consists of alphabetical characters and numbers only.
 	 *
-	 * @param   string   input string
-	 * @param   boolean  trigger UTF-8 compatibility
+	 * @param   string  $str    input string
+	 * @param   boolean $utf8   trigger UTF-8 compatibility
 	 * @return  boolean
 	 */
 	public static function alpha_numeric($str, $utf8 = FALSE)
@@ -411,8 +412,8 @@ class Kohana_Valid {
 	/**
 	 * Checks whether a string consists of alphabetical characters, numbers, underscores and dashes only.
 	 *
-	 * @param   string   input string
-	 * @param   boolean  trigger UTF-8 compatibility
+	 * @param   string  $str    input string
+	 * @param   boolean $utf8   trigger UTF-8 compatibility
 	 * @return  boolean
 	 */
 	public static function alpha_dash($str, $utf8 = FALSE)
@@ -432,8 +433,8 @@ class Kohana_Valid {
 	/**
 	 * Checks whether a string consists of digits only (no dots or dashes).
 	 *
-	 * @param   string   input string
-	 * @param   boolean  trigger UTF-8 compatibility
+	 * @param   string  $str    input string
+	 * @param   boolean $utf8   trigger UTF-8 compatibility
 	 * @return  boolean
 	 */
 	public static function digit($str, $utf8 = FALSE)
@@ -454,7 +455,7 @@ class Kohana_Valid {
 	 * Uses {@link http://www.php.net/manual/en/function.localeconv.php locale conversion}
 	 * to allow decimal point to be locale specific.
 	 *
-	 * @param   string   input string
+	 * @param   string  $str    input string
 	 * @return  boolean
 	 */
 	public static function numeric($str)
@@ -469,9 +470,9 @@ class Kohana_Valid {
 	/**
 	 * Tests if a number is within a range.
 	 *
-	 * @param   string   number to check
-	 * @param   integer  minimum value
-	 * @param   integer  maximum value
+	 * @param   string  $number number to check
+	 * @param   integer $min    minimum value
+	 * @param   integer $max    maximum value
 	 * @return  boolean
 	 */
 	public static function range($number, $min, $max)
@@ -483,9 +484,9 @@ class Kohana_Valid {
 	 * Checks if a string is a proper decimal format. Optionally, a specific
 	 * number of digits can be checked too.
 	 *
-	 * @param   string   number to check
-	 * @param   integer  number of decimal places
-	 * @param   integer  number of digits
+	 * @param   string  $str    number to check
+	 * @param   integer $places number of decimal places
+	 * @param   integer $digits number of digits
 	 * @return  boolean
 	 */
 	public static function decimal($str, $places = 2, $digits = NULL)
@@ -512,7 +513,7 @@ class Kohana_Valid {
 	 * is quite flexible as it does not require an initial "#" and also allows for
 	 * the short notation using only three instead of six hexadecimal characters.
 	 *
-	 * @param   string   input string
+	 * @param   string  $str    input string
 	 * @return  boolean
 	 */
 	public static function color($str)
@@ -523,9 +524,9 @@ class Kohana_Valid {
 	/**
 	 * Checks if a field matches the value of another field.
 	 *
-	 * @param   array    array of values
-	 * @param   string   field name
-	 * @param   string   field name to match
+	 * @param   array   $array  array of values
+	 * @param   string  $field  field name
+	 * @param   string  $match  field name to match
 	 * @return  boolean
 	 */
 	public static function matches($array, $field, $match)

--- a/classes/kohana/validation.php
+++ b/classes/kohana/validation.php
@@ -13,7 +13,7 @@ class Kohana_Validation implements ArrayAccess {
 	/**
 	 * Creates a new Validation instance.
 	 *
-	 * @param   array   array to use for validation
+	 * @param   array   $array  array to use for validation
 	 * @return  Validation
 	 */
 	public static function factory(array $array)
@@ -43,7 +43,7 @@ class Kohana_Validation implements ArrayAccess {
 	 * Sets the unique "any field" key and creates an ArrayObject from the
 	 * passed array.
 	 *
-	 * @param   array   array to validate
+	 * @param   array   $array  array to validate
 	 * @return  void
 	 */
 	public function __construct(array $array)
@@ -55,9 +55,9 @@ class Kohana_Validation implements ArrayAccess {
 	 * Throws an exception because Validation is read-only.
 	 * Implements ArrayAccess method.
 	 *
-	 * @throws  object   Kohana_Exception
-	 * @param   string   key to set
-	 * @param   mixed    value to set
+	 * @throws  Kohana_Exception
+	 * @param   string   $offset    key to set
+	 * @param   mixed    $value     value to set
 	 * @return  void
 	 */
 	public function offsetSet($offset, $value)
@@ -69,8 +69,8 @@ class Kohana_Validation implements ArrayAccess {
 	 * Checks if key is set in array data.
 	 * Implements ArrayAccess method.
 	 *
-	 * @param   string   key to check
-	 * @return  bool     whether the key is set
+	 * @param   string  $offset key to check
+	 * @return  bool    whether the key is set
 	 */
 	public function offsetExists($offset)
 	{
@@ -81,8 +81,8 @@ class Kohana_Validation implements ArrayAccess {
 	 * Throws an exception because Validation is read-only.
 	 * Implements ArrayAccess method.
 	 *
-	 * @throws  object   Kohana_Exception
-	 * @param   string   key to unset
+	 * @throws  Kohana_Exception
+	 * @param   string  $offset key to unset
 	 * @return  void
 	 */
 	public function offsetUnset($offset)
@@ -94,8 +94,8 @@ class Kohana_Validation implements ArrayAccess {
 	 * Gets a value from the array data.
 	 * Implements ArrayAccess method.
 	 *
-	 * @param   string   key to return
-	 * @return  mixed    value from array
+	 * @param   string  $offset key to return
+	 * @return  mixed   value from array
 	 */
 	public function offsetGet($offset)
 	{
@@ -107,7 +107,7 @@ class Kohana_Validation implements ArrayAccess {
 	 *
 	 *     $copy = $array->copy($new_data);
 	 *
-	 * @param   array   new data set
+	 * @param   array   $array  new data set
 	 * @return  Validation
 	 * @since   3.0.5
 	 */
@@ -147,8 +147,8 @@ class Kohana_Validation implements ArrayAccess {
 	/**
 	 * Sets or overwrites the label name for a field.
 	 *
-	 * @param   string  field name
-	 * @param   string  label
+	 * @param   string  $field  field name
+	 * @param   string  $label  label
 	 * @return  $this
 	 */
 	public function label($field, $label)
@@ -162,7 +162,7 @@ class Kohana_Validation implements ArrayAccess {
 	/**
 	 * Sets labels using an array.
 	 *
-	 * @param   array  list of field => label names
+	 * @param   array   $labels list of field => label names
 	 * @return  $this
 	 */
 	public function labels(array $labels)
@@ -189,9 +189,9 @@ class Kohana_Validation implements ArrayAccess {
 	 *     // The "password" field must match the "password_repeat" field
 	 *     $validation->rule('password', 'matches', array(':validation', 'password', 'password_repeat'));
 	 *
-	 * @param   string    field name
-	 * @param   callback  valid PHP callback
-	 * @param   array     extra parameters for the rule
+	 * @param   string      $field  field name
+	 * @param   callback    $rule   valid PHP callback
+	 * @param   array       $params extra parameters for the rule
 	 * @return  $this
 	 */
 	public function rule($field, $rule, array $params = NULL)
@@ -217,8 +217,8 @@ class Kohana_Validation implements ArrayAccess {
 	/**
 	 * Add rules using an array.
 	 *
-	 * @param   string  field name
-	 * @param   array   list of callbacks
+	 * @param   string  $field  field name
+	 * @param   array   $rules  list of callbacks
 	 * @return  $this
 	 */
 	public function rules($field, array $rules)
@@ -238,8 +238,8 @@ class Kohana_Validation implements ArrayAccess {
 	 *     $validation->bind(':model', $model)
 	 *         ->rule('status', 'valid_status', array(':model'));
 	 *
-	 * @param   string  variable name or an array of variables
-	 * @param   mixed   value
+	 * @param   string  $key    variable name or an array of variables
+	 * @param   mixed   $value  value
 	 * @return  $this
 	 */
 	public function bind($key, $value = NULL)
@@ -268,7 +268,6 @@ class Kohana_Validation implements ArrayAccess {
 	 *          // The data is valid, do something here
 	 *     }
 	 *
-	 * @param   boolean   allow empty array?
 	 * @return  boolean
 	 */
 	public function check()
@@ -427,8 +426,9 @@ class Kohana_Validation implements ArrayAccess {
 	/**
 	 * Add an error to a field.
 	 *
-	 * @param   string  field name
-	 * @param   string  error message
+	 * @param   string  $field  field name
+	 * @param   string  $error  error message
+	 * @param   array   $params
 	 * @return  $this
 	 */
 	public function error($field, $error, array $params = NULL)
@@ -453,8 +453,8 @@ class Kohana_Validation implements ArrayAccess {
 	 *     $errors = $Validation->errors('forms/login');
 	 *
 	 * @uses    Kohana::message
-	 * @param   string  file to load error messages from
-	 * @param   mixed   translate the message
+	 * @param   string  $file       file to load error messages from
+	 * @param   mixed   $translate  translate the message
 	 * @return  array
 	 */
 	public function errors($file = NULL, $translate = TRUE)

--- a/classes/kohana/validation.php
+++ b/classes/kohana/validation.php
@@ -118,7 +118,7 @@ class Kohana_Validation extends ArrayObject {
 	 *
 	 *     // The "username" must not be empty and have a minimum length of 4
 	 *     $validation->rule('username', 'not_empty')
-	 *                ->rule('username', 'min_length', array('username', 4));
+	 *                ->rule('username', 'min_length', array(':value', 4));
 	 *
 	 *     // The "password" field must match the "password_repeat" field
 	 *     $validation->rule('password', 'matches', array(':validation', 'password', 'password_repeat'));

--- a/classes/kohana/validation/exception.php
+++ b/classes/kohana/validation/exception.php
@@ -14,10 +14,10 @@ class Kohana_Validation_Exception extends Kohana_Exception {
 	public $array;
 
 	/**
-	 * @param  Validation  Validation object
-	 * @param  string    error message
-	 * @param  array     translation variables
-	 * @param  int       the exception code
+	 * @param  Validation   $array      Validation object
+	 * @param  string       $message    error message
+	 * @param  array        $values     translation variables
+	 * @param  int          $code       the exception code
 	 */
 	public function __construct(Validation $array, $message = 'Failed to validate array', array $values = NULL, $code = 0)
 	{

--- a/classes/kohana/view.php
+++ b/classes/kohana/view.php
@@ -21,8 +21,8 @@ class Kohana_View {
 	 *
 	 *     $view = View::factory($file);
 	 *
-	 * @param   string  view filename
-	 * @param   array   array of values
+	 * @param   string  $file   view filename
+	 * @param   array   $data   array of values
 	 * @return  View
 	 */
 	public static function factory($file = NULL, array $data = NULL)
@@ -37,8 +37,8 @@ class Kohana_View {
 	 *
 	 *     $output = View::capture($file, $data);
 	 *
-	 * @param   string  filename
-	 * @param   array   variables
+	 * @param   string  $kohana_view_filename   filename
+	 * @param   array   $kohana_view_data       variables
 	 * @return  string
 	 */
 	protected static function capture($kohana_view_filename, array $kohana_view_data)
@@ -79,8 +79,8 @@ class Kohana_View {
 	 *
 	 *     View::set_global($name, $value);
 	 *
-	 * @param   string  variable name or an array of variables
-	 * @param   mixed   value
+	 * @param   string  $key    variable name or an array of variables
+	 * @param   mixed   $value  value
 	 * @return  void
 	 */
 	public static function set_global($key, $value = NULL)
@@ -104,8 +104,8 @@ class Kohana_View {
 	 *
 	 *     View::bind_global($key, $value);
 	 *
-	 * @param   string  variable name
-	 * @param   mixed   referenced variable
+	 * @param   string  $key    variable name
+	 * @param   mixed   $value  referenced variable
 	 * @return  void
 	 */
 	public static function bind_global($key, & $value)
@@ -125,8 +125,8 @@ class Kohana_View {
 	 *
 	 *     $view = new View($file);
 	 *
-	 * @param   string  view filename
-	 * @param   array   array of values
+	 * @param   string  $file   view filename
+	 * @param   array   $data   array of values
 	 * @return  void
 	 * @uses    View::set_filename
 	 */
@@ -152,7 +152,7 @@ class Kohana_View {
 	 *
 	 * [!!] If the variable has not yet been set, an exception will be thrown.
 	 *
-	 * @param   string  variable name
+	 * @param   string  $key    variable name
 	 * @return  mixed
 	 * @throws  Kohana_Exception
 	 */
@@ -178,8 +178,8 @@ class Kohana_View {
 	 *
 	 *     $view->foo = 'something';
 	 *
-	 * @param   string  variable name
-	 * @param   mixed   value
+	 * @param   string  $key    variable name
+	 * @param   mixed   $value  value
 	 * @return  void
 	 */
 	public function __set($key, $value)
@@ -194,7 +194,7 @@ class Kohana_View {
 	 *
 	 * [!!] `NULL` variables are not considered to be set by [isset](http://php.net/isset).
 	 *
-	 * @param   string  variable name
+	 * @param   string  $key    variable name
 	 * @return  boolean
 	 */
 	public function __isset($key)
@@ -207,7 +207,7 @@ class Kohana_View {
 	 *
 	 *     unset($view->foo);
 	 *
-	 * @param   string  variable name
+	 * @param   string  $key    variable name
 	 * @return  void
 	 */
 	public function __unset($key)
@@ -241,7 +241,7 @@ class Kohana_View {
 	 *
 	 *     $view->set_filename($file);
 	 *
-	 * @param   string  view filename
+	 * @param   string  $file   view filename
 	 * @return  View
 	 * @throws  View_Exception
 	 */
@@ -272,8 +272,8 @@ class Kohana_View {
 	 *     // Create the values $food and $beverage in the view
 	 *     $view->set(array('food' => 'bread', 'beverage' => 'water'));
 	 *
-	 * @param   string   variable name or an array of variables
-	 * @param   mixed    value
+	 * @param   string  $key    variable name or an array of variables
+	 * @param   mixed   $value  value
 	 * @return  $this
 	 */
 	public function set($key, $value = NULL)
@@ -302,8 +302,8 @@ class Kohana_View {
 	 *     // This reference can be accessed as $ref within the view
 	 *     $view->bind('ref', $bar);
 	 *
-	 * @param   string   variable name
-	 * @param   mixed    referenced variable
+	 * @param   string  $key    variable name
+	 * @param   mixed   $value  referenced variable
 	 * @return  $this
 	 */
 	public function bind($key, & $value)
@@ -322,10 +322,10 @@ class Kohana_View {
 	 * [!!] Global variables with the same key name as local variables will be
 	 * overwritten by the local variable.
 	 *
-	 * @param    string  view filename
-	 * @return   string
-	 * @throws   View_Exception
-	 * @uses     View::capture
+	 * @param   string  $file   view filename
+	 * @return  string
+	 * @throws  View_Exception
+	 * @uses    View::capture
 	 */
 	public function render($file = NULL)
 	{

--- a/guide/kohana/menu.md
+++ b/guide/kohana/menu.md
@@ -19,7 +19,7 @@
    - [Routing](routing)
    - [Error Handling](errors)
    - [Tips & Common Mistakes](tips)
-   - [Upgrading from v3.0](upgrading)
+   - [Upgrading from v3.1](upgrading)
 - Basic Usage
    - [Debugging](debugging)
    - [Loading Classes](autoloading)

--- a/guide/kohana/tutorials/git.md
+++ b/guide/kohana/tutorials/git.md
@@ -51,8 +51,8 @@ We don't want git to track log or cache files, so add a `.gitignore` file to eac
 
 Now we need the `index.php` and `bootstrap.php` files:
 
-    wget https://github.com/kohana/kohana/raw/3.1/master/index.php --no-check-certificate
-    wget https://github.com/kohana/kohana/raw/3.1/master/application/bootstrap.php --no-check-certificate -O application/bootstrap.php
+    wget https://github.com/kohana/kohana/raw/3.2/master/index.php --no-check-certificate
+    wget https://github.com/kohana/kohana/raw/3.2/master/application/bootstrap.php --no-check-certificate -O application/bootstrap.php
 
 Commit these changes too:
 
@@ -77,13 +77,13 @@ To add a new submodule complete the following steps:
 
 At some point you will probably also want to upgrade your submodules. To update all of your submodules to the latest `HEAD` version:
 
-    git submodule foreach 'git checkout 3.1/master && git pull origin 3.1/master'
+    git submodule foreach 'git checkout 3.2/master && git pull origin 3.2/master'
 
 To update a single submodule, for example, `system`:
 
     cd system
-    git checkout 3.1/master
-    git pull origin 3.1/master
+    git checkout 3.2/master
+    git pull origin 3.2/master
     cd ..
     git add system
     git commit -m 'Updated system to latest version'
@@ -91,7 +91,7 @@ To update a single submodule, for example, `system`:
 If you want to update a single submodule to a specific commit:
 
     cd modules/database
-    git pull origin 3.1/master
+    git pull origin 3.2/master
     git checkout fbfdea919028b951c23c3d99d2bc1f5bbeda0c0b
     cd ../..
     git add database
@@ -99,7 +99,7 @@ If you want to update a single submodule to a specific commit:
 
 Note that you can also check out the commit at a tagged official release point, for example:
 
-    git checkout 3.1.0
+    git checkout v3.2.0
 
 Simply run `git tag` without arguments to get a list of all tags.
 

--- a/tests/kohana/NumTest.php
+++ b/tests/kohana/NumTest.php
@@ -23,7 +23,7 @@ class Kohana_NumTest extends Unittest_TestCase
 	{
 		parent::setUp();
 
-		setlocale(LC_ALL, 'English');
+		setlocale(LC_ALL, 'en_US.utf8');
 	}
 
 	/**

--- a/tests/kohana/RequestTest.php
+++ b/tests/kohana/RequestTest.php
@@ -145,8 +145,10 @@ class Kohana_RequestTest extends Unittest_TestCase
 	 */
 	public function test_param()
 	{
+		$route = new Route('(<controller>(/<action>(/<id>)))');
+
 		$uri = 'foo/bar/id';
-		$request = Request::factory($uri);
+		$request = Request::factory($uri, NULL, array($route));
 
 		$this->assertArrayHasKey('id', $request->param());
 		$this->assertArrayNotHasKey('foo', $request->param());

--- a/tests/kohana/RequestTest.php
+++ b/tests/kohana/RequestTest.php
@@ -105,7 +105,7 @@ class Kohana_RequestTest extends Unittest_TestCase
 
 		$route = new Route('(<controller>(/<action>))');
 		$route->defaults(array(
-			'controller' => 'kohana_requsttest_dummy',
+			'controller' => 'kohana_requesttest_dummy',
 			'action'     => 'index',
 		));
 

--- a/tests/kohana/RequestTest.php
+++ b/tests/kohana/RequestTest.php
@@ -105,7 +105,7 @@ class Kohana_RequestTest extends Unittest_TestCase
 
 		$route = new Route('(<controller>(/<action>))');
 		$route->defaults(array(
-			'controller' => 'welcome',
+			'controller' => 'kohana_requsttest_dummy',
 			'action'     => 'index',
 		));
 
@@ -720,3 +720,11 @@ class Kohana_RequestTest extends Unittest_TestCase
 		$this->assertSame($expected, $request->client());
 	}
 } // End Kohana_RequestTest
+
+class Controller_Kohana_RequestTest_Dummy extends Controller
+{
+	public function action_index()
+	{
+	
+	}
+}

--- a/tests/kohana/SecurityTest.php
+++ b/tests/kohana/SecurityTest.php
@@ -9,7 +9,6 @@
  * @package    Kohana
  * @category   Tests
  */
-
 class Kohana_SecurityTest extends Unittest_TestCase
 {
 	/**
@@ -67,6 +66,17 @@ class Kohana_SecurityTest extends Unittest_TestCase
 	 */
 	public function provider_csrf_token()
 	{
+		// Unfortunately this data provider has to use the session in order to 
+		// generate its data. If headers have already been sent then this method
+		// throws an error, even if the test is does not run.  If we return an 
+		// empty array then this also causes an error, so the only way to get 
+		// around it is to return an array of misc data and have the test skip 
+		// if headers have been sent. It's annoying this hack has to be 
+		// implemented, but the security code isn't exactly brilliantly 
+		// implemented. Ideally we'd be able to inject a session instance
+		if (headers_sent())
+			return array(array('', '', 0));
+
 		$array = array();
 		for ($i = 0; $i <= 4; $i++)
 		{
@@ -85,6 +95,9 @@ class Kohana_SecurityTest extends Unittest_TestCase
 	 */
 	public function test_csrf_token($expected, $input, $iteration)
 	{
+		if (headers_sent())
+			$this->markTestSkipped('Headers have already been sent, session not available');
+
 		Security::$token_name = 'token_'.$iteration;
 		$this->assertSame(TRUE, $input);
 		$this->assertSame($expected, Security::token(FALSE));

--- a/tests/kohana/request/client/CacheTest.php
+++ b/tests/kohana/request/client/CacheTest.php
@@ -61,7 +61,13 @@ class Kohana_Request_Client_CacheTest extends Unittest_TestCase {
 	 */
 	public function test_cache_miss()
 	{
-		$request       = new Request('welcome/index');
+		$route = new Route('welcome/index');
+		$route->defaults(array(
+			'controller' => 'Kohana_Request_CacheTest_Dummy',
+			'action'     => 'index',
+		));
+
+		$request       = new Request('welcome/index', NULL, array($route));
 		$cache_mock    = $this->_get_cache_mock();
 
 		$request->client()->cache(HTTP_Cache::factory($cache_mock));
@@ -248,3 +254,11 @@ class Kohana_Request_Client_CacheTest extends Unittest_TestCase {
 		return $this->getMock('Cache_File', array(), array(), '', FALSE);
 	}
 } // End Kohana_Request_Client_CacheTest
+
+class Controller_Kohana_Request_CacheTest_Dummy extends Controller 
+{
+	public function action_index()
+	{
+	
+	}
+}


### PR DESCRIPTION
Can't overwrite some options: 
    CURLOPT_COOKIE, CURLOPT_HTTPHEADER, CURLOPT_POSTFIELDS, CURLOPT_CUSTOMREQUEST, CURLOPT_RETURNTRANSFER and CURLOPT_HEADER

I had to upload a file via request and had to do this hardcoded:
    $post_data = array('file_contents' => '@'.$file);
        $request->body($file_to_upload);

while it would be more correct to use the option:
    $post_data = array('file_contents' => '@'.$file);
    $request->client()->options(CURLOPT_POSTFIELDS, $post_data);
