### PR TITLE
Check for PHP 5.4 before doing get_magic_quotes_gpc as it has been deprecated.

### DIFF
--- a/classes/kohana/core.php
+++ b/classes/kohana/core.php
@@ -325,7 +325,7 @@ class Kohana_Core {
 		}
 
 		// Determine if the extremely evil magic quotes are enabled
-		Kohana::$magic_quotes = (bool) get_magic_quotes_gpc();
+		Kohana::$magic_quotes = version_compare(PHP_VERSION, '5.4') < 0 AND get_magic_quotes_gpc();
 
 		// Sanitize all request variables
 		$_GET    = Kohana::sanitize($_GET);


### PR DESCRIPTION
Pull-request updated to work for pre-release versions of 5.4 (e.g. 5.4.0-beta1), removed bool cast, changed request from master branch to develop.
