### PR TITLE
fixing broken links on the main guide page

### DIFF
--- a/guide/kohana/index.md
+++ b/guide/kohana/index.md
@@ -6,9 +6,13 @@ Kohana is an open source, [object oriented](http://wikipedia.org/wiki/Object-Ori
 
 ## What makes Kohana great?
 
-Anything can be extended using the unique [filesystem](about.filesystem) design, little or no [configuration](about.configuration) is necessary, [error handling](debugging.errors) helps locate the source of errors quickly, and [debugging](debugging) and [profiling](debugging.profiling) provide insight into the application.
+Anything can be extended using the unique [filesystem](files) design, little or no [configuration](config) is
+necessary, [error handling](errors) helps locate the source of errors quickly, and [debugging](debugging) and [profiling](profiling) provide insight into the application.
 
-To help secure your applications, tools for [input validation](security.validation), [signed cookies](security.cookies), [form](security.forms) and [HTML](security.html) generators are all included. The [database](security.database) layer provides protection against [SQL injection](http://wikipedia.org/wiki/SQL_Injection). Of course, all official code is carefully written and reviewed for security.
+To help secure your applications, tools for [input validation](security/validation),
+[signed cookies](security/cookies), [Form] and [HTML] generators are all included. The
+ [database](security/database) layer provides protection against [SQL injection](http://wikipedia
+ .org/wiki/SQL_Injection). Of course, all official code is carefully written and reviewed for security.
 
 ## Contribute to the Documentation
 


### PR DESCRIPTION
i've fixed the links, though some of them, namely signed cookies and database security are pretty redundant, so maybe they need removing all together? 
