### PR TITLE
3.3/develop

### DIFF
--- a/classes/kohana/text.php
+++ b/classes/kohana/text.php
@@ -87,10 +87,8 @@ class Kohana_Text {
 	 * @return  string
 	 * @uses    UTF8::strlen
 	 */
-	public static function limit_chars($str, $limit = 100, $end_char = NULL, $preserve_words = FALSE)
+	public static function limit_chars($str, $limit = 100, $end_char = '...', $preserve_words = FALSE)
 	{
-		$end_char = ($end_char === NULL) ? '…' : $end_char;
-
 		$limit = (int) $limit;
 
 		if (trim($str) === '' OR UTF8::strlen($str) <= $limit)


### PR DESCRIPTION
$end_char was already defaulting to null, so the check of null just to set to an ellipses was unnecessary duplication of logic. Furthermore, the character in the file was an actual single U+2026 character which would cause errors in some applications and IDE's depending on UTF support and font (see http://www.fileformat.info/info/unicode/char/2026/fontsupport.htm) so I've changed it to (3) period characters instead to comply with UTF-8 and fonts.
