### PR TITLE
3.2/develop

### DIFF
--- a/classes/kohana/request.php
+++ b/classes/kohana/request.php
@@ -947,6 +947,9 @@ class Kohana_Request implements HTTP_Request {
 	 */
 	public function redirect($url = '', $code = 302)
 	{
+		if(Request::initial() !== Request::current())
+			return NULL;
+		
 		$referrer = $this->uri();
 		$protocol = ($this->secure()) ? 'https' : TRUE;
 


### PR DESCRIPTION
Calls to Kohana_Request redirect() that execute in a sub-request result in the return value of Request::$initial->execute() ( in the initial non sub-request request ) being and empty string instead of an instance of Response.  I've added one line to redirect() to simply void out if the currently executing request isn't the initial.  With this in place calls to redirect in sub-requests (which are _everywhere_ in apps that want pre-HMVC code) still return a response object so you can $response->status() and whatever else.
