### PR TITLE
Fixed a misspelling in the upgrade guide

### DIFF
--- a/guide/kohana/upgrading.md
+++ b/guide/kohana/upgrading.md
@@ -29,7 +29,7 @@ Examples:
 
 ## Redirects (HTTP 300, 301, 302, 303, 307)
 
-Redirects are no longer issued against the [Request] object. The new syntax from inside a controler is:
+Redirects are no longer issued against the [Request] object. The new syntax from inside a controller is:
 
     $this->redirect('http://www.google.com', 302);
 


### PR DESCRIPTION
Fixed a little misspelling (just to test how contributing works for more contributes like user guide translation in the future)

I hope I'm commiting it this time in the correct branch. Sorry if not, the whole git stuff it new for me. 
