### PR TITLE
3.3/develop

### DIFF
--- a/classes/Kohana/Text.php
+++ b/classes/Kohana/Text.php
@@ -60,7 +60,7 @@ class Kohana_Text {
 	public static function limit_words($str, $limit = 100, $end_char = NULL)
 	{
 		$limit = (int) $limit;
-		$end_char = ($end_char === NULL) ? '…' : $end_char;
+		$end_char = ($end_char === NULL) ? '...' : $end_char;
 
 		if (trim($str) === '')
 			return $str;
@@ -89,7 +89,7 @@ class Kohana_Text {
 	 */
 	public static function limit_chars($str, $limit = 100, $end_char = NULL, $preserve_words = FALSE)
 	{
-		$end_char = ($end_char === NULL) ? '…' : $end_char;
+		$end_char = ($end_char === NULL) ? '...' : $end_char;
 
 		$limit = (int) $limit;
 

--- a/tests/kohana/TextTest.php
+++ b/tests/kohana/TextTest.php
@@ -112,8 +112,8 @@ class Kohana_TextTest extends Unittest_TestCase
 		return array
 		(
 			array('', '', 100, NULL),
-			array('…', 'The rain in spain', -10, NULL),
-			array('The rain…', 'The rain in spain', 2, NULL),
+			array('...', 'The rain in spain', -10, NULL),
+			array('The rain...', 'The rain in spain', 2, NULL),
 			array('The rain...', 'The rain in spain', 2, '...'),
 		);
 	}
@@ -138,12 +138,12 @@ class Kohana_TextTest extends Unittest_TestCase
 		return array
 		(
 			array('', '', 100, NULL, FALSE),
-			array('…', 'BOO!', -42, NULL, FALSE),
-			array('making php bet…', 'making php better for the sane', 14, NULL, FALSE),
+			array('...', 'BOO!', -42, NULL, FALSE),
+			array('making php bet...', 'making php better for the sane', 14, NULL, FALSE),
 			array('Garçon! Un café s.v.p.', 'Garçon! Un café s.v.p.', 50, '__', FALSE),
 			array('Garçon!__', 'Garçon! Un café s.v.p.', 8, '__', FALSE),
 			// @issue 3238
-			array('making php…', 'making php better for the sane', 14, NULL, TRUE),
+			array('making php...', 'making php better for the sane', 14, NULL, TRUE),
 			array('Garçon!__', 'Garçon! Un café s.v.p.', 9, '__', TRUE),
 			array('Garçon!__', 'Garçon! Un café s.v.p.', 7, '__', TRUE),
 			array('__', 'Garçon! Un café s.v.p.', 5, '__', TRUE),


### PR DESCRIPTION
Following along with the pull request I closed here (https://github.com/kohana/core/pull/218#issuecomment-3953700) I've researched a bit more, and found that the ellipsis character does indeed cause issues with many IDE's and editors depending on font support for the character. This was clearly not an intentional use of the ellipsis character (you can look at TextTest.php and see the inconsistency in the output) but most likely due to the like of spell checkers in the editor or OS (Coda for Mac will automatically convert (3) periods into an ellipsis for example).
