### PR TITLE
#4013 Arr::get should use array_key_exists instead of isset

### DIFF
--- a/classes/kohana/arr.php
+++ b/classes/kohana/arr.php
@@ -274,7 +274,7 @@ class Kohana_Arr {
 	 */
 	public static function get($array, $key, $default = NULL)
 	{
-		return isset($array[$key]) ? $array[$key] : $default;
+		return array_key_exists($key, $array) ? $array[$key] : $default;
 	}
 
 	/**


### PR DESCRIPTION
Currently Arr::get() relies on isset so it can't handle NULL values:

eg.
$test = array('foo' => 'foo' , 'bar' => NULL);
$test = Arr::get($test, 'bar', 'default');

Test is 'default' when it should be NULL. Fix is to use array_key_exists instead of isset.
