### PR TITLE
Kohana environment values are illogical

### DIFF
--- a/classes/Kohana/Core.php
+++ b/classes/Kohana/Core.php
@@ -20,10 +20,10 @@ class Kohana_Core {
 	const CODENAME = 'Kolibri';
 
 	// Common environment type constants for consistency and convenience
-	const PRODUCTION  = 10;
-	const STAGING     = 20;
-	const TESTING     = 30;
-	const DEVELOPMENT = 40;
+	const PRODUCTION  = 40;
+	const STAGING     = 30;
+	const TESTING     = 20;
+	const DEVELOPMENT = 10;
 
 	// Security check that is added to all generated PHP files
 	const FILE_SECURITY = '<?php defined(\'SYSPATH\') OR die(\'No direct script access.\');';


### PR DESCRIPTION
http://dev.kohanaframework.org/issues/4494

Right now the following statement is false:

```
Kohana::DEVELOPMENT < Kohana::PRODUCTION
```

The values should be switched so they make logical sense when being used in an integer comparison.

The change cleans up the following code:

```
if (Kohana::$environment === Kohana::DEVELOPMENT OR
    Kohana::$environment === Kohana::TESTING)
```

to

```
if (Kohana::$environment < Kohana::STAGING)
```
