### PR TITLE
#3141 - Handle indexed arrays consistently in Arr::merge()

### DIFF
--- a/classes/kohana/arr.php
+++ b/classes/kohana/arr.php
@@ -391,7 +391,10 @@ class Kohana_Arr {
 	}
 
 	/**
-	 * Merges one or more arrays recursively and preserves all keys.
+	 * Recursively merge two or more arrays. Values in an associative array
+	 * overwrite previous values with the same key. Values in an indexed array
+	 * are appended, but only when they do not already exist in the result.
+	 *
 	 * Note that this does not work the same as [array_merge_recursive](http://php.net/array_merge_recursive)!
 	 *
 	 *     $john = array('name' => 'john', 'children' => array('fred', 'paul', 'sally', 'jane'));
@@ -403,64 +406,75 @@ class Kohana_Arr {
 	 *     // The output of $john will now be:
 	 *     array('name' => 'mary', 'children' => array('fred', 'paul', 'sally', 'jane'))
 	 *
-	 * @param   array  $a1      initial array
-	 * @param   array  $a2,...  array to merge
+	 * @param   array  $array1      initial array
+	 * @param   array  $array2,...  array to merge
 	 * @return  array
 	 */
-	public static function merge(array $a1, array $a2)
+	public static function merge($array1, $array2)
 	{
-		$result = array();
-		for ($i = 0, $total = func_num_args(); $i < $total; $i++)
+		if (Arr::is_assoc($array2))
 		{
-			// Get the next array
-			$arr = func_get_arg($i);
-
-			// Is the array associative?
-			$assoc = Arr::is_assoc($arr);
-
-			foreach ($arr as $key => $val)
+			foreach ($array2 as $key => $value)
 			{
-				if (isset($result[$key]))
+				if (is_array($value)
+					AND isset($array1[$key])
+					AND is_array($array1[$key])
+				)
 				{
-					if (is_array($val) AND is_array($result[$key]))
+					$array1[$key] = Arr::merge($array1[$key], $value);
+				}
+				else
+				{
+					$array1[$key] = $value;
+				}
+			}
+		}
+		else
+		{
+			foreach ($array2 as $value)
+			{
+				if ( ! in_array($value, $array1, TRUE))
+				{
+					$array1[] = $value;
+				}
+			}
+		}
+
+		if (func_num_args() > 2)
+		{
+			foreach (array_slice(func_get_args(), 2) as $array2)
+			{
+				if (Arr::is_assoc($array2))
+				{
+					foreach ($array2 as $key => $value)
 					{
-						if (Arr::is_assoc($val))
+						if (is_array($value)
+							AND isset($array1[$key])
+							AND is_array($array1[$key])
+						)
 						{
-							// Associative arrays are merged recursively
-							$result[$key] = Arr::merge($result[$key], $val);
+							$array1[$key] = Arr::merge($array1[$key], $value);
 						}
 						else
 						{
-							// Find the values that are not already present
-							$diff = array_diff($val, $result[$key]);
-
-							// Indexed arrays are merged to prevent duplicates
-							$result[$key] = array_merge($result[$key], $diff);
-						}
-					}
-					else
-					{
-						if ($assoc)
-						{
-							// Associative values are replaced
-							$result[$key] = $val;
-						}
-						elseif ( ! in_array($val, $result, TRUE))
-						{
-							// Indexed values are added only if they do not yet exist
-							$result[] = $val;
+							$array1[$key] = $value;
 						}
 					}
 				}
 				else
 				{
-					// New values are added
-					$result[$key] = $val;
+					foreach ($array2 as $value)
+					{
+						if ( ! in_array($value, $array1, TRUE))
+						{
+							$array1[] = $value;
+						}
+					}
 				}
 			}
 		}
 
-		return $result;
+		return $array1;
 	}
 
 	/**

--- a/tests/kohana/ArrTest.php
+++ b/tests/kohana/ArrTest.php
@@ -242,14 +242,19 @@ class Kohana_ArrTest extends Unittest_TestCase
 			),
 			// See how it merges sub-arrays with numerical indexes
 			array(
-				array(array('test1','test3'), array('test2','test4')),
+				array(array('test1','test2'), array('test2','test3')),
 				array(array('test1'), array('test2')),
-				array(array('test3'), array('test4')),
+				array(array('test2'), array('test3')),
 			),
 			array(
-				array(array('test1','test3'), array('test2','test4')),
-				array(array('test1'), array('test2')),
-				array(array('test3'), array('test4')),
+				array(array(array('test1')), array(array('test2'))),
+				array(array(array('test1')), array(array('test2'))),
+				array(array(array('test2')), array(array('test3'))),
+			),
+			array(
+				array('a' => array('test1','test2'), 'b' => array('test2','test3')),
+				array('a' => array('test1'), 'b' => array('test2')),
+				array('a' => array('test2'), 'b' => array('test3')),
 			),
 			array(
 				array('digits' => array(0, 1, 2, 3)),
@@ -278,6 +283,66 @@ class Kohana_ArrTest extends Unittest_TestCase
 				array('foo'	=> 'bar'),
 				array('foo'	=> array('bar')),
 				array('foo'	=> 'bar'),
+			),
+
+			// data set #9
+			// Associative, Associative
+			array(
+				array('a' => 'K', 'b' => 'K', 'c' => 'L'),
+				array('a' => 'J', 'b' => 'K'),
+				array('a' => 'K', 'c' => 'L'),
+			),
+			// Associative, Indexed
+			array(
+				array('a' => 'J', 'b' => 'K', 'K', 'L'),
+				array('a' => 'J', 'b' => 'K'),
+				array('K', 'L'),
+			),
+			// Associative, Mixed
+			array(
+				array('a' => 'J', 'b' => 'K', 'K', 'c' => 'L'),
+				array('a' => 'J', 'b' => 'K'),
+				array('K', 'c' => 'L'),
+			),
+
+			// data set #12
+			// Indexed, Associative
+			array(
+				array('J', 'K', 'a' => 'K', 'c' => 'L'),
+				array('J', 'K'),
+				array('a' => 'K', 'c' => 'L'),
+			),
+			// Indexed, Indexed
+			array(
+				array('J', 'K', 'L'),
+				array('J', 'K'),
+				array('K', 'L'),
+			),
+			// Indexed, Mixed
+			array(
+				array('K', 'K', 'c' => 'L'),
+				array('J', 'K'),
+				array('K', 'c' => 'L'),
+			),
+
+			// data set #15
+			// Mixed, Associative
+			array(
+				array('a' => 'K', 'K', 'c' => 'L'),
+				array('a' => 'J', 'K'),
+				array('a' => 'K', 'c' => 'L'),
+			),
+			// Mixed, Indexed
+			array(
+				array('a' => 'J', 'K', 'L'),
+				array('a' => 'J', 'K'),
+				array('J', 'L'),
+			),
+			// Mixed, Mixed
+			array(
+				array('a' => 'K', 'L'),
+				array('a' => 'J', 'K'),
+				array('a' => 'K', 'L'),
 			),
 		);
 	}

--- a/tests/kohana/ArrTest.php
+++ b/tests/kohana/ArrTest.php
@@ -242,12 +242,12 @@ class Kohana_ArrTest extends Unittest_TestCase
 			),
 			// See how it merges sub-arrays with numerical indexes
 			array(
-				array(array('test1','test2'), array('test2','test3')),
+				array(array('test1'), array('test2'), array('test3')),
 				array(array('test1'), array('test2')),
 				array(array('test2'), array('test3')),
 			),
 			array(
-				array(array(array('test1')), array(array('test2'))),
+				array(array(array('test1')), array(array('test2')), array(array('test3'))),
 				array(array(array('test1')), array(array('test2'))),
 				array(array(array('test2')), array(array('test3'))),
 			),
@@ -294,7 +294,7 @@ class Kohana_ArrTest extends Unittest_TestCase
 			),
 			// Associative, Indexed
 			array(
-				array('a' => 'J', 'b' => 'K', 'K', 'L'),
+				array('a' => 'J', 'b' => 'K', 'L'),
 				array('a' => 'J', 'b' => 'K'),
 				array('K', 'L'),
 			),
@@ -343,6 +343,13 @@ class Kohana_ArrTest extends Unittest_TestCase
 				array('a' => 'K', 'L'),
 				array('a' => 'J', 'K'),
 				array('a' => 'K', 'L'),
+			),
+
+			// Bug #3141
+			array(
+				array('servers' => array(array('1.1.1.1', 4730), array('2.2.2.2', 4730))),
+				array('servers' => array(array('1.1.1.1', 4730))),
+				array('servers' => array(array('2.2.2.2', 4730))),
 			),
 		);
 	}


### PR DESCRIPTION
The first commit adds more tests for existing behavior. The second commit changes behavior for indexed arrays, and appears faster, too.
