### PR TITLE
3.3/cleanup

### DIFF
--- a/guide/kohana/install.md
+++ b/guide/kohana/install.md
@@ -5,8 +5,27 @@
 3. Upload the contents of this folder to your webserver.
 4. Open `application/bootstrap.php` and make the following changes:
 	- Set the default [timezone](http://php.net/timezones) for your application.
+		
+		~~~
+			// Example of changing timezone from Chicago to Sao Paulo, Brazil
+			date_default_timezone_set('America/Sao_Paulo');
+		~~~
 	- Set the `base_url` in the [Kohana::init] call to reflect the location of the kohana folder on your server relative to the document root.
+
+		~~~
+			// Example of kohana's installation at /var/www/mywebsite and
+			// Apache's DocumentRoot configured to /var/www
+			Kohana::init(array(
+				'base_url'   => '/mywebsite',
+			));
+		~~~	
 6. Make sure the `application/cache` and `application/logs` directories are writable by the web server.
+
+	~~~
+		sudo chmod 777 -R application/cache
+		sudo chmod 777 -R application/logs
+	~~~
+	
 7. Test your installation by opening the URL you set as the `base_url` in your favorite browser.
 
 [!!] Depending on your platform, the installation's subdirs may have lost their permissions thanks to zip extraction. Chmod them all to 755 by running `find . -type d -exec chmod 0755 {} \;` from the root of your Kohana installation.

--- a/tests/kohana/ConfigTest.php
+++ b/tests/kohana/ConfigTest.php
@@ -381,7 +381,7 @@ class Kohana_ConfigTest extends Unittest_TestCase
 		// Due to crazy limitations in phpunit's mocking engine we have to be fairly
 		// liberal here as to what order we receive the config items
 		// Good news is that order shouldn't matter *yay*
-		//
+		// 
 		// Now save your eyes and skip the next... 13 lines!
 		$key = $this->logicalOr('pie', 'kohana');
 		$val = $this->logicalOr('good', 'awesome');

--- a/tests/kohana/CookieTest.php
+++ b/tests/kohana/CookieTest.php
@@ -21,7 +21,9 @@ class Kohana_CookieTest extends Unittest_TestCase
 	/**
 	 * Sets up the environment
 	 */
+	// @codingStandardsIgnoreStart
 	public function setUp()
+	// @codingStandardsIgnoreEnd
 	{
 		parent::setUp();
 
@@ -31,7 +33,9 @@ class Kohana_CookieTest extends Unittest_TestCase
 	/**
 	 * Tears down the environment
 	 */
+	// @codingStandardsIgnoreStart
 	public function tearDown()
+	// @codingStandardsIgnoreEnd
 	{
 		parent::tearDown();
 
@@ -64,8 +68,9 @@ class Kohana_CookieTest extends Unittest_TestCase
 	 */
 	public function test_set($key, $value, $exp, $expected)
 	{
-		if (headers_sent())
+		if (headers_sent()) {
 			$this->markTestSkipped('Cannot test setting cookies as headers have already been sent');
+		}
 
 		$this->assertSame($expected, cookie::set($key, $value, $exp));
 	}
@@ -100,8 +105,9 @@ class Kohana_CookieTest extends Unittest_TestCase
 	 */
 	public function test_get($key, $value, $expected)
 	{
-		if (headers_sent())
+		if (headers_sent()) {
 			$this->markTestSkipped('Cannot test setting cookies as headers have already been sent');
+		}
 
 		// Force $_COOKIE
 		if ($key !== NULL)
@@ -135,8 +141,9 @@ class Kohana_CookieTest extends Unittest_TestCase
 	 */
 	public function test_delete($key, $expected)
 	{
-		if (headers_sent())
+		if (headers_sent()) {
 			$this->markTestSkipped('Cannot test setting cookies as headers have already been sent');
+		}
 
 		$this->assertSame($expected, cookie::delete($key));
 	}

--- a/tests/kohana/DateTest.php
+++ b/tests/kohana/DateTest.php
@@ -21,7 +21,9 @@ class Kohana_DateTest extends Unittest_TestCase
 	/**
 	 * Ensures we have a consistant timezone for testing.
 	 */
+	// @codingStandardsIgnoreStart
 	public function setUp()
+	// @codingStandardsIgnoreEnd
 	{
 		parent::setUp();
 
@@ -33,7 +35,9 @@ class Kohana_DateTest extends Unittest_TestCase
 	/**
 	 * Restores original timezone after testing.
 	 */
+	// @codingStandardsIgnoreStart
 	public function tearDown()
+	// @codingStandardsIgnoreEnd
 	{
 		date_default_timezone_set($this->_original_timezone);
 

--- a/tests/kohana/FormTest.php
+++ b/tests/kohana/FormTest.php
@@ -20,11 +20,13 @@ class Kohana_FormTest extends Unittest_TestCase
 	 * Defaults for this test
 	 * @var array
 	 */
+	// @codingStandardsIgnoreStart
 	protected $environmentDefault = array(
 		'Kohana::$base_url' => '/',
 		'HTTP_HOST' => 'kohanaframework.org',
 		'Kohana::$index_file' => '',
 	);
+	// @codingStandardsIgnoreEnd
 
 	/**
 	 * Provides test data for test_open()

--- a/tests/kohana/HTMLTest.php
+++ b/tests/kohana/HTMLTest.php
@@ -16,12 +16,18 @@
  */
 class Kohana_HTMLTest extends Unittest_TestCase
 {
+	/**
+	 * Defaults for this test
+	 * @var array
+	 */
+	// @codingStandardsIgnoreStart
 	protected $environmentDefault = array(
 		'Kohana::$base_url'    => '/kohana/',
 		'Kohana::$index_file'  => 'index.php',
 		'HTML::$strict' => TRUE,
 		'HTTP_HOST'	=> 'www.kohanaframework.org',
 	);
+	// @codingStandardsIgnoreStart
 
 	/**
 	 * Provides test data for test_attributes()

--- a/tests/kohana/HTTPTest.php
+++ b/tests/kohana/HTTPTest.php
@@ -15,11 +15,17 @@
  */
 class Kohana_HTTPTest extends Unittest_TestCase {
 
+	/**
+	 * Defaults for this test
+	 * @var array
+	 */
+	// @codingStandardsIgnoreStart
 	protected $environmentDefault = array(
 		'Kohana::$base_url'    => '/kohana/',
 		'Kohana::$index_file'  => 'index.php',
 		'HTTP_HOST'	           => 'www.example.com',
 	);
+	// @codingStandardsIgnoreEnd
 
 	/**
 	 * Provides test data for test_attributes()

--- a/tests/kohana/Http/HeaderTest.php
+++ b/tests/kohana/Http/HeaderTest.php
@@ -429,7 +429,9 @@ class Kohana_HTTP_HeaderTest extends Unittest_TestCase {
 	 *
 	 * @return  array
 	 */
+	// @codingStandardsIgnoreStart
 	public function provider_offsetSet()
+	// @codingStandardsIgnoreEnd
 	{
 		return array(
 			array(
@@ -526,7 +528,9 @@ class Kohana_HTTP_HeaderTest extends Unittest_TestCase {
 	 * @param   array  $expected     expected
 	 * @return  void
 	 */
+	// @codingStandardsIgnoreStart
 	public function test_offsetSet(array $constructor, array $to_set, array $expected)
+	// @codingStandardsIgnoreEnd
 	{
 		$http_header = new HTTP_Header($constructor);
 
@@ -546,7 +550,9 @@ class Kohana_HTTP_HeaderTest extends Unittest_TestCase {
 	 *
 	 * @return  array
 	 */
+	// @codingStandardsIgnoreStart
 	public function provider_offsetGet()
+	// @codingStandardsIgnoreEnd
 	{
 		return array(
 			array(
@@ -607,7 +613,9 @@ class Kohana_HTTP_HeaderTest extends Unittest_TestCase {
 	 * @param   mixed     expected
 	 * @return  void
 	 */
+	// @codingStandardsIgnoreStart
 	public function test_offsetGet(array $state, $key, $expected)
+	// @codingStandardsIgnoreEnd
 	{
 		$header = new HTTP_Header($state);
 
@@ -619,7 +627,9 @@ class Kohana_HTTP_HeaderTest extends Unittest_TestCase {
 	 *
 	 * @return  array
 	 */
+	// @codingStandardsIgnoreStart
 	public function provider_offsetExists()
+	// @codingStandardsIgnoreEnd
 	{
 		return array(
 			array(
@@ -671,7 +681,9 @@ class Kohana_HTTP_HeaderTest extends Unittest_TestCase {
 	 * @param   boolean  $expected  expected 
 	 * @return  void
 	 */
+	// @codingStandardsIgnoreStart
 	public function test_offsetExists(array $state, $key, $expected)
+	// @codingStandardsIgnoreEnd
 	{
 		$header = new HTTP_Header($state);
 
@@ -683,7 +695,9 @@ class Kohana_HTTP_HeaderTest extends Unittest_TestCase {
 	 *
 	 * @return  array
 	 */
+	// @codingStandardsIgnoreStart
 	public function provider_offsetUnset()
+	// @codingStandardsIgnoreEnd
 	{
 		return array(
 			array(
@@ -735,7 +749,9 @@ class Kohana_HTTP_HeaderTest extends Unittest_TestCase {
 	 * @param   array   $expected  expected 
 	 * @return  void
 	 */
+	// @codingStandardsIgnoreStart
 	public function test_offsetUnset(array $state, $remove, array $expected)
+	// @codingStandardsIgnoreEnd
 	{
 		$header = new HTTP_Header($state);
 		$header->offsetUnset($remove);

--- a/tests/kohana/I18nTest.php
+++ b/tests/kohana/I18nTest.php
@@ -20,9 +20,11 @@ class Kohana_I18nTest extends Unittest_TestCase {
 	 * Default values for the environment, see setEnvironment
 	 * @var array
 	 */
+	// @codingStandardsIgnoreStart
 	protected $environmentDefault =	array(
 		'I18n::$lang' => 'en-us',
 	);
+	// @codingStandardsIgnoreEnd
 
 	/**
 	 * Provides test data for test_lang()

--- a/tests/kohana/InflectorTest.php
+++ b/tests/kohana/InflectorTest.php
@@ -175,9 +175,9 @@ class Kohana_InflectorTest extends Unittest_TestCase
 	 *
 	 * @test
 	 * @dataProvider provider_decamelize
-	 * @param string Camelized string
-	 * @param string Glue
-	 * @param string Expected string
+	 * @param string $input Camelized string
+	 * @param string $glue Glue
+	 * @param string $expected Expected string
 	 */
 	public function test_decamelize($input, $glue, $expected)
 	{

--- a/tests/kohana/NumTest.php
+++ b/tests/kohana/NumTest.php
@@ -20,7 +20,9 @@ class Kohana_NumTest extends Unittest_TestCase
 	/**
 	 * SetUp test enviroment
 	 */
+	// @codingStandardsIgnoreStart
 	public function setUp()
+	// @codingStandardsIgnoreEnd
 	{
 		parent::setUp();
 
@@ -30,7 +32,9 @@ class Kohana_NumTest extends Unittest_TestCase
 	/**
 	 * Tear down environment
 	 */
+	// @codingStandardsIgnoreStart
 	public function tearDown()
+	// @codingStandardsIgnoreEnd
 	{
 		parent::tearDown();
 

--- a/tests/kohana/RequestTest.php
+++ b/tests/kohana/RequestTest.php
@@ -18,14 +18,18 @@ class Kohana_RequestTest extends Unittest_TestCase
 {
 	protected $_inital_request;
 
+	// @codingStandardsIgnoreStart
 	public function setUp()
+	// @codingStandardsIgnoreEnd
 	{
 		parent::setUp();
 		$this->_initial_request = Request::$initial;
 		Request::$initial = new Request('/');
 	}
 
+	// @codingStandardsIgnoreStart
 	public function tearDown()
+	// @codingStandardsIgnoreEnd
 	{
 		Request::$initial = $this->_initial_request;
 		parent::tearDown();

--- a/tests/kohana/RouteTest.php
+++ b/tests/kohana/RouteTest.php
@@ -22,7 +22,9 @@ class Kohana_RouteTest extends Unittest_TestCase
 	/**
 	 * Remove all caches
 	 */
+	// @codingStandardsIgnoreStart
 	public function setUp()
+	// @codingStandardsIgnoreEnd
 	{
 		parent::setUp();
 
@@ -32,7 +34,9 @@ class Kohana_RouteTest extends Unittest_TestCase
 	/**
 	 * Removes cache files created during tests
 	 */
+	// @codingStandardsIgnoreStart
 	public function tearDown()
+	// @codingStandardsIgnoreEnd
 	{
 		parent::tearDown();
 

--- a/tests/kohana/SecurityTest.php
+++ b/tests/kohana/SecurityTest.php
@@ -96,8 +96,9 @@ class Kohana_SecurityTest extends Unittest_TestCase
 	 */
 	public function test_csrf_token($expected, $input, $iteration)
 	{
-		if (headers_sent())
+		if (headers_sent()) {
 			$this->markTestSkipped('Headers have already been sent, session not available');
+		}
 
 		Security::$token_name = 'token_'.$iteration;
 		$this->assertSame(TRUE, $input);

--- a/tests/kohana/SessionTest.php
+++ b/tests/kohana/SessionTest.php
@@ -22,7 +22,9 @@ class Kohana_SessionTest extends Unittest_TestCase
 	 *
 	 * @return Session
 	 */
+	// @codingStandardsIgnoreStart
 	public function getMockSession(array $config = array())
+	// @codingStandardsIgnoreEnd
 	{
 		return $this->getMockForAbstractClass('Session', array($config));
 	}

--- a/tests/kohana/TextTest.php
+++ b/tests/kohana/TextTest.php
@@ -16,7 +16,9 @@ class Kohana_TextTest extends Unittest_TestCase
 	/**
 	 * Sets up the test enviroment
 	 */
+	// @codingStandardsIgnoreStart
 	function setUp()
+	// @codingStandardsIgnoreEnd
 	{
 		parent::setUp();
 

--- a/tests/kohana/URLTest.php
+++ b/tests/kohana/URLTest.php
@@ -20,12 +20,14 @@ class Kohana_URLTest extends Unittest_TestCase
 	 * Default values for the environment, see setEnvironment
 	 * @var array
 	 */
+	// @codingStandardsIgnoreStart
 	protected $environmentDefault =	array(
 		'Kohana::$base_url'	=> '/kohana/',
 		'Kohana::$index_file'=> 'index.php',
 		'HTTP_HOST' => 'example.com',
 		'_GET'		=> array(),
 	);
+	// @codingStandardsIgnoreEnd
 
 	/**
 	 * Provides test data for test_base()

--- a/tests/kohana/UploadTest.php
+++ b/tests/kohana/UploadTest.php
@@ -79,7 +79,7 @@ class Kohana_UploadTest extends Unittest_TestCase
 	 * @param string $field the files field to test
 	 * @param string $bytes valid bite size
 	 * @param array $environment set the $_FILES array
-	 * @param $expected what to expect
+	 * @param bool $expected what to expect
 	 */
 	public function test_size($field, $bytes, $environment, $expected)
 	{

--- a/tests/kohana/ValidTest.php
+++ b/tests/kohana/ValidTest.php
@@ -831,9 +831,9 @@ class Kohana_ValidTest extends Unittest_TestCase
 	 *
 	 * @test
 	 * @dataProvider provider_regex
-	 * @param string Value to test against
-	 * @param string Valid pcre regular expression
-	 * @param bool Does the value match the expression?
+	 * @param string $value Value to test against
+	 * @param string $regex Valid pcre regular expression
+	 * @param bool $expected Does the value match the expression?
 	 */
 	public function test_regex($value, $regex, $expected)
 	{

--- a/tests/kohana/ValidationTest.php
+++ b/tests/kohana/ValidationTest.php
@@ -589,7 +589,9 @@ class Kohana_ValidationTest extends Unittest_TestCase
 		$this->assertSame($data, $validation->data());
 	}
 
+	// @codingStandardsIgnoreStart
 	public function test_offsetExists()
+	// @codingStandardsIgnoreEnd
 	{
 		$array = array(
 			'one' => 'Hello',
@@ -604,7 +606,9 @@ class Kohana_ValidationTest extends Unittest_TestCase
 		$this->assertFalse(isset($validation['five']));
 	}
 
+	// @codingStandardsIgnoreStart
 	public function test_offsetSet_throws_exception()
+	// @codingStandardsIgnoreEnd
 	{
 		$this->setExpectedException('Kohana_Exception');
 
@@ -614,7 +618,9 @@ class Kohana_ValidationTest extends Unittest_TestCase
 		$validation['field'] = 'something';
 	}
 
+	// @codingStandardsIgnoreStart
 	public function test_offsetGet()
+	// @codingStandardsIgnoreEnd
 	{
 		$array = array(
 			'one' => 'Hello',
@@ -629,7 +635,9 @@ class Kohana_ValidationTest extends Unittest_TestCase
 		$this->assertSame($array['ten'], $validation['ten']);
 	}
 
+	// @codingStandardsIgnoreStart
 	public function test_offsetUnset()
+	// @codingStandardsIgnoreEnd
 	{
 		$this->setExpectedException('Kohana_Exception');
 

--- a/tests/kohana/ViewTest.php
+++ b/tests/kohana/ViewTest.php
@@ -22,7 +22,9 @@ class Kohana_ViewTest extends Unittest_TestCase
 	 *
 	 * @return null
 	 */
+	// @codingStandardsIgnoreStart
 	public static function setupBeforeClass()
+	// @codingStandardsIgnoreEnd
 	{
 		self::$old_modules = Kohana::modules();
 
@@ -37,7 +39,9 @@ class Kohana_ViewTest extends Unittest_TestCase
 	 *
 	 * @return null
 	 */
+	// @codingStandardsIgnoreStart
 	public static function teardownAfterClass()
+	// @codingStandardsIgnoreEnd
 	{
 		Kohana::modules(self::$old_modules);
 	}

--- a/tests/kohana/request/ClientTest.php
+++ b/tests/kohana/request/ClientTest.php
@@ -270,7 +270,8 @@ class Kohana_Request_ClientTest extends Unittest_TestCase
 			// Straightforward response manipulation
 			array(
 				array('X-test-1' =>
-					function($request, $response, $client){
+					function($request, $response, $client)
+					{
 						$response->body(json_encode(array('body'=>'test1-body-changed')));
 						return $response;
 				}),
@@ -280,7 +281,8 @@ class Kohana_Request_ClientTest extends Unittest_TestCase
 			// Subsequent request execution
 			array(
 				array('X-test-2' =>
-					function($request, $response, $client){
+					function($request, $response, $client)
+					{
 						return Request::factory($response->headers('X-test-2'));
 				}),
 				$this->_dummy_uri(200,
@@ -291,7 +293,8 @@ class Kohana_Request_ClientTest extends Unittest_TestCase
 			// No callbacks triggered
 			array(
 				array('X-test-3' =>
-					function ($request, $response, $client) {
+					function ($request, $response, $client)
+					{
 						throw new Exception("Unexpected execution of X-test-3 callback");
 				}),
 				$this->_dummy_uri(200, array('X-test-1' => 'foo'), 'test3-body'),
@@ -301,11 +304,13 @@ class Kohana_Request_ClientTest extends Unittest_TestCase
 			array(
 				array(
 					'X-test-1' =>
-						function($request, $response, $client){
+						function($request, $response, $client)
+						{
 							return Request::factory($response->headers('X-test-1'));
 						},
 					'X-test-2' =>
-						function($request, $response, $client){
+						function($request, $response, $client)
+						{
 							return Request::factory($response->headers('X-test-2'));
 						}
 				),
@@ -321,11 +326,13 @@ class Kohana_Request_ClientTest extends Unittest_TestCase
 			array(
 				array(
 					'X-test-1' =>
-						function($request, $response, $client){
+						function($request, $response, $client)
+						{
 							return Request::factory($response->headers('X-test-1'));
 						},
 					'X-test-2' =>
-						function($request, $response, $client){
+						function($request, $response, $client)
+						{
 							return Request::factory($response->headers('X-test-2'));
 						}
 				),
@@ -381,7 +388,8 @@ class Kohana_Request_ClientTest extends Unittest_TestCase
 					$uri,
 					array(
 						'header_callbacks' => array(
-							'x-cb' => function ($request, $response, $client)
+							'x-cb' => 
+								function ($request, $response, $client)
 								{
 									$client->callback_params('testcase')->requests_executed++;
 									// Recurse into a new request

--- a/tests/kohana/request/client/ExternalTest.php
+++ b/tests/kohana/request/client/ExternalTest.php
@@ -63,9 +63,9 @@ class Kohana_Request_Client_ExternalTest extends Unittest_TestCase {
 	 * 
 	 * @dataProvider provider_factory
 	 *
-	 * @param   array    params 
-	 * @param   string   client 
-	 * @param   Request_Client_External expected 
+	 * @param   array   $params  params 
+	 * @param   string  $client  client 
+	 * @param   Request_Client_External $expected expected 
 	 * @return  void
 	 */
 	public function test_factory($params, $client, $expected)
@@ -109,9 +109,9 @@ class Kohana_Request_Client_ExternalTest extends Unittest_TestCase {
 	 *
 	 * @dataProvider provider_options
 	 * 
-	 * @param   mixed     key 
-	 * @param   mixed     value 
-	 * @param   array     expected 
+	 * @param   mixed  $key  key 
+	 * @param   mixed  $value  value 
+	 * @param   array  $expected  expected 
 	 * @return  void
 	 */
 	public function test_options($key, $value, $expected)

--- a/utf8/transliterate_to_ascii.php
+++ b/utf8/transliterate_to_ascii.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') OR die('No direct script access.');
 /**
  * UTF8::transliterate_to_ascii
  *


### PR DESCRIPTION
One error left in kohana-core, which is a mistake in the definition file.
There is a possibility that I broke the UTF-8 tests. Those files should probably be changed to hex encoded instead of the actual characters.

Now fixed the UTF-8 tests.
