### PR TITLE
Added missing 'expose' comment to Kohana::init() refs #4180

### DIFF
--- a/classes/kohana/cli.php
+++ b/classes/kohana/cli.php
@@ -22,7 +22,7 @@ class Kohana_CLI {
 	 * @param   string  $options,...    option name
 	 * @return  array
 	 */
-	public static function options($options)
+	public static function options()
 	{
 		// Get all of the requested options
 		$options = func_get_args();

--- a/classes/kohana/core.php
+++ b/classes/kohana/core.php
@@ -182,6 +182,7 @@ class Kohana_Core {
 	 * `boolean` | errors     | Should Kohana catch PHP errors and uncaught Exceptions and show the `error_view`. See [Error Handling](kohana/errors) for more info. <br /> <br /> Recommended setting: `TRUE` while developing, `FALSE` on production servers. | `TRUE`
 	 * `boolean` | profile    | Whether to enable the [Profiler](kohana/profiling). <br /> <br />Recommended setting: `TRUE` while developing, `FALSE` on production servers. | `TRUE`
 	 * `boolean` | caching    | Cache file locations to speed up [Kohana::find_file].  This has nothing to do with [Kohana::cache], [Fragments](kohana/fragments) or the [Cache module](cache).  <br /> <br />  Recommended setting: `FALSE` while developing, `TRUE` on production servers. | `FALSE`
+	 * `boolean` | expose     | Set the X-Powered-By header
 	 *
 	 * @throws  Kohana_Exception
 	 * @param   array   $settings   Array of settings.  See above.


### PR DESCRIPTION
This also effects 3.3/develop, so ideally it will need merging into that branch too
