### PR TITLE
Inflector updates

### DIFF
--- a/classes/Kohana/Inflector.php
+++ b/classes/Kohana/Inflector.php
@@ -183,6 +183,10 @@ class Kohana_Inflector {
 		{
 			$str = Inflector::$irregular[$str];
 		}
+		elseif (in_array($str, Inflector::$irregular))
+		{
+			// Do nothing
+		}
 		elseif (preg_match('/[sxz]$/', $str) OR preg_match('/[^aeioudgkprt]h$/', $str))
 		{
 			$str .= 'es';

--- a/classes/Kohana/Inflector.php
+++ b/classes/Kohana/Inflector.php
@@ -253,7 +253,7 @@ class Kohana_Inflector {
 	 */
 	public static function underscore($str)
 	{
-		return preg_replace('/\s+/', '_', trim($str));
+		return preg_replace('/(\s|-|~|=)+/', '_', trim($str));
 	}
 
 	/**


### PR DESCRIPTION
Inflector::plural should not pluralize plural form of an irregular verb.

Inflector::underscore should replace not only white-space with a underscore, but some other characters as well.
