### PR TITLE
Docs update: Configuration in core/system guide

### DIFF
--- a/guide/kohana/config.md
+++ b/guide/kohana/config.md
@@ -1,7 +1,7 @@
 # Configuration
 
-By default kohana is setup to load configuration values from [config files](files/config) in the
-cascading filesystem.  However, it is very easy to adapt it to load config values in other 
+By default Kohana is setup to load configuration values from [config files](files/config) in the
+cascading filesystem.  However, it is very easy to adapt it to load config values in other
 locations/formats.
 
 ## Sources
@@ -12,24 +12,24 @@ storing configuration values.
 To read config from a source you need a **Config Reader**. Similarly, to write config to a source
 you need a **Config Writer**.
 
-Implementing them is as simpe as extending the 
+Implementing them is as simple as extending the
 [Kohana_Config_Reader] / [Kohana_Config_Writer] interfaces:
 
 	class Kohana_Config_Database_Reader implements Kohana_Config_Reader
 	class Kohana_Config_Database_Writer extends Kohana_Config_Database_Reader implements Kohana_Config_Writer
 
-You'll notice in the above example that the Database Writer extends the Database Reader. 
-This is the convention with config sources, the reasoning being that if you can write to a 
-source chances are you can also read from it as well. However, this convention is not enforced 
+You'll notice in the above example that the Database Writer extends the Database Reader.
+This is the convention with config sources, the reasoning being that if you can write to a
+source chances are you can also read from it as well. However, this convention is not enforced
 and is left to the developer's discretion.
 
 ## Groups
 
-In order to aide organisation config values are split up into logical "groups".  For example
-database related settings go in a `database` group, and session related settings go in a 
+In order to aid organisation config values are split up into logical "groups".  For example,
+database related settings go in a `database` group, and session related settings go in a
 `session` group.
 
-How these groups are stored/organised is up to the config source.  For example the file source
+How these groups are stored/organised is up to the config source.  For example, the file source
 puts different config groups into different files (`database.php`, `session.php`) whereas
 the database source uses a column to distinguish between groups.
 
@@ -63,18 +63,18 @@ from the config group to the value you want:
 			)
 		)
 	);
-	
+
 	// Code which needs hostname:
 	$hostname = Kohana::$config->load('database.default.connection.hostname');
-	
+
 
 Which is equivalent to:
 
 	$config = Kohana::$config->load('database')->get('default');
-	
+
 	$hostname = $config['connection']['hostname'];
 
-Obviously this method is a lot more compact than the original, however please bear in mind that using
+Obviously this method is a lot more compact than the original. However, please bear in mind that using
 `dot.notation` is a _lot_ slower than calling `get()` and traversing the array yourself.  Dot notation
 can be useful if you only need one specific variable, but otherwise it's best to use `get()`.
 
@@ -82,10 +82,10 @@ As [Config_Group] extends [Array_Object](http://php.net/manual/en/class.arrayobj
 syntax to get/set config vars:
 
 	$config = Kohana::$config->load('database');
-	
+
 	// Getting the var
 	$hostname = $config['default']['connection']['hostname'];
-	
+
 	// Setting the var
 	$config['default']['connection']['hostname'] = '127.0.0.1';
 
@@ -93,8 +93,8 @@ Again, this syntax is more costly than calling `get()` / `set()`.
 
 ## Config Merging
 
-One of the useful features of the config system is config group merging. This works in a similar way 
-to the cascading filesystem, with configuration from lower sources lower down the source stack being 
+One of the useful features of the config system is config group merging. This works in a similar way
+to the cascading filesystem, with configuration from lower sources lower down the source stack being
 merged with sources further up the stack.
 
 If two sources contain the same config variables then the one from the source further up the stack will
@@ -116,17 +116,17 @@ For example, using the setup outlined above:
 
 	// Configuration in the filesystem:
 		email:
-			sender: 
+			sender:
 				email: my.awesome.address@example.com
 				name:  Unknown
 			method: smtp
-	
+
 	// Configuration in the database:
 		email:
 			sender:
 				email: my.supercool.address@gmail.com
 				name:  Kohana Bot
-	
+
 	// Configuration returned by Kohana::$config->load('email')
 		email:
 			sender:
@@ -149,17 +149,17 @@ In this example, any values found in the filesystem will override those found in
 
 	// Configuration in the filesystem:
 		email:
-			sender: 
+			sender:
 				email: my.awesome.address@example.com
 				name:  Unknown
 			method: smtp
-	
+
 	// Configuration in the database:
 		email:
 			sender:
 				email: my.supercool.address@gmail.com
 				name:  Kohana Bot
-	
+
 	// Configuration returned by Kohana::$config->load('email')
 		email:
 			sender:
@@ -169,21 +169,21 @@ In this example, any values found in the filesystem will override those found in
 
 ## Using different config sources based on the environment
 
-In some situation's you'll need to use different config values depending on which state `Kohana::$environment`
+In some situations you'll need to use different config values depending on which state `Kohana::$environment`
 is in. Unit testing is a prime example of such a situation. Most setups have two databases; one for normal
 development and a separate one for unit testing (to isolate the tests from your development).
 
 In this case you still need access to the config settings stored in the `config` directory as it contains generic
 settings that are needed whatever environment your application is in (e.g. encryption settings),
-)o replacing the default `Config_File` source isn't really an option.
+so replacing the default `Config_File` source isn't really an option.
 
 To get around this you can attach a separate config file reader which loads its config from a subdir of `config` called
 "testing":
 
 	Kohana::$config->attach(new Config_File);
-	
+
 	Kohana::$config->attach(new Config_Database);
-	
+
 	if (Kohana::$environment === Kohana::TESTING)
 	{
 		Kohana::$config->attach(new Config_File('config/testing'));


### PR DESCRIPTION
- "Kohana" should be as capitalised noun when used in text
- Changed possessive of "situation's" as it should be of plural version
- "For example" needs to lead sentence with pause from comma before example outlined
- Minor typos

Not sure where those blank line changed came from though.
