### PR TITLE
Passes CodeSniffer with  exceptions:

### DIFF
--- a/classes/Arr.php
+++ b/classes/Arr.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Arr extends Kohana_Arr {}

--- a/classes/Config.php
+++ b/classes/Config.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Config extends Kohana_Config {}

--- a/classes/Config/File.php
+++ b/classes/Config/File.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Config_File extends Kohana_Config_File {}

--- a/classes/Config/Group.php
+++ b/classes/Config/Group.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 
 class Config_Group extends Kohana_Config_Group {}

--- a/classes/Controller.php
+++ b/classes/Controller.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 abstract class Controller extends Kohana_Controller {}

--- a/classes/Controller/Template.php
+++ b/classes/Controller/Template.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 abstract class Controller_Template extends Kohana_Controller_Template {}

--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Cookie extends Kohana_Cookie {}

--- a/classes/Date.php
+++ b/classes/Date.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Date extends Kohana_Date {}

--- a/classes/Debug.php
+++ b/classes/Debug.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Debug extends Kohana_Debug {}

--- a/classes/Encrypt.php
+++ b/classes/Encrypt.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Encrypt extends Kohana_Encrypt {}

--- a/classes/Feed.php
+++ b/classes/Feed.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Feed extends Kohana_Feed {}

--- a/classes/File.php
+++ b/classes/File.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class File extends Kohana_File {}

--- a/classes/Form.php
+++ b/classes/Form.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Form extends Kohana_Form {}

--- a/classes/Fragment.php
+++ b/classes/Fragment.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Fragment extends Kohana_Fragment {}

--- a/classes/HTML.php
+++ b/classes/HTML.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTML extends Kohana_HTML {}

--- a/classes/HTTP.php
+++ b/classes/HTTP.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 abstract class HTTP extends Kohana_HTTP {}

--- a/classes/HTTP/Exception.php
+++ b/classes/HTTP/Exception.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Exception extends Kohana_HTTP_Exception {}

--- a/classes/HTTP/Exception/300.php
+++ b/classes/HTTP/Exception/300.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Exception_300 extends Kohana_HTTP_Exception_300 {}

--- a/classes/HTTP/Exception/301.php
+++ b/classes/HTTP/Exception/301.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Exception_301 extends Kohana_HTTP_Exception_301 {}

--- a/classes/HTTP/Exception/302.php
+++ b/classes/HTTP/Exception/302.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Exception_302 extends Kohana_HTTP_Exception_302 {}

--- a/classes/HTTP/Exception/303.php
+++ b/classes/HTTP/Exception/303.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Exception_303 extends Kohana_HTTP_Exception_303 {}

--- a/classes/HTTP/Exception/304.php
+++ b/classes/HTTP/Exception/304.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Exception_304 extends Kohana_HTTP_Exception_304 {}

--- a/classes/HTTP/Exception/305.php
+++ b/classes/HTTP/Exception/305.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Exception_305 extends Kohana_HTTP_Exception_305 {}

--- a/classes/HTTP/Exception/307.php
+++ b/classes/HTTP/Exception/307.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Exception_307 extends Kohana_HTTP_Exception_307 {}

--- a/classes/HTTP/Exception/400.php
+++ b/classes/HTTP/Exception/400.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Exception_400 extends Kohana_HTTP_Exception_400 {}

--- a/classes/HTTP/Exception/401.php
+++ b/classes/HTTP/Exception/401.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Exception_401 extends Kohana_HTTP_Exception_401 {}

--- a/classes/HTTP/Exception/402.php
+++ b/classes/HTTP/Exception/402.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Exception_402 extends Kohana_HTTP_Exception_402 {}

--- a/classes/HTTP/Exception/403.php
+++ b/classes/HTTP/Exception/403.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Exception_403 extends Kohana_HTTP_Exception_403 {}

--- a/classes/HTTP/Exception/404.php
+++ b/classes/HTTP/Exception/404.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Exception_404 extends Kohana_HTTP_Exception_404 {}

--- a/classes/HTTP/Exception/405.php
+++ b/classes/HTTP/Exception/405.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Exception_405 extends Kohana_HTTP_Exception_405 {}

--- a/classes/HTTP/Exception/406.php
+++ b/classes/HTTP/Exception/406.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Exception_406 extends Kohana_HTTP_Exception_406 {}

--- a/classes/HTTP/Exception/407.php
+++ b/classes/HTTP/Exception/407.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Exception_407 extends Kohana_HTTP_Exception_407 {}

--- a/classes/HTTP/Exception/408.php
+++ b/classes/HTTP/Exception/408.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Exception_408 extends Kohana_HTTP_Exception_408 {}

--- a/classes/HTTP/Exception/409.php
+++ b/classes/HTTP/Exception/409.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Exception_409 extends Kohana_HTTP_Exception_409 {}

--- a/classes/HTTP/Exception/410.php
+++ b/classes/HTTP/Exception/410.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Exception_410 extends Kohana_HTTP_Exception_410 {}

--- a/classes/HTTP/Exception/411.php
+++ b/classes/HTTP/Exception/411.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Exception_411 extends Kohana_HTTP_Exception_411 {}

--- a/classes/HTTP/Exception/412.php
+++ b/classes/HTTP/Exception/412.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Exception_412 extends Kohana_HTTP_Exception_412 {}

--- a/classes/HTTP/Exception/413.php
+++ b/classes/HTTP/Exception/413.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Exception_413 extends Kohana_HTTP_Exception_413 {}

--- a/classes/HTTP/Exception/414.php
+++ b/classes/HTTP/Exception/414.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Exception_414 extends Kohana_HTTP_Exception_414 {}

--- a/classes/HTTP/Exception/415.php
+++ b/classes/HTTP/Exception/415.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Exception_415 extends Kohana_HTTP_Exception_415 {}

--- a/classes/HTTP/Exception/416.php
+++ b/classes/HTTP/Exception/416.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Exception_416 extends Kohana_HTTP_Exception_416 {}

--- a/classes/HTTP/Exception/417.php
+++ b/classes/HTTP/Exception/417.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Exception_417 extends Kohana_HTTP_Exception_417 {}

--- a/classes/HTTP/Exception/500.php
+++ b/classes/HTTP/Exception/500.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Exception_500 extends Kohana_HTTP_Exception_500 {}

--- a/classes/HTTP/Exception/501.php
+++ b/classes/HTTP/Exception/501.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Exception_501 extends Kohana_HTTP_Exception_501 {}

--- a/classes/HTTP/Exception/502.php
+++ b/classes/HTTP/Exception/502.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Exception_502 extends Kohana_HTTP_Exception_502 {}

--- a/classes/HTTP/Exception/503.php
+++ b/classes/HTTP/Exception/503.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Exception_503 extends Kohana_HTTP_Exception_503 {}

--- a/classes/HTTP/Exception/504.php
+++ b/classes/HTTP/Exception/504.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Exception_504 extends Kohana_HTTP_Exception_504 {}

--- a/classes/HTTP/Exception/505.php
+++ b/classes/HTTP/Exception/505.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Exception_505 extends Kohana_HTTP_Exception_505 {}

--- a/classes/HTTP/Exception/Expected.php
+++ b/classes/HTTP/Exception/Expected.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 abstract class HTTP_Exception_Expected extends Kohana_HTTP_Exception_Expected {}

--- a/classes/HTTP/Exception/Redirect.php
+++ b/classes/HTTP/Exception/Redirect.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 abstract class HTTP_Exception_Redirect extends Kohana_HTTP_Exception_Redirect {}

--- a/classes/HTTP/Header.php
+++ b/classes/HTTP/Header.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class HTTP_Header extends Kohana_HTTP_Header {}

--- a/classes/HTTP/Message.php
+++ b/classes/HTTP/Message.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 interface HTTP_Message extends Kohana_HTTP_Message {}

--- a/classes/HTTP/Request.php
+++ b/classes/HTTP/Request.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 interface HTTP_Request extends Kohana_HTTP_Request {}

--- a/classes/HTTP/Response.php
+++ b/classes/HTTP/Response.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 interface HTTP_Response extends Kohana_HTTP_Response {}

--- a/classes/I18n.php
+++ b/classes/I18n.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class I18n extends Kohana_I18n {}

--- a/classes/Inflector.php
+++ b/classes/Inflector.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Inflector extends Kohana_Inflector {}

--- a/classes/Kohana.php
+++ b/classes/Kohana.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana extends Kohana_Core {}

--- a/classes/Kohana/Arr.php
+++ b/classes/Kohana/Arr.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Array helper.
  *
@@ -296,9 +296,9 @@ class Kohana_Arr {
 	 *     $data = array('level1' => array('level2a' => 'value 1', 'level2b' => 'value 2'));
 	 *     Arr::extract($data, array('level1.level2a', 'password'));
 	 *
-	 * @param   array   array to extract paths from
-	 * @param   array   list of path
-	 * @param   mixed   default value
+	 * @param   array  $array    array to extract paths from
+	 * @param   array  $paths    list of path
+	 * @param   mixed  $default  default value
 	 * @return  array
 	 */
 	public static function extract($array, array $paths, $default = NULL)
@@ -392,7 +392,7 @@ class Kohana_Arr {
 			{
 				$array[$key] = Arr::map($callbacks, $array[$key]);
 			}
-			elseif ( ! is_array($keys) or in_array($key, $keys))
+			elseif ( ! is_array($keys) OR in_array($key, $keys))
 			{
 				if (is_array($callbacks))
 				{

--- a/classes/Kohana/Config.php
+++ b/classes/Kohana/Config.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Wrapper for configuration arrays. Multiple configuration readers can be
  * attached to allow loading configuration from files, database, etc.

--- a/classes/Kohana/Config/File.php
+++ b/classes/Kohana/Config/File.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * File-based configuration reader. Multiple configuration directories can be
  * used by attaching multiple instances of this class to [Config].

--- a/classes/Kohana/Config/Group.php
+++ b/classes/Kohana/Config/Group.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 /**
  * The group wrapper acts as an interface to all the config directives

--- a/classes/Kohana/Config/Reader.php
+++ b/classes/Kohana/Config/Reader.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 /**
  * Interface for config readers

--- a/classes/Kohana/Config/Source.php
+++ b/classes/Kohana/Config/Source.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Base Config source Interface
  *

--- a/classes/Kohana/Config/Writer.php
+++ b/classes/Kohana/Config/Writer.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 /**
  * Interface for config writers

--- a/classes/Kohana/Controller.php
+++ b/classes/Kohana/Controller.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Abstract controller class. Controllers should only be created using a [Request].
  *

--- a/classes/Kohana/Controller/Template.php
+++ b/classes/Kohana/Controller/Template.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Abstract controller class for automatic templating.
  *

--- a/classes/Kohana/Cookie.php
+++ b/classes/Kohana/Cookie.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Cookie helper.
  *

--- a/classes/Kohana/Core.php
+++ b/classes/Kohana/Core.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Contains the most low-level helpers methods in Kohana:
  *
@@ -499,7 +499,7 @@ class Kohana_Core {
 		{
 			$namespace = substr($class, 0, $last_namespace_position);
 			$class     = substr($class, $last_namespace_position + 1);
-			$file      = str_replace('\\', DIRECTORY_SEPARATOR, $namespace) . DIRECTORY_SEPARATOR;
+			$file      = str_replace('\\', DIRECTORY_SEPARATOR, $namespace).DIRECTORY_SEPARATOR;
 		}
 
 		$file .= str_replace('_', DIRECTORY_SEPARATOR, $class);
@@ -1024,7 +1024,7 @@ class Kohana_Core {
 		if (Kohana::$errors AND $error = error_get_last() AND in_array($error['type'], Kohana::$shutdown_errors))
 		{
 			// Clean the output buffer
-			ob_get_level() and ob_clean();
+			ob_get_level() AND ob_clean();
 
 			// Fake an exception for nice debugging
 			Kohana_Exception::handler(new ErrorException($error['message'], $error['type'], 0, $error['file'], $error['line']));

--- a/classes/Kohana/Date.php
+++ b/classes/Kohana/Date.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Date helper.
  *

--- a/classes/Kohana/Debug.php
+++ b/classes/Kohana/Debug.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Contains debugging and dumping tools.
  *

--- a/classes/Kohana/Encrypt.php
+++ b/classes/Kohana/Encrypt.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * The Encrypt library provides two-way encryption of text and binary strings
  * using the [Mcrypt](http://php.net/mcrypt) extension, which consists of three

--- a/classes/Kohana/Exception.php
+++ b/classes/Kohana/Exception.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana_Exception extends Kohana_Kohana_Exception {}

--- a/classes/Kohana/Feed.php
+++ b/classes/Kohana/Feed.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * RSS and Atom feed helper.
  *
@@ -52,7 +52,7 @@ class Kohana_Feed {
 		if ($feed === FALSE)
 			return array();
 
-		$namespaces = $feed->getNamespaces(true);
+		$namespaces = $feed->getNamespaces(TRUE);
 
 		// Detect the feed type. RSS 1.0/2.0 and Atom 1.0 are supported.
 		$feed = isset($feed->channel) ? $feed->xpath('//item') : $feed->entry;

--- a/classes/Kohana/File.php
+++ b/classes/Kohana/File.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * File helper class.
  *

--- a/classes/Kohana/Form.php
+++ b/classes/Kohana/Form.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Form helper class. Unless otherwise noted, all generated HTML will be made
  * safe using the [HTML::chars] method. This prevents against simple XSS

--- a/classes/Kohana/Fragment.php
+++ b/classes/Kohana/Fragment.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * View fragment caching. This is primarily used to cache small parts of a view
  * that rarely change. For instance, you may want to cache the footer of your

--- a/classes/Kohana/HTML.php
+++ b/classes/Kohana/HTML.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * HTML helper class. Provides generic methods for generating various HTML
  * tags and making output HTML safe.

--- a/classes/Kohana/HTTP.php
+++ b/classes/Kohana/HTTP.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Contains the most low-level helpers methods in Kohana:
  *

--- a/classes/Kohana/HTTP/Exception.php
+++ b/classes/Kohana/HTTP/Exception.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 abstract class Kohana_HTTP_Exception extends Kohana_Exception {
 

--- a/classes/Kohana/HTTP/Exception/300.php
+++ b/classes/Kohana/HTTP/Exception/300.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana_HTTP_Exception_300 extends HTTP_Exception_Redirect {
 

--- a/classes/Kohana/HTTP/Exception/301.php
+++ b/classes/Kohana/HTTP/Exception/301.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana_HTTP_Exception_301 extends HTTP_Exception_Redirect {
 

--- a/classes/Kohana/HTTP/Exception/302.php
+++ b/classes/Kohana/HTTP/Exception/302.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana_HTTP_Exception_302 extends HTTP_Exception_Redirect {
 

--- a/classes/Kohana/HTTP/Exception/303.php
+++ b/classes/Kohana/HTTP/Exception/303.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana_HTTP_Exception_303 extends HTTP_Exception_Redirect {
 

--- a/classes/Kohana/HTTP/Exception/304.php
+++ b/classes/Kohana/HTTP/Exception/304.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana_HTTP_Exception_304 extends HTTP_Exception_Expected {
 

--- a/classes/Kohana/HTTP/Exception/305.php
+++ b/classes/Kohana/HTTP/Exception/305.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana_HTTP_Exception_305 extends HTTP_Exception_Expected {
 

--- a/classes/Kohana/HTTP/Exception/307.php
+++ b/classes/Kohana/HTTP/Exception/307.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana_HTTP_Exception_307 extends HTTP_Exception_Redirect {
 

--- a/classes/Kohana/HTTP/Exception/400.php
+++ b/classes/Kohana/HTTP/Exception/400.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana_HTTP_Exception_400 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/401.php
+++ b/classes/Kohana/HTTP/Exception/401.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana_HTTP_Exception_401 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/402.php
+++ b/classes/Kohana/HTTP/Exception/402.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana_HTTP_Exception_402 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/403.php
+++ b/classes/Kohana/HTTP/Exception/403.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana_HTTP_Exception_403 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/404.php
+++ b/classes/Kohana/HTTP/Exception/404.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana_HTTP_Exception_404 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/405.php
+++ b/classes/Kohana/HTTP/Exception/405.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana_HTTP_Exception_405 extends HTTP_Exception_Expected {
 

--- a/classes/Kohana/HTTP/Exception/406.php
+++ b/classes/Kohana/HTTP/Exception/406.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana_HTTP_Exception_406 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/407.php
+++ b/classes/Kohana/HTTP/Exception/407.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana_HTTP_Exception_407 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/408.php
+++ b/classes/Kohana/HTTP/Exception/408.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana_HTTP_Exception_408 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/409.php
+++ b/classes/Kohana/HTTP/Exception/409.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana_HTTP_Exception_409 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/410.php
+++ b/classes/Kohana/HTTP/Exception/410.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana_HTTP_Exception_410 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/411.php
+++ b/classes/Kohana/HTTP/Exception/411.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana_HTTP_Exception_411 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/412.php
+++ b/classes/Kohana/HTTP/Exception/412.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana_HTTP_Exception_412 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/413.php
+++ b/classes/Kohana/HTTP/Exception/413.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana_HTTP_Exception_413 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/414.php
+++ b/classes/Kohana/HTTP/Exception/414.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana_HTTP_Exception_414 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/415.php
+++ b/classes/Kohana/HTTP/Exception/415.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana_HTTP_Exception_415 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/416.php
+++ b/classes/Kohana/HTTP/Exception/416.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana_HTTP_Exception_416 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/417.php
+++ b/classes/Kohana/HTTP/Exception/417.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana_HTTP_Exception_417 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/500.php
+++ b/classes/Kohana/HTTP/Exception/500.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana_HTTP_Exception_500 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/501.php
+++ b/classes/Kohana/HTTP/Exception/501.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana_HTTP_Exception_501 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/502.php
+++ b/classes/Kohana/HTTP/Exception/502.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana_HTTP_Exception_502 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/503.php
+++ b/classes/Kohana/HTTP/Exception/503.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana_HTTP_Exception_503 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/504.php
+++ b/classes/Kohana/HTTP/Exception/504.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana_HTTP_Exception_504 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/505.php
+++ b/classes/Kohana/HTTP/Exception/505.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Kohana_HTTP_Exception_505 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/Expected.php
+++ b/classes/Kohana/HTTP/Exception/Expected.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * "Expected" HTTP exception class. Used for all [HTTP_Exception]'s where a standard
  * Kohana error page should never be shown. 

--- a/classes/Kohana/HTTP/Exception/Redirect.php
+++ b/classes/Kohana/HTTP/Exception/Redirect.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Redirect HTTP exception class. Used for all [HTTP_Exception]'s where the status
  * code indicates a redirect.

--- a/classes/Kohana/HTTP/Header.php
+++ b/classes/Kohana/HTTP/Header.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * The Kohana_HTTP_Header class provides an Object-Orientated interface
  * to HTTP headers. This can parse header arrays returned from the
@@ -294,7 +294,7 @@ class Kohana_HTTP_Header extends ArrayObject {
 		 *
 		 * HTTP header declarations should be treated as case-insensitive
 		 */
-		$input = array_change_key_case((array) $input, CASE_LOWER);
+		$input = array_change_key_case( (array) $input, CASE_LOWER);
 
 		parent::__construct($input, $flags, $iterator_class);
 	}
@@ -421,7 +421,7 @@ class Kohana_HTTP_Header extends ArrayObject {
 		 *
 		 * HTTP header declarations should be treated as case-insensitive
 		 */
-		$input = array_change_key_case((array) $input, CASE_LOWER);
+		$input = array_change_key_case( (array) $input, CASE_LOWER);
 
 		return parent::exchangeArray($input);
 	}
@@ -887,8 +887,7 @@ class Kohana_HTTP_Header extends ArrayObject {
 
 		if ( ! isset($headers['content-type']))
 		{
-			$processed_headers[] = 'Content-Type: '.Kohana::$content_type.
-				'; charset='.Kohana::$charset;
+			$processed_headers[] = 'Content-Type: '.Kohana::$content_type.'; charset='.Kohana::$charset;
 		}
 
 		if (Kohana::$expose AND ! isset($headers['x-powered-by']))

--- a/classes/Kohana/HTTP/Message.php
+++ b/classes/Kohana/HTTP/Message.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * The HTTP Interaction interface providing the core HTTP methods that
  * should be implemented by any HTTP request or response class.

--- a/classes/Kohana/HTTP/Request.php
+++ b/classes/Kohana/HTTP/Request.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * A HTTP Request specific interface that adds the methods required
  * by HTTP requests. Over and above [Kohana_HTTP_Interaction], this

--- a/classes/Kohana/HTTP/Response.php
+++ b/classes/Kohana/HTTP/Response.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * A HTTP Reponse specific interface that adds the methods required
  * by HTTP responses. Over and above [Kohana_HTTP_Interaction], this

--- a/classes/Kohana/I18n.php
+++ b/classes/Kohana/I18n.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Internationalization (i18n) class. Provides language loading and translation
  * methods without dependencies on [gettext](http://php.net/gettext).

--- a/classes/Kohana/Inflector.php
+++ b/classes/Kohana/Inflector.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Inflector helper class. Inflection is changing the form of a word based on
  * the context it is used in. For example, changing a word into a plural form.

--- a/classes/Kohana/Kohana/Exception.php
+++ b/classes/Kohana/Kohana/Exception.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct access');
+<?php defined('SYSPATH') OR die('No direct access');
 /**
  * Kohana exception class. Translates exceptions using the [I18n] class.
  *
@@ -118,7 +118,7 @@ class Kohana_Kohana_Exception extends Exception {
 			 * but to bail. Hard.
 			 */
 			// Clean the output buffer if one exists
-			ob_get_level() and ob_clean();
+			ob_get_level() AND ob_clean();
 
 			// Set the Status code to 500, and Content-Type to text/plain.
 			header('Content-Type: text/plain; charset='.Kohana::$charset, TRUE, 500);
@@ -224,7 +224,7 @@ class Kohana_Kohana_Exception extends Exception {
 						}
 
 						// XDebug also has a different name for the parameters array
-						if ( isset($frame['params']) && ! isset($frame['args']))
+						if (isset($frame['params']) AND ! isset($frame['args']))
 						{
 							$frame['args'] = $frame['params'];
 						}

--- a/classes/Kohana/Log.php
+++ b/classes/Kohana/Log.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Message logging with observer-based log writing.
  *

--- a/classes/Kohana/Log/File.php
+++ b/classes/Kohana/Log/File.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * File log writer. Writes out messages and stores them in a YYYY/MM directory.
  *

--- a/classes/Kohana/Log/StdErr.php
+++ b/classes/Kohana/Log/StdErr.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * STDERR log writer. Writes out messages to STDERR.
  *

--- a/classes/Kohana/Log/StdOut.php
+++ b/classes/Kohana/Log/StdOut.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * STDOUT log writer. Writes out messages to STDOUT.
  *

--- a/classes/Kohana/Log/Syslog.php
+++ b/classes/Kohana/Log/Syslog.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Syslog log writer.
  *
@@ -42,7 +42,7 @@ class Kohana_Log_Syslog extends Log_Writer {
 	{
 		foreach ($messages as $message)
 		{
-			if (Log::STRACE == $message['level'])
+			if ($message['level'] == Log::STRACE)
 			{
 				$message['level'] = Log::DEBUG;
 			}

--- a/classes/Kohana/Log/Writer.php
+++ b/classes/Kohana/Log/Writer.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Log writer abstract class. All [Log] writers must extend this class.
  *

--- a/classes/Kohana/Model.php
+++ b/classes/Kohana/Model.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Model base class. All models should extend this class.
  *

--- a/classes/Kohana/Num.php
+++ b/classes/Kohana/Num.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Number helper class. Provides additional formatting methods that for working
  * with numbers.
@@ -132,7 +132,7 @@ class Kohana_Num {
 	 * @param boolean $native Set to false to force use of the userland implementation
 	 * @return float Rounded number
 	 */
-	public static function round($value, $precision = 0, $mode = self::ROUND_HALF_UP, $native = true)
+	public static function round($value, $precision = 0, $mode = self::ROUND_HALF_UP, $native = TRUE)
 	{
 		if (version_compare(PHP_VERSION, '5.3', '>=') AND $native)
 		{

--- a/classes/Kohana/Profiler.php
+++ b/classes/Kohana/Profiler.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Provides simple benchmarking and profiling. To display the statistics that
  * have been collected, load the `profiler/stats` [View]:

--- a/classes/Kohana/Request.php
+++ b/classes/Kohana/Request.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Request. Uses the [Route] class to determine what
  * [Controller] to send the request to.

--- a/classes/Kohana/Request/Client/Curl.php
+++ b/classes/Kohana/Request/Client/Curl.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * [Request_Client_External] Curl driver performs external requests using the
  * php-curl extention. This is the default driver for all external requests.

--- a/classes/Kohana/Request/Client/External.php
+++ b/classes/Kohana/Request/Client/External.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * [Request_Client_External] provides a wrapper for all external request
  * processing. This class should be extended by all drivers handling external

--- a/classes/Kohana/Request/Client/HTTP.php
+++ b/classes/Kohana/Request/Client/HTTP.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * [Request_Client_External] HTTP driver performs external requests using the
  * php-http extention. To use this driver, ensure the following is completed

--- a/classes/Kohana/Request/Client/Internal.php
+++ b/classes/Kohana/Request/Client/Internal.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Request Client for internal execution
  *

--- a/classes/Kohana/Request/Client/Stream.php
+++ b/classes/Kohana/Request/Client/Stream.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * [Request_Client_External] Stream driver performs external requests using php
  * sockets. To use this driver, ensure the following is completed

--- a/classes/Kohana/Request/Exception.php
+++ b/classes/Kohana/Request/Exception.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * @package    Kohana
  * @category   Exceptions

--- a/classes/Kohana/Response.php
+++ b/classes/Kohana/Response.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Response wrapper. Created as the result of any [Request] execution
  * or utility method (i.e. Redirect). Implements standard HTTP

--- a/classes/Kohana/Route.php
+++ b/classes/Kohana/Route.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Routes are used to determine the controller and action for a requested URI.
  * Every route generates a regular expression which is used to match a URI

--- a/classes/Kohana/Security.php
+++ b/classes/Kohana/Security.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Security helper class.
  *

--- a/classes/Kohana/Session.php
+++ b/classes/Kohana/Session.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Base session class.
  *
@@ -425,7 +425,7 @@ abstract class Kohana_Session {
 	/**
 	 * Serializes the session data.
 	 *
-	 * @param   array    data
+	 * @param   array  $data  data
 	 * @return  string
 	 */
 	protected function _serialize($data)
@@ -436,7 +436,7 @@ abstract class Kohana_Session {
 	/**
 	 * Unserializes the session data.
 	 *
-	 * @param   string   data
+	 * @param   string  $data  data
 	 * @return  array
 	 */
 	protected function _unserialize($data)
@@ -447,7 +447,7 @@ abstract class Kohana_Session {
 	/**
 	 * Encodes the session data using [base64_encode].
 	 *
-	 * @param   string   data
+	 * @param   string  $data  data
 	 * @return  string
 	 */
 	protected function _encode($data)
@@ -458,7 +458,7 @@ abstract class Kohana_Session {
 	/**
 	 * Decodes the session data using [base64_decode].
 	 *
-	 * @param   string   data
+	 * @param   string  $data  data
 	 * @return  string
 	 */
 	protected function _decode($data)

--- a/classes/Kohana/Session/Cookie.php
+++ b/classes/Kohana/Session/Cookie.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Cookie-based session class.
  *

--- a/classes/Kohana/Session/Exception.php
+++ b/classes/Kohana/Session/Exception.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * @package    Kohana
  * @category   Exceptions

--- a/classes/Kohana/Session/Native.php
+++ b/classes/Kohana/Session/Native.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Native PHP session class.
  *

--- a/classes/Kohana/Text.php
+++ b/classes/Kohana/Text.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Text helper class. Provides simple methods for working with text.
  *

--- a/classes/Kohana/URL.php
+++ b/classes/Kohana/URL.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * URL helper class.
  *

--- a/classes/Kohana/UTF8.php
+++ b/classes/Kohana/UTF8.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * A port of [phputf8](http://phputf8.sourceforge.net/) to a unified set
  * of files. Provides multi-byte aware replacement string functions.

--- a/classes/Kohana/UTF8/Exception.php
+++ b/classes/Kohana/UTF8/Exception.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * @package    Kohana
  * @category   Exceptions

--- a/classes/Kohana/Upload.php
+++ b/classes/Kohana/Upload.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Upload helper class for working with uploaded files and [Validation].
  *

--- a/classes/Kohana/Valid.php
+++ b/classes/Kohana/Valid.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Validation rules.
  *
@@ -74,7 +74,7 @@ class Kohana_Valid {
 	{
 		if (is_array($length))
 		{
-			foreach($length as $strlen)
+			foreach ($length as $strlen)
 			{
 				if (UTF8::strlen($value) === $strlen)
 					return TRUE;

--- a/classes/Kohana/Validation.php
+++ b/classes/Kohana/Validation.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Array and variable validation.
  *

--- a/classes/Kohana/Validation/Exception.php
+++ b/classes/Kohana/Validation/Exception.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * @package    Kohana
  * @category   Exceptions

--- a/classes/Kohana/View.php
+++ b/classes/Kohana/View.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Acts as an object wrapper for HTML pages with embedded PHP, called "views".
  * Variables can be assigned with the view object and referenced locally within

--- a/classes/Kohana/View/Exception.php
+++ b/classes/Kohana/View/Exception.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * @package    Kohana
  * @category   Exceptions

--- a/classes/Log.php
+++ b/classes/Log.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Log extends Kohana_Log {}

--- a/classes/Log/File.php
+++ b/classes/Log/File.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Log_File extends Kohana_Log_File {}

--- a/classes/Log/StdErr.php
+++ b/classes/Log/StdErr.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Log_StdErr extends Kohana_Log_StdErr {}

--- a/classes/Log/StdOut.php
+++ b/classes/Log/StdOut.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Log_StdOut extends Kohana_Log_StdOut {}

--- a/classes/Log/Syslog.php
+++ b/classes/Log/Syslog.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Log_Syslog extends Kohana_Log_Syslog {}

--- a/classes/Log/Writer.php
+++ b/classes/Log/Writer.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 abstract class Log_Writer extends Kohana_Log_Writer {}

--- a/classes/Model.php
+++ b/classes/Model.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 abstract class Model extends Kohana_Model {}

--- a/classes/Num.php
+++ b/classes/Num.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Num extends Kohana_Num {}

--- a/classes/Profiler.php
+++ b/classes/Profiler.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Profiler extends Kohana_Profiler {}

--- a/classes/Request.php
+++ b/classes/Request.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Request extends Kohana_Request {}

--- a/classes/Request/Client.php
+++ b/classes/Request/Client.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 abstract class Request_Client extends Kohana_Request_Client {}

--- a/classes/Request/Client/Curl.php
+++ b/classes/Request/Client/Curl.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Request_Client_Curl extends Kohana_Request_Client_Curl {}

--- a/classes/Request/Client/External.php
+++ b/classes/Request/Client/External.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 abstract class Request_Client_External extends Kohana_Request_Client_External {}

--- a/classes/Request/Client/HTTP.php
+++ b/classes/Request/Client/HTTP.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Request_Client_HTTP extends Kohana_Request_Client_HTTP {}

--- a/classes/Request/Client/Internal.php
+++ b/classes/Request/Client/Internal.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Request_Client_Internal extends Kohana_Request_Client_Internal {}

--- a/classes/Request/Client/Stream.php
+++ b/classes/Request/Client/Stream.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Request_Client_Stream extends Kohana_Request_Client_Stream {}

--- a/classes/Request/Exception.php
+++ b/classes/Request/Exception.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * @package    Kohana
  * @category   Exceptions

--- a/classes/Response.php
+++ b/classes/Response.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Response extends Kohana_Response {}

--- a/classes/Route.php
+++ b/classes/Route.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Route extends Kohana_Route {}

--- a/classes/Security.php
+++ b/classes/Security.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Security extends Kohana_Security {}

--- a/classes/Session.php
+++ b/classes/Session.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 abstract class Session extends Kohana_Session {}

--- a/classes/Session/Cookie.php
+++ b/classes/Session/Cookie.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Session_Cookie extends Kohana_Session_Cookie {}

--- a/classes/Session/Exception.php
+++ b/classes/Session/Exception.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * @package    Kohana
  * @category   Exceptions

--- a/classes/Session/Native.php
+++ b/classes/Session/Native.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Session_Native extends Kohana_Session_Native {}

--- a/classes/Text.php
+++ b/classes/Text.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Text extends Kohana_Text {}

--- a/classes/URL.php
+++ b/classes/URL.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class URL extends Kohana_URL {}

--- a/classes/UTF8.php
+++ b/classes/UTF8.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class UTF8 extends Kohana_UTF8 {}

--- a/classes/UTF8/Exception.php
+++ b/classes/UTF8/Exception.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * @package    Kohana
  * @category   Exceptions

--- a/classes/Upload.php
+++ b/classes/Upload.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Upload extends Kohana_Upload {}

--- a/classes/Valid.php
+++ b/classes/Valid.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Valid extends Kohana_Valid {}

--- a/classes/Validation.php
+++ b/classes/Validation.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Validation extends Kohana_Validation {}

--- a/classes/Validation/Exception.php
+++ b/classes/Validation/Exception.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class Validation_Exception extends Kohana_Validation_Exception {}

--- a/classes/View.php
+++ b/classes/View.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 class View extends Kohana_View {}

--- a/classes/View/Exception.php
+++ b/classes/View/Exception.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * @package    Kohana
  * @category   Exceptions

--- a/config/credit_cards.php
+++ b/config/credit_cards.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Credit card validation configuration.
  *

--- a/config/curl.php
+++ b/config/curl.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 return array(
 	CURLOPT_USERAGENT      => 'Mozilla/5.0 (compatible; Kohana v'.Kohana::VERSION.' +http://kohanaframework.org/)',

--- a/config/encrypt.php
+++ b/config/encrypt.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 return array(
 

--- a/config/inflector.php
+++ b/config/inflector.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 return array(
 

--- a/config/mimes.php
+++ b/config/mimes.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * A list of mime types. Our list is generally more complete and accurate than
  * the operating system MIME list.

--- a/config/session.php
+++ b/config/session.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 return array(
 	'cookie' => array(

--- a/config/user_agents.php
+++ b/config/user_agents.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 return array(
 

--- a/config/userguide.php
+++ b/config/userguide.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 return array(
 	// Leave this alone

--- a/guide/kohana/extension.md
+++ b/guide/kohana/extension.md
@@ -10,7 +10,7 @@ The default Kohana classes, and many extensions, use this definition so that alm
 
 For instance, if you wanted to create method that sets encrypted cookies using the [Encrypt] class, you would create a file at `application/classes/cookie.php` that extends Kohana_Cookie, and adds your functions:
 
-    <?php defined('SYSPATH') or die('No direct script access.');
+    <?php defined('SYSPATH') OR die('No direct script access.');
 
     class Cookie extends Kohana_Cookie {
 

--- a/guide/kohana/files/config.md
+++ b/guide/kohana/files/config.md
@@ -2,7 +2,7 @@
 
 Configuration files are used to store any kind of configuration needed for a module, class, or anything else you want.  They are plain PHP files, stored in the `config/` directory, which return an associative array:
 
-    <?php defined('SYSPATH') or die('No direct script access.');
+    <?php defined('SYSPATH') OR die('No direct script access.');
 
     return array(
         'setting' => 'value',
@@ -24,7 +24,7 @@ For example, if we wanted to change or add to an entry in the inflector configur
 
     // config/inflector.php
 
-    <?php defined('SYSPATH') or die('No direct script access.');
+    <?php defined('SYSPATH') OR die('No direct script access.');
 
     return array(
         'irregular' => array(
@@ -39,7 +39,7 @@ Let's say we want a config file to store and easily change things like the title
 
     // config/site.php
 
-    <?php defined('SYSPATH') or die('No direct script access.');
+    <?php defined('SYSPATH') OR die('No direct script access.');
 
     return array(
         'title' => 'Our Shiny Website',
@@ -52,7 +52,7 @@ Let's say we want an archive of versions of some software.  We could use config 
 
 	// config/versions.php
 
-	<?php defined('SYSPATH') or die('No direct script access.');
+	<?php defined('SYSPATH') OR die('No direct script access.');
 	
     return array(
 		'1.0.0' => array(

--- a/guide/kohana/security/encryption.md
+++ b/guide/kohana/security/encryption.md
@@ -8,7 +8,7 @@ Next, copy the default config/encryption.php from system/config folder to your a
 
 The default Encryption config file that ships with Kohana 3.2.x looks like this:
 
-    <?php defined('SYSPATH') or die('No direct script access.');
+    <?php defined('SYSPATH') OR die('No direct script access.');
 
     return array(
 
@@ -42,7 +42,7 @@ It is strongly recommended that you choose a high-strength random key using the 
 
 Here's a sample encryption configuration with three types of encryption defined. **If you copy this example, please change your keys!**
 
-    <?php defined('SYSPATH') or die('No direct script access.');
+    <?php defined('SYSPATH') OR die('No direct script access.');
     // application/config/encrypt.php
 
     return array(

--- a/i18n/en.php
+++ b/i18n/en.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 return array();

--- a/i18n/es.php
+++ b/i18n/es.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 return array
 (

--- a/i18n/fr.php
+++ b/i18n/fr.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 return array
 (

--- a/messages/validation.php
+++ b/messages/validation.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 
 return array(
 	'alpha'         => ':field must contain only letters',

--- a/tests/kohana/ArrTest.php
+++ b/tests/kohana/ArrTest.php
@@ -530,11 +530,11 @@ class Kohana_ArrTest extends Unittest_TestCase
 	{
 		$range = Arr::range($step, $max);
 
-		$this->assertSame((int) floor($max / $step), count($range));
+		$this->assertSame( (int) floor($max / $step), count($range));
 
 		$current = $step;
 
-		foreach($range as $key => $value)
+		foreach ($range as $key => $value)
 		{
 			$this->assertSame($key, $value);
 			$this->assertSame($current, $key);

--- a/tests/kohana/Config/GroupTest.php
+++ b/tests/kohana/Config/GroupTest.php
@@ -35,7 +35,7 @@ class Kohana_Config_GroupTest extends Kohana_Unittest_TestCase
 	 */
 	public function get_mock_group($group, $config = array(), $instance = NULL)
 	{
-		if($instance === NULL)
+		if ($instance === NULL)
 		{
 			$instance = $this->get_mock_config();
 		}

--- a/tests/kohana/Http/HeaderTest.php
+++ b/tests/kohana/Http/HeaderTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * Unit Tests for Kohana_HTTP_Header
  *
@@ -59,8 +59,8 @@ class Kohana_HTTP_HeaderTest extends Unittest_TestCase {
 	 * 
 	 * @dataProvider provider_accept_quality
 	 *
-	 * @param   array     input
-	 * @param   array     expected output
+	 * @param   array  $parts     input
+	 * @param   array  $expected  expected output
 	 * @return  void
 	 */
 	public function test_accept_quality(array $parts, array $expected)
@@ -121,8 +121,8 @@ class Kohana_HTTP_HeaderTest extends Unittest_TestCase {
 	 * 
 	 * @dataProvider provider_parse_accept_header
 	 *
-	 * @param   string    accept in
-	 * @param   array     expected out
+	 * @param   string  $accept    accept in
+	 * @param   array   $expected  expected out
 	 * @return  void
 	 */
 	public function test_parse_accept_header($accept, array $expected)
@@ -171,8 +171,8 @@ class Kohana_HTTP_HeaderTest extends Unittest_TestCase {
 	 * 
 	 * @dataProvider provider_parse_charset_header
 	 *
-	 * @param   string    accept 
-	 * @param   array     expected 
+	 * @param   string  $accept    accept 
+	 * @param   array   $expected  expected 
 	 * @return  void
 	 */
 	public function test_parse_charset_header($accept, array $expected)
@@ -225,8 +225,8 @@ class Kohana_HTTP_HeaderTest extends Unittest_TestCase {
 	 * 
 	 * @dataProvider provider_parse_encoding_header
 	 *
-	 * @param   string    accept 
-	 * @param   array     expected 
+	 * @param   string  $accept    accept 
+	 * @param   array   $expected  expected 
 	 * @return  void
 	 */
 	public function test_parse_encoding_header($accept, array $expected)
@@ -294,8 +294,8 @@ class Kohana_HTTP_HeaderTest extends Unittest_TestCase {
 	 * 
 	 * @dataProvider provider_parse_language_header
 	 * 
-	 * @param   string    accept 
-	 * @param   array     expected 
+	 * @param   string  $accept    accept 
+	 * @param   array   $expected  expected 
 	 * @return  void
 	 */
 	public function test_parse_language_header($accept, array $expected)
@@ -347,8 +347,8 @@ class Kohana_HTTP_HeaderTest extends Unittest_TestCase {
 	 * 
 	 * @dataProvider provider_create_cache_control
 	 *
-	 * @param   array     input 
-	 * @param   string    expected 
+	 * @param   array   $input     input 
+	 * @param   string  $expected  expected 
 	 * @return  void
 	 */
 	public function test_create_cache_control(array $input, $expected)
@@ -400,8 +400,8 @@ class Kohana_HTTP_HeaderTest extends Unittest_TestCase {
 	 *
 	 * @dataProvider provider_parse_cache_control
 	 * 
-	 * @param   string    input 
-	 * @param   array     expected 
+	 * @param   string  $input     input 
+	 * @param   array   $expected  expected 
 	 * @return  void
 	 */
 	public function test_parse_cache_control($input, array $expected)
@@ -521,9 +521,9 @@ class Kohana_HTTP_HeaderTest extends Unittest_TestCase {
 	 *
 	 * @dataProvider provider_offsetSet
 	 * 
-	 * @param   array     constructor
-	 * @param   array     to_set 
-	 * @param   array     expected
+	 * @param   array  $constructor  constructor
+	 * @param   array  $to_set       to_set 
+	 * @param   array  $expected     expected
 	 * @return  void
 	 */
 	public function test_offsetSet(array $constructor, array $to_set, array $expected)
@@ -553,7 +553,7 @@ class Kohana_HTTP_HeaderTest extends Unittest_TestCase {
 				array(
 					'FoO'   => 'bar',
 					'START' => 'end',
-					'true'  => true
+					'true'  => TRUE
 				),
 				'FOO',
 				'bar'
@@ -562,25 +562,25 @@ class Kohana_HTTP_HeaderTest extends Unittest_TestCase {
 				array(
 					'FoO'   => 'bar',
 					'START' => 'end',
-					'true'  => true
+					'true'  => TRUE
 				),
 				'true',
-				true
+				TRUE
 			),
 			array(
 				array(
 					'FoO'   => 'bar',
 					'START' => 'end',
-					'true'  => true
+					'true'  => TRUE
 				),
 				'True',
-				true
+				TRUE
 			),
 			array(
 				array(
 					'FoO'   => 'bar',
 					'START' => 'end',
-					'true'  => true
+					'true'  => TRUE
 				),
 				'Start',
 				'end'
@@ -666,9 +666,9 @@ class Kohana_HTTP_HeaderTest extends Unittest_TestCase {
 	 * 
 	 * @dataProvider provider_offsetExists
 	 *
-	 * @param   array    state 
-	 * @param   string   key 
-	 * @param   boolean  expected 
+	 * @param   array    $state     state 
+	 * @param   string   $key       key 
+	 * @param   boolean  $expected  expected 
 	 * @return  void
 	 */
 	public function test_offsetExists(array $state, $key, $expected)
@@ -730,9 +730,9 @@ class Kohana_HTTP_HeaderTest extends Unittest_TestCase {
 	 *
 	 * @dataProvider provider_offsetUnset
 	 *
-	 * @param   array     state 
-	 * @param   string    remove 
-	 * @param   array     expected 
+	 * @param   array   $state     state 
+	 * @param   string  $remove    remove 
+	 * @param   array   $expected  expected 
 	 * @return  void
 	 */
 	public function test_offsetUnset(array $state, $remove, array $expected)

--- a/tests/kohana/NumTest.php
+++ b/tests/kohana/NumTest.php
@@ -195,7 +195,7 @@ class Kohana_NumTest extends Unittest_TestCase
 	{
 		foreach (array(Num::ROUND_HALF_UP, Num::ROUND_HALF_DOWN, Num::ROUND_HALF_EVEN, Num::ROUND_HALF_ODD) as $i => $mode)
 		{
-			$this->assertSame($expected[$i], Num::round($input, $precision, $mode, false));
+			$this->assertSame($expected[$i], Num::round($input, $precision, $mode, FALSE));
 		}
 	}
 }

--- a/tests/kohana/RequestTest.php
+++ b/tests/kohana/RequestTest.php
@@ -534,7 +534,7 @@ class Kohana_RequestTest extends Unittest_TestCase
 	{
 		foreach ($headers as $key => $expected_value)
 		{
-			$this->assertSame((string) $request->headers($key), $expected_value);
+			$this->assertSame( (string) $request->headers($key), $expected_value);
 		}
 	}
 

--- a/tests/kohana/ValidationTest.php
+++ b/tests/kohana/ValidationTest.php
@@ -443,7 +443,7 @@ class Kohana_ValidationTest extends Unittest_TestCase
 		$current = i18n::lang();
 		i18n::lang('es');
 
-		foreach($rules as $field => $field_rules)
+		foreach ($rules as $field => $field_rules)
 		{
 			$validation->rules($field, $field_rules);
 		}

--- a/utf8/from_unicode.php
+++ b/utf8/from_unicode.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * UTF8::from_unicode
  *

--- a/utf8/ltrim.php
+++ b/utf8/ltrim.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * UTF8::ltrim
  *

--- a/utf8/ord.php
+++ b/utf8/ord.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * UTF8::ord
  *

--- a/utf8/rtrim.php
+++ b/utf8/rtrim.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * UTF8::rtrim
  *

--- a/utf8/str_ireplace.php
+++ b/utf8/str_ireplace.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * UTF8::str_ireplace
  *

--- a/utf8/str_pad.php
+++ b/utf8/str_pad.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * UTF8::str_pad
  *

--- a/utf8/str_split.php
+++ b/utf8/str_split.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * UTF8::str_split
  *

--- a/utf8/strcasecmp.php
+++ b/utf8/strcasecmp.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * UTF8::strcasecmp
  *

--- a/utf8/strcspn.php
+++ b/utf8/strcspn.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * UTF8::strcspn
  *

--- a/utf8/stristr.php
+++ b/utf8/stristr.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * UTF8::stristr
  *

--- a/utf8/strlen.php
+++ b/utf8/strlen.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * UTF8::strlen
  *

--- a/utf8/strpos.php
+++ b/utf8/strpos.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * UTF8::strpos
  *

--- a/utf8/strrev.php
+++ b/utf8/strrev.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * UTF8::strrev
  *

--- a/utf8/strrpos.php
+++ b/utf8/strrpos.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * UTF8::strrpos
  *

--- a/utf8/strspn.php
+++ b/utf8/strspn.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * UTF8::strspn
  *

--- a/utf8/strtolower.php
+++ b/utf8/strtolower.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * UTF8::strtolower
  *

--- a/utf8/strtoupper.php
+++ b/utf8/strtoupper.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * UTF8::strtoupper
  *

--- a/utf8/substr.php
+++ b/utf8/substr.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * UTF8::substr
  *

--- a/utf8/substr_replace.php
+++ b/utf8/substr_replace.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * UTF8::substr_replace
  *

--- a/utf8/to_unicode.php
+++ b/utf8/to_unicode.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * UTF8::to_unicode
  *

--- a/utf8/trim.php
+++ b/utf8/trim.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * UTF8::trim
  *

--- a/utf8/ucfirst.php
+++ b/utf8/ucfirst.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * UTF8::ucfirst
  *

--- a/utf8/ucwords.php
+++ b/utf8/ucwords.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * UTF8::ucwords
  *

--- a/views/profiler/stats.php
+++ b/views/profiler/stats.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.') ?>
+<?php defined('SYSPATH') OR die('No direct script access.') ?>
 
 <style type="text/css">
 <?php include Kohana::find_file('views', 'profiler/style', 'css') ?>


### PR DESCRIPTION
- I was not able to modify UTF-8 file: "expected OR but found or" core/utf8/transliterate_to_ascii.php:1
- "Function name "__" is invalid; only PHP magic functions should be prefixed with a double underscore" core/classes/Kohana/I18n.php:155
- "Method name "exchangeArray" is not in all lowercase using underscores for word separators" core/classes/Kohana/HTTP/Header.php:417
- "Whitespace before a closing parenthesis is not allowed" core/classes/Kohana/Arr.php:443
- "Whitespace before a closing parenthesis is not allowed" core/classes/Kohana/Arr.php:475
