### PR TITLE
Added support for PHP 5.3+ namespaces in routing.

### DIFF
--- a/classes/kohana/core.php
+++ b/classes/kohana/core.php
@@ -488,8 +488,7 @@ class Kohana_Core {
 		try
 		{
 			// Transform the class name into a path
-			$file = str_replace('_', '/', strtolower($class));
-			$file = str_replace('\\', '/', $file);
+			$file = preg_replace('/[_\\\\]/', '/', strtolower($class));
 
 			if ($path = Kohana::find_file('classes', $file))
 			{

--- a/classes/kohana/core.php
+++ b/classes/kohana/core.php
@@ -488,7 +488,7 @@ class Kohana_Core {
 		try
 		{
 			// Transform the class name into a path
-			$file = preg_replace('/[_\\\\]/', '/', strtolower($class));
+			$file = str_replace(array('_', '\\'), '/', strtolower($class));
 
 			if ($path = Kohana::find_file('classes', $file))
 			{

--- a/classes/kohana/core.php
+++ b/classes/kohana/core.php
@@ -489,6 +489,7 @@ class Kohana_Core {
 		{
 			// Transform the class name into a path
 			$file = str_replace('_', '/', strtolower($class));
+			$file = str_replace('\\', '/', $file);
 
 			if ($path = Kohana::find_file('classes', $file))
 			{

--- a/classes/kohana/request.php
+++ b/classes/kohana/request.php
@@ -836,6 +836,17 @@ class Kohana_Request implements HTTP_Request {
 				// Use the default action
 				$this->_action = Route::$default_action;
 			}
+			
+			if (isset($params['namespace']))
+			{
+				// Store the namespace
+				$this->_namespace = $params['namespace'];
+			}
+			else
+			{
+				// User the default namespace
+				$this->_namespace = Route::$default_namespace;
+			}
 
 			// These are accessible as public vars and can be overloaded
 			unset($params['controller'], $params['action'], $params['directory']);
@@ -1052,6 +1063,26 @@ class Kohana_Request implements HTTP_Request {
 
 		// Act as a setter
 		$this->_controller = (string) $controller;
+
+		return $this;
+	}
+
+	/**
+	 * Sets and gets the namespace for the matched route.
+	 *
+	 * @param   string   $namespace  Namespace to execute the action
+	 * @return  mixed
+	 */
+	public function name_space($namespace = NULL)
+	{
+		if ($namespace === NULL)
+		{
+			// Act as a getter
+			return $this->_namespace;
+		}
+
+		// Act as a setter
+		$this->_namespace = (string) $namespace;
 
 		return $this;
 	}

--- a/classes/kohana/request/client/internal.php
+++ b/classes/kohana/request/client/internal.php
@@ -49,6 +49,13 @@ class Kohana_Request_Client_Internal extends Request_Client {
 
 		// Controller
 		$controller = $request->controller();
+		
+		// Namespace
+		$namespace = $request->name_space();
+		if ($namespace)
+		{
+			$namespace .= '\\';
+		}
 
 		if ($directory)
 		{
@@ -82,19 +89,19 @@ class Kohana_Request_Client_Internal extends Request_Client {
 
 		try
 		{
-			if ( ! class_exists($prefix.$controller))
+			if ( ! class_exists($namespace.$prefix.$controller))
 			{
 				throw new HTTP_Exception_404('The requested URL :uri was not found on this server.',
 													array(':uri' => $request->uri()));
 			}
 
 			// Load the controller using reflection
-			$class = new ReflectionClass($prefix.$controller);
+			$class = new ReflectionClass($namespace.$prefix.$controller);
 
 			if ($class->isAbstract())
 			{
 				throw new Kohana_Exception('Cannot create instances of abstract :controller',
-					array(':controller' => $prefix.$controller));
+					array(':controller' => $namespace.$prefix.$controller));
 			}
 
 			// Create a new instance of the controller

--- a/classes/kohana/route.php
+++ b/classes/kohana/route.php
@@ -62,6 +62,11 @@ class Kohana_Route {
 	public static $default_action = 'index';
 
 	/**
+	 * @var  string  default namespace for all routes
+	 */
+	public static $default_namespace = '';
+
+	/**
 	 * @var  bool Indicates whether routes are cached
 	 */
 	public static $cache = FALSE;


### PR DESCRIPTION
Allows you to create a route like:

``` php
<?php # init.php

namespace My\Discussion;

\Route::set('my-discussions', 'discussions')
    ->defaults(array(
        'namespace'  => 'My\\Discussion',
        'controller' => 'discussion',
        'action'     => 'index'
    ));
```

This allows a module to be separated by namespace. If you don't specify a namespace, then the 5.3 syntax will not be used, so it is still backwards compatible with <5.3.
