### PR TITLE
Correct the param label from param2 to param3

### DIFF
--- a/messages/validation.php
+++ b/messages/validation.php
@@ -15,7 +15,7 @@ return array(
 	'exact_length'  => ':field must be exactly :param2 characters long',
 	'in_array'      => ':field must be one of the available options',
 	'ip'            => ':field must be an ip address',
-	'matches'       => ':field must be the same as :param2',
+	'matches'       => ':field must be the same as :param3',
 	'min_length'    => ':field must be at least :param2 characters long',
 	'max_length'    => ':field must not exceed :param2 characters long',
 	'not_empty'     => ':field must not be empty',


### PR DESCRIPTION
EXAMPLE: if not, rule('password_confirm', 'matches', array(':validation', ':field', 'password') will cause ouput password confirm must be the same as password confirm
