### PR TITLE
Normalize the Accept-Language header so it matches on upper-cased country codes (en-US)

### DIFF
--- a/classes/kohana/http/header.php
+++ b/classes/kohana/http/header.php
@@ -771,7 +771,7 @@ class Kohana_HTTP_Header extends ArrayObject {
 		{
 			if ($this->offsetExists('Accept-Language'))
 			{
-				$language_header = $this->offsetGet('Accept-Language');
+				$language_header = strtolower($this->offsetGet('Accept-Language'));
 			}
 			else
 			{

--- a/tests/kohana/Http/HeaderTest.php
+++ b/tests/kohana/Http/HeaderTest.php
@@ -1260,7 +1260,7 @@ class Kohana_HTTP_HeaderTest extends Unittest_TestCase {
 				),
 				'en-us',
 				TRUE,
-				1
+				(float) 1
 			),			
 		);
 	}

--- a/tests/kohana/Http/HeaderTest.php
+++ b/tests/kohana/Http/HeaderTest.php
@@ -1254,6 +1254,14 @@ class Kohana_HTTP_HeaderTest extends Unittest_TestCase {
 				TRUE,
 				(float) 0
 			),
+			array(
+				array(
+					'accept-language'  => 'en-US'
+				),
+				'en-us',
+				TRUE,
+				1
+			),			
 		);
 	}
 
@@ -1331,6 +1339,16 @@ class Kohana_HTTP_HeaderTest extends Unittest_TestCase {
 				TRUE,
 				'fr'
 			),
+			array(
+				array(
+					'accept-language'  => 'en-US'
+				),
+				array(
+					'en-us'
+				),
+				TRUE,
+				'en-us'
+			),			
 		);
 	}
 


### PR DESCRIPTION
Normalize the Accept-Language header so it matches on upper-cased country codes (en-US). This happens in Internet Explorer (9), Safari on Windows. 

Fixes: http://dev.kohanaframework.org/issues/4502

Modified tests to check for this scenario. 
