### PR TITLE
Set correct mime-type for js files (should be application/javascript) - fixes #4496

### DIFF
--- a/config/mimes.php
+++ b/config/mimes.php
@@ -80,7 +80,7 @@ return array
 	'jpe'   => array('image/jpeg', 'image/pjpeg'),
 	'jpeg'  => array('image/jpeg', 'image/pjpeg'),
 	'jpg'   => array('image/jpeg', 'image/pjpeg'),
-	'js'    => array('application/x-javascript'),
+	'js'    => array('application/javascript'),
 	'json'  => array('application/json'),
 	'latex' => array('application/x-latex'),
 	'lha'   => array('application/octet-stream'),


### PR DESCRIPTION
A very small change to fix http://dev.kohanaframework.org/issues/4496 - File::mime_by_ext reports an invalid mime-type (application/x-javascript) for .js files which is not valid per the RFC.
