### PR TITLE
Typo in doc block for Config Reader

### DIFF
--- a/classes/kohana/config.php
+++ b/classes/kohana/config.php
@@ -36,7 +36,7 @@ class Kohana_Config {
 	{
 		if ($first === TRUE)
 		{
-			// Place the log reader at the top of the stack
+			// Place the config reader at the top of the stack
 			array_unshift($this->_sources, $source);
 		}
 		else

--- a/classes/kohana/config/reader.php
+++ b/classes/kohana/config/reader.php
@@ -13,7 +13,7 @@ interface Kohana_Config_Reader extends Kohana_Config_Source
 {
 	
 	/**
-	 * Tries to load the specificed configuration group
+	 * Tries to load the specified configuration group
 	 *
 	 * Returns FALSE if group does not exist or an array if it does
 	 *

--- a/tests/kohana/ConfigTest.php
+++ b/tests/kohana/ConfigTest.php
@@ -80,7 +80,7 @@ class Kohana_ConfigTest extends Unittest_TestCase
 
 	/**
 	 * Test that attaching a new reader (and passing FALSE as second param) causes
-	 * phpunit to append the reader rather than prepend
+	 * the config object to append the reader rather than prepend
 	 *
 	 * @test
 	 * @covers Config::attach


### PR DESCRIPTION
fixing typo in doc block for Config Reader. Does this need an issue on redmine?
