### PR TITLE
Un-needed duplication setting  to null and then on null setting char to '...'

### DIFF
--- a/classes/kohana/text.php
+++ b/classes/kohana/text.php
@@ -87,10 +87,8 @@ class Kohana_Text {
 	 * @return  string
 	 * @uses    UTF8::strlen
 	 */
-	public static function limit_chars($str, $limit = 100, $end_char = NULL, $preserve_words = FALSE)
+	public static function limit_chars($str, $limit = 100, $end_char = '…', $preserve_words = FALSE)
 	{
-		$end_char = ($end_char === NULL) ? '…' : $end_char;
-
 		$limit = (int) $limit;
 
 		if (trim($str) === '' OR UTF8::strlen($str) <= $limit)


### PR DESCRIPTION
Any reason why this logic would be necessary? 

<code>$end_char = ($end_char === NULL) ? '…' : $end_char;</code>

Also, I'm pretty sure the character in there is a ellipsis character and not ... (3 periods) which I'm fairly sure will break some IDE's or code editors due to UTF support (or lack thereof) so that may need to be updated as well.
