### PR TITLE
Docs edit: Bootstrap & Upgrading core/system guides

### DIFF
--- a/guide/kohana/bootstrap.md
+++ b/guide/kohana/bootstrap.md
@@ -6,27 +6,27 @@ The bootstrap is located at `application/bootstrap.php`.  It is responsible for 
 
 ## Environment setup
 
-First the bootstrap sets the timezone and the locale, and adds Kohana's autoloader so the [cascading filesystem](files) works.  You could add any other settings that all your application needed here.
+The bootstrap first sets the timezone and locale, and then adds Kohana's autoloader so the [cascading filesystem](files) works.  You could add any other settings that all your application needed here.
 
 ~~~
 // Sample excerpt from bootstrap.php with comments trimmed down
 
 // Set the default time zone.
 date_default_timezone_set('America/Chicago');
- 
+
 // Set the default locale.
 setlocale(LC_ALL, 'en_US.utf-8');
- 
+
 // Enable the Kohana auto-loader.
 spl_autoload_register(array('Kohana', 'auto_load'));
- 
+
 // Enable the Kohana auto-loader for unserialization.
 ini_set('unserialize_callback_func', 'spl_autoload_call');
 ~~~
 
 ## Initialization and Configuration
 
-Kohana is then initialized by calling [Kohana::init], and the log and [config](files/config) reader/writers are enabled. 
+Kohana is then initialized by calling [Kohana::init], and the log and [config](files/config) reader/writers are enabled.
 
 ~~~
 // Sample excerpt from bootstrap.php with comments trimmed down
@@ -48,7 +48,7 @@ You can add conditional statements to make the bootstrap have different values b
 ~~~
 // Excerpt from http://github.com/isaiahdw/kohanaphp.com/blob/f2afe8e28b/application/bootstrap.php
 ... [trimmed]
- 
+
 /**
  * Set the environment status by the domain.
  */
@@ -56,11 +56,11 @@ if (strpos($_SERVER['HTTP_HOST'], 'kohanaphp.com') !== FALSE)
 {
 	// We are live!
 	Kohana::$environment = Kohana::PRODUCTION;
- 
+
 	// Turn off notices and strict errors
 	error_reporting(E_ALL ^ E_NOTICE ^ E_STRICT);
 }
- 
+
 /**
  * Initialize Kohana, setting the default options.
  ... [trimmed]
@@ -82,7 +82,7 @@ Kohana::init(array(
 
 **Read the [Modules](modules) page for a more detailed description.**
 
-[Modules](modules) are then loaded using [Kohana::modules()].  Including modules is optional.  
+[Modules](modules) are then loaded using [Kohana::modules()].  Including modules is optional.
 
 Each key in the array should be the name of the module, and the value is the path to the module, either relative or absolute.
 ~~~
@@ -99,7 +99,7 @@ Kohana::modules(array(
 
 **Read the [Routing](routing) page for a more detailed description and more examples.**
 
-[Routes](routing) are then defined via [Route::set()].  
+[Routes](routing) are then defined via [Route::set()].
 
 ~~~
 // The default route that comes with Kohana 3

--- a/guide/kohana/upgrading.md
+++ b/guide/kohana/upgrading.md
@@ -2,7 +2,7 @@
 
 ## HVMC Isolation
 
-HVMC Sub-request isolation has been improved to prevent exceptions leaking from this inner to the outer request. If you we're previous catching any exceptions from sub-requests, you should now be checking the [Response] object returned from [Request::execute].
+HVMC Sub-request isolation has been improved to prevent exceptions leaking from this inner to the outer request. If you were previously catching any exceptions from sub-requests, you should now be checking the [Response] object returned from [Request::execute].
 
 ## HTTP Exceptions
 
@@ -43,7 +43,7 @@ Custom error pages are now easier than ever to implement, thanks to some of the 
 
 See [Custom Error Pages](tutorials/error-pages) for more details.
 
-## Browser cache checking (ETag's)
+## Browser cache checking (ETags)
 
 The Response::check_cache method has moved to [HTTP::check_cache], with an alias at [Controller::check_cache]. Previously, this method would be used from a controller like this:
 
@@ -56,9 +56,9 @@ Now, there are two options for using the method:
 which is an alias for:
 
     HTTP::check_cache($this->request, $this->response, sha1('my content'));
-    
+
 ## PSR-0 support (file/class naming conventions)
-With the introduction of [PSR-0](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md) support, the autoloading of classes is case sensitive. Now, the file (and folder) 
+With the introduction of [PSR-0](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md) support, the autoloading of classes is case sensitive. Now, the file (and folder)
 names must match the class name exactly.
 
 Examples:
@@ -66,15 +66,15 @@ Examples:
     Kohana_Core
 
 would be located in
-    
+
     classes/Kohana/Core.php
 
 and
 
     Kohana_HTTP_Header
 
-would be located in 
+would be located in
 
     classes/Kohana/HTTP/Header.php
 
-This also affects dynamically named classes such as drivers and orms, so for example in the database config using `'mysql'` as the type instead of `'MySQL'` would throw a class not found error.
+This also affects dynamically named classes such as drivers and ORMs. So for example, in the database config using `'mysql'` as the type instead of `'MySQL'` would throw a class not found error.


### PR DESCRIPTION
- Tense and sentence structure about what the bootstrap is doing 
- Wanting ORM to be capitalised as it is an abbreviation
- ETag not in a possessive use, so should drop the apostrophe
