### PR TITLE
Fix for $request->redirect() bug when Kohana:$index_file is activated

### DIFF
--- a/classes/kohana/request.php
+++ b/classes/kohana/request.php
@@ -242,7 +242,8 @@ class Kohana_Request implements HTTP_Request {
 
 	/**
 	 * Automatically detects the URI of the main request using PATH_INFO,
-	 * REQUEST_URI, PHP_SELF or REDIRECT_URL.
+	 * REQUEST_URI, PHP_SELF or 
+	 _URL.
 	 *
 	 *     $uri = Request::detect_uri();
 	 *
@@ -936,7 +937,7 @@ class Kohana_Request implements HTTP_Request {
 
 		if (strpos($referrer, '://') === FALSE)
 		{
-			$referrer = URL::site($referrer, TRUE, Kohana::$index_file);
+			$referrer = URL::site($referrer, TRUE, TRUE);
 		}
 
 		if (strpos($url, '://') === FALSE)

--- a/classes/kohana/request.php
+++ b/classes/kohana/request.php
@@ -943,7 +943,7 @@ class Kohana_Request implements HTTP_Request {
 		if (strpos($url, '://') === FALSE)
 		{
 			// Make the URI into a URL
-			$url = URL::site($url, TRUE, Kohana::$index_file);
+			$url = URL::site($url, TRUE, TRUE);
 		}
 
 		if (($response = $this->response()) === NULL)


### PR DESCRIPTION
There was a problem in $request->redirect() when Kohana:$index_file is activated. Kohana:$index_file must be a string value or FALSE not TRUE.
