### PR TITLE
Fix linkrot on intro page, remove other 301 redirects

### DIFF
--- a/guide/kohana/index.md
+++ b/guide/kohana/index.md
@@ -1,23 +1,19 @@
 # What is Kohana?
 
-Kohana is an open source, [object oriented](http://wikipedia.org/wiki/Object-Oriented_Programming) [MVC](http://wikipedia.org/wiki/Model–View–Controller "Model View Controller") [web framework](http://wikipedia.org/wiki/Web_Framework) built using [PHP5](http://php.net/manual/intro-whatis "PHP Hypertext Preprocessor") by a team of volunteers that aims to be swift, secure, and small.
+Kohana is an open source, [object oriented](http://en.wikipedia.org/wiki/Object-oriented_programming) [MVC](http://en.wikipedia.org/wiki/Model–view–controller "Model View Controller") [web framework](http://en.wikipedia.org/wiki/Web_application_framework) built using [PHP5](http://php.net/manual/intro-whatis "PHP Hypertext Preprocessor") by a team of volunteers that aims to be swift, secure, and small.
 
 [!!] Kohana is licensed under a [BSD license](http://kohanaframework.org/license), so you can legally use it for any kind of open source, commercial, or personal project.
 
 ## What makes Kohana great?
 
-Anything can be extended using the unique [filesystem](files) design, little or no [configuration](config) is
-necessary, [error handling](errors) helps locate the source of errors quickly, and [debugging](debugging) and [profiling](profiling) provide insight into the application.
+Anything can be extended using the unique [filesystem](files) design, little or no [configuration](config) is necessary, [error handling](errors) helps locate the source of errors quickly, and [debugging](debugging) and [profiling](profiling) provide insight into the application.
 
-To help secure your applications, tools for [input validation](security/validation),
-[signed cookies](security/cookies), [Form] and [HTML] generators are all included. The
- [database](security/database) layer provides protection against [SQL injection](http://wikipedia
- .org/wiki/SQL_Injection). Of course, all official code is carefully written and reviewed for security.
+To help secure your applications, tools for [input validation](security/validation), [signed cookies](security/cookies), [form](../../guide-api/form) and [HTML](../../guide-api/html) generators are all included. The [database](security/database) layer provides protection against [SQL injection](http://wikipedia.org/wiki/SQL_injection). Of course, all official code is carefully written and reviewed for security.
 
 ## Contribute to the Documentation
 
-We are working very hard to provide complete documentation. To help improve the guide, please [fork the userguide](http://github.com/kohana/userguide), make your changes, and send a pull request. If you are not familiar with git, you can also submit a [feature request](http://dev.kohanaframework.org/projects/kohana3/issues) (requires registration).
+We are working very hard to provide complete documentation. To help improve the guide, please [fork the userguide](http://github.com/kohana/userguide), make your changes, and send a pull request. If you are not familiar with Git, you can also submit a [feature request](http://dev.kohanaframework.org/projects/kohana3/issues) (requires registration).
 
 ## Unofficial Documentation
 
-If you are having trouble finding an answer here, have a look through the [unofficial wiki](http://kerkness.ca/wiki/doku.php). Your answer may also be found by searching the [forum](http://forum.kohanaphp.com/) or [stackoverflow](http://stackoverflow.com/questions/tagged/kohana) followed by asking your question on either.  Additionally, you can chat with the community of developers on the freenode [#kohana](irc://irc.freenode.net/kohana) IRC channel.  
+If you are having trouble finding an answer here, have a look through the [unofficial wiki](http://kerkness.ca/kowiki/doku.php). Your answer may also be found by searching the [forum](http://forum.kohanaframework.org/) or [Stack Overflow](http://stackoverflow.com/questions/tagged/kohana) followed by asking your question on either.  Additionally, you can chat with the community of developers on the freenode [#kohana](irc://irc.freenode.net/kohana) IRC channel.

--- a/guide/kohana/index.md
+++ b/guide/kohana/index.md
@@ -8,7 +8,7 @@ Kohana is an open source, [object oriented](http://en.wikipedia.org/wiki/Object-
 
 Anything can be extended using the unique [filesystem](files) design, little or no [configuration](config) is necessary, [error handling](errors) helps locate the source of errors quickly, and [debugging](debugging) and [profiling](profiling) provide insight into the application.
 
-To help secure your applications, tools for [input validation](security/validation), [signed cookies](security/cookies), [form](../../guide-api/form) and [HTML](../../guide-api/html) generators are all included. The [database](security/database) layer provides protection against [SQL injection](http://wikipedia.org/wiki/SQL_injection). Of course, all official code is carefully written and reviewed for security.
+To help secure your applications, tools for [input validation](security/validation), [signed cookies](security/cookies), [form] and [HTML] generators are all included. The [database](security/database) layer provides protection against [SQL injection](http://wikipedia.org/wiki/SQL_injection). Of course, all official code is carefully written and reviewed for security.
 
 ## Contribute to the Documentation
 


### PR DESCRIPTION
Links on the index are all pointing to URLs that have moved either out there in the Internet or internally to the guide itself. 

This fixes up those linkrot issues as well as point to the canonical location on several Wikipedia articles instead of their redirects.

Also 
- "Stack Overflow" the site has a space between the words
- "Git" should be capitalised for the application.
