### PR TITLE
revamped Feed Helper

### DIFF
--- a/classes/kohana/feed.php
+++ b/classes/kohana/feed.php
@@ -1,4 +1,4 @@
-<?php //defined('SYSPATH') or die('No direct script access.');
+<?php defined('SYSPATH') or die('No direct script access.');
 /**
  * RSS and Atom feed helper.
  *
@@ -8,252 +8,252 @@
  */
 class Kohana_Feed {
 
-	const FEED_FORMAT_ATOM = 'atom';
-	const FEED_FORMAT_RSS2 = 'rss2';
+    const FEED_FORMAT_ATOM = 'atom';
+    const FEED_FORMAT_RSS2 = 'rss2';
 
-	private $format = self::FEED_FORMAT_RSS2;
-	private $encoding = 'UTF-8';
+    private $format = self::FEED_FORMAT_RSS2;
+    private $encoding = 'UTF-8';
 
-	private $feed = array();
-	private $entry = array();
-	private $current_entry = array();
-
-
-	/**
-	 * setter for encoding
-	 */
-	public function set_encoding($encoding)
-	{
-		return $this->encoding = $encoding;
-	}
-
-	/**
-	 * setter for format
-	 */
-	public function set_format($format)
-	{
-		if (in_array($format, array(self::FEED_FORMAT_ATOM, self::FEED_FORMAT_RSS2)))
-		{
-			return $this->format = $format;
-		}
-		throw new Exception('invalid feed format');
-	}
-
-	/**
-	 * add one field to field
-	 * 
-	 * when $value is a scalar
-	 * <field attribue1="foo">value</field>
-	 * 
-	 * when $value is an array
-	 * <field attribue1="foo">
-	 *   <name>foo</name>
-	 *   <url>example.com</url>
-	 * </field>
-	 *
-	 * when $value is null
-	 * <field attribute1="foo" />
-	 *
-	 * @param	string 	tag name
-	 * @param	mixed  	tag value
-	 * @param	array   set of tag attributes as key value pairs
-	 */ 
-	public function add_feed_info($field, $value = null, array $attributes = array())
-	{
-		$this->feed[] = array($field, $value, $attributes);
-	}
-
-	/**
-	 * add one field to current entry
-	 *
-	 */
-	public function add_entry_info($field, $value = null, array $attributes = array())
-	{
-		$this->current_entry[] = array($field, $value, $attributes);
-	}
+    private $feed = array();
+    private $entry = array();
+    private $current_entry = array();
 
 
-	/**
-	 * close current entry and open a new one
-	 */
-	public function next_entry()
-	{
-		if (!empty($this->current_entry))
-		{
-			$this->entry[] = $this->current_entry;
-			$this->current_entry = array();
-		}
-	}
+    /**
+     * Setter for encoding
+     */
+    public function set_encoding($encoding)
+    {
+    	return $this->encoding = $encoding;
+    }
 
-	/**
-	 * ouput XML from data collected
-	 *
-	 */
-	public function render() 
-	{	
-		$this->next_entry();
-		switch ($this->format)
-		{
-			case self::FEED_FORMAT_ATOM:
-				$feed = simplexml_load_string('<?xml version="1.0" encoding="'.$this->encoding.'"?><feed xmlns="http://www.w3.org/2005/Atom"></feed>');
-				$entry_tag = 'entry';
-				break;
-			case self::FEED_FORMAT_RSS2:
-			default:
-				$feed = simplexml_load_string('<?xml version="1.0" encoding="'.$this->encoding.'"?><rss version="2.0"><channel></channel></rss>');
-				$entry_tag = 'item';
-				break;
+    /**
+     * Setter for format
+     */
+    public function set_format($format)
+    {
+    	if (in_array($format, array(self::FEED_FORMAT_ATOM, self::FEED_FORMAT_RSS2)))
+    	{
+    		return $this->format = $format;
+    	}
+    	throw new Exception('invalid feed format');
+    }
 
-		}
+    /**
+     * Add one field to field
+     * 
+     * When $value is a scalar
+     * <field attribue1="foo">value</field>
+     * 
+     * When $value is an array
+     * <field attribue1="foo">
+     *   <name>foo</name>
+     *   <url>example.com</url>
+     * </field>
+     *
+     * When $value is null
+     * <field attribute1="foo" />
+     *
+     * @param	string 	tag name
+     * @param	mixed  	tag value
+     * @param	array   set of tag attributes as key value pairs
+     */ 
+    public function add_feed_info($field, $value = null, array $attributes = array())
+    {
+    	$this->feed[] = array($field, $value, $attributes);
+    }
 
-		$this->push_fields($this->feed, $feed);
-		foreach ($this->entry as $entry)
-		{
-			$curr_entry = $feed->addChild($entry_tag);
-			$this->push_fields($entry, $curr_entry);
-		}
-
-		// DOM is preferred, as it generates more readable XML
-		if (function_exists('dom_import_simplexml'))
-		{
-			$feed = dom_import_simplexml($feed)->ownerDocument;
-			$feed->formatOutput = TRUE;
-			return $feed->saveXML();
-		}
-
-		// Export the document as XML
-		return $feed->asXML();
-	}
-
-	/**
-	 * helper which handles pushing sub fields and attributes
-	 *
-	 * @param array 
-	 * @param simplexml object
-	 */
-	protected function push_fields($fields, $sxo)
-	{
-		foreach ($fields as $curr)
-		{
-			list($field, $value, $attributes) = $curr;
-
-			if (is_array($value))
-			{
-				$child = $sxo->addChild($field);
-				foreach ($value as $subfield => $subvalue)
-				{
-					$child->addChild($subfield, $this->scrub_field($subfield, $subvalue));
-				}
-			}
-			else
-			{	
-				$child = $sxo->addChild($field, $this->scrub_field($field, $value));
-			}
-			foreach ($attributes as $attribute_name => $attribute_value)
-			{
-				$child->addAttribute($attribute_name, $this->scrub_field($attribute_name, $attribute_value));
-			}
-		}
-	}
+    /**
+     * Add one field to current entry
+     *
+     */
+    public function add_entry_info($field, $value = null, array $attributes = array())
+    {
+    	$this->current_entry[] = array($field, $value, $attributes);
+    }
 
 
-	/**
-	 * filters field values
-	 *
-	 * currently it tries to detect URL fields and attributes, and set them with current site domain if not already set.
-	 * may be extended to do more.
-	 * 
-	 * @param 	string	tag name
-	 * @param   string	tag value
-	 * @return	string  scrubbed value
-	 */
-	protected function scrub_field($field, $value)
-	{
-		if (in_array($field, array('href','url','uri','link'))
-			&& strpos($value, '://') === FALSE
-			&& !empty($value)
-		)
-		{
-			return URL::site($value, 'http');
-		}
-		return $value;
-	}
+    /**
+     * Close current entry and open a new one
+     */
+    public function next_entry()
+    {
+    	if (!empty($this->current_entry))
+    	{
+    		$this->entry[] = $this->current_entry;
+    		$this->current_entry = array();
+    	}
+    }
 
-	/**
-	 * Parses a remote feed into an array.
-	 *
-	 * @param   string   remote feed URL
-	 * @param   integer  item limit to fetch
-	 * @return  array
-	 */
-	public static function parse($feed, $limit = 0)
-	{
-		// Check if SimpleXML is installed
-		if ( ! function_exists('simplexml_load_file'))
-			throw new Kohana_Exception('SimpleXML must be installed!');
+    /**
+     * Ouput XML from data collected
+     *
+     */
+    public function render() 
+    {	
+    	$this->next_entry();
+    	switch ($this->format)
+    	{
+    		case self::FEED_FORMAT_ATOM:
+    			$feed = simplexml_load_string('<?xml version="1.0" encoding="'.$this->encoding.'"?><feed xmlns="http://www.w3.org/2005/Atom"></feed>');
+    			$entry_tag = 'entry';
+    			break;
+    		case self::FEED_FORMAT_RSS2:
+    		default:
+    			$feed = simplexml_load_string('<?xml version="1.0" encoding="'.$this->encoding.'"?><rss version="2.0"><channel></channel></rss>');
+    			$entry_tag = 'item';
+    			break;
 
-		// Make limit an integer
-		$limit = (int) $limit;
+    	}
 
-		// Disable error reporting while opening the feed
-		$error_level = error_reporting(0);
+    	$this->push_fields($this->feed, $feed);
+    	foreach ($this->entry as $entry)
+    	{
+    		$curr_entry = $feed->addChild($entry_tag);
+    		$this->push_fields($entry, $curr_entry);
+    	}
 
-		// Allow loading by filename or raw XML string
-		$load = (is_file($feed) OR Valid::url($feed)) ? 'simplexml_load_file' : 'simplexml_load_string';
+    	// DOM is preferred, as it generates more readable XML
+    	if (function_exists('dom_import_simplexml'))
+    	{
+    		$feed = dom_import_simplexml($feed)->ownerDocument;
+    		$feed->formatOutput = TRUE;
+    		return $feed->saveXML();
+    	}
 
-		// Load the feed
-		$feed = $load($feed, 'SimpleXMLElement', LIBXML_NOCDATA);
+    	// Export the document as XML
+    	return $feed->asXML();
+    }
 
-		// Restore error reporting
-		error_reporting($error_level);
+    /**
+     * Helper which handles pushing sub fields and attributes
+     *
+     * @param array 
+     * @param simplexml object
+     */
+    protected function push_fields($fields, $sxo)
+    {
+    	foreach ($fields as $curr)
+    	{
+    		list($field, $value, $attributes) = $curr;
 
-		// Feed could not be loaded
-		if ($feed === FALSE)
-			return array();
+    		if (is_array($value))
+    		{
+    			$child = $sxo->addChild($field);
+    			foreach ($value as $subfield => $subvalue)
+    			{
+    				$child->addChild($subfield, $this->scrub_field($subfield, $subvalue));
+    			}
+    		}
+    		else
+    		{	
+    			$child = $sxo->addChild($field, $this->scrub_field($field, $value));
+    		}
+    		foreach ($attributes as $attribute_name => $attribute_value)
+    		{
+    			$child->addAttribute($attribute_name, $this->scrub_field($attribute_name, $attribute_value));
+    		}
+    	}
+    }
 
-		$namespaces = $feed->getNamespaces(true);
 
-		// Detect the feed type. RSS 1.0/2.0 and Atom 1.0 are supported.
-		$feed = isset($feed->channel) ? $feed->xpath('//item') : $feed->entry;
+    /**
+     * Filters field values
+     *
+     * Currently it tries to detect URL fields and attributes, and set them with current site domain if not already set.
+     * May be extended to do more.
+     * 
+     * @param 	string	tag name
+     * @param   string	tag value
+     * @return	string  scrubbed value
+     */
+    protected function scrub_field($field, $value)
+    {
+    	if (in_array($field, array('href','url','uri','link'))
+    		&& strpos($value, '://') === FALSE
+    		&& !empty($value)
+    	)
+    	{
+    		return URL::site($value, 'http');
+    	}
+    	return $value;
+    }
 
-		$i = 0;
-		$items = array();
+    /**
+     * Parses a remote feed into an array.
+     *
+     * @param   string   remote feed URL
+     * @param   integer  item limit to fetch
+     * @return  array
+     */
+    public static function parse($feed, $limit = 0)
+    {
+    	// Check if SimpleXML is installed
+    	if ( ! function_exists('simplexml_load_file'))
+    		throw new Kohana_Exception('SimpleXML must be installed!');
 
-		foreach ($feed as $item)
-		{
-			if ($limit > 0 AND $i++ === $limit)
-				break;
-			$item_fields = (array) $item;
+    	// Make limit an integer
+    	$limit = (int) $limit;
 
-			// get namespaced tags
-			foreach ($namespaces as $ns)
-			{
-				$item_fields += (array) $item->children($ns);
-			}
-			$items[] = $item_fields;
-		}
+    	// Disable error reporting while opening the feed
+    	$error_level = error_reporting(0);
 
-		return $items;
-	}
+    	// Allow loading by filename or raw XML string
+    	$load = (is_file($feed) OR Valid::url($feed)) ? 'simplexml_load_file' : 'simplexml_load_string';
 
-	/**
-	 * Creates a feed from the given parameters.
-	 *
-	 * Deprecated
-	 * this function provides backwards compatability
-	 *
-	 * @param   array   feed information
-	 * @param   array   items to add to the feed
-	 * @param   string  define which format to use (rss2 or atom)
-	 * @param   string  define which encoding to use
-	 * @return  string
-	 */
-	public static function create($info, $items, $format = self::FEED_FORMAT_RSS2, $encoding = 'UTF-8')
-	{
+    	// Load the feed
+    	$feed = $load($feed, 'SimpleXMLElement', LIBXML_NOCDATA);
+
+    	// Restore error reporting
+    	error_reporting($error_level);
+
+    	// Feed could not be loaded
+    	if ($feed === FALSE)
+    		return array();
+
+    	$namespaces = $feed->getNamespaces(true);
+
+    	// Detect the feed type. RSS 1.0/2.0 and Atom 1.0 are supported.
+    	$feed = isset($feed->channel) ? $feed->xpath('//item') : $feed->entry;
+
+    	$i = 0;
+    	$items = array();
+
+    	foreach ($feed as $item)
+    	{
+    		if ($limit > 0 AND $i++ === $limit)
+    			break;
+    		$item_fields = (array) $item;
+
+    		// get namespaced tags
+    		foreach ($namespaces as $ns)
+    		{
+    			$item_fields += (array) $item->children($ns);
+    		}
+    		$items[] = $item_fields;
+    	}
+
+    	return $items;
+    }
+
+    /**
+     * Creates a feed from the given parameters.
+     *
+     * Deprecated
+     * This function provides backwards compatability
+     *
+     * @param   array   feed information
+     * @param   array   items to add to the feed
+     * @param   string  define which format to use (rss2 or atom)
+     * @param   string  define which encoding to use
+     * @return  string
+     */
+    public static function create($info, $items, $format = self::FEED_FORMAT_RSS2, $encoding = 'UTF-8')
+    {
 
         $info += array('title' => 'Generated Feed', 'link' => '', 'generator' => 'KohanaPHP');
 
-		$feed = new self();
+    	$feed = new self();
 
         $feed->set_encoding($encoding);
         $feed->set_format($format);
@@ -271,6 +271,6 @@ class Kohana_Feed {
 
         return $feed->render();
 
-	}
+    }
 
 } // End Feed

--- a/classes/kohana/feed.php
+++ b/classes/kohana/feed.php
@@ -7,241 +7,241 @@
  * @license    http://kohanaframework.org/license
  */
 class Kohana_Feed {
-	
-	const FEED_FORMAT_ATOM = 'atom';
-	const FEED_FORMAT_RSS2 = 'rss2';
+    
+    const FEED_FORMAT_ATOM = 'atom';
+    const FEED_FORMAT_RSS2 = 'rss2';
 
-	private $format = self::FEED_FORMAT_RSS2;
-	private $feed = array();
-	private $entry = array();
-	private $encoding = 'UTF-8';
-
-
-	/**
-	 * setter for encoding
-	 */
-	public function set_encoding($encoding)
-	{
-		return $this->encoding = $encoding;
-	}
-
-	/**
-	 * setter for format
-	 */
-	public function set_format($format)
-	{
-		if (in_array($format, array(self::FEED_FORMAT_ATOM, self::FEED_FORMAT_RSS2)))
-		{
-			return $this->format = $format;
-		}
-		throw new Exception('invalid feed format');
-	}
-
-	/**
-	 * add one field to field
-	 *
-	 */ 
-	public function add_feed_info($field, $value, array $attributes = array())
-	{
-		$this->feed[] = array($field, $value, $attributes);
-	}
-
-	/**
-	 * add one field to current entry
-	 *
-	 */
-	public function add_entry_info($field, $value, array $attributes = array())
-	{
-		$this->entry[] = array($field, $value, $attributes);
-	}
+    private $format = self::FEED_FORMAT_RSS2;
+    private $feed = array();
+    private $entry = array();
+    private $encoding = 'UTF-8';
 
 
-	/**
-	 * close current entry and open a new one
-	 */
-	public function next_entry()
-	{
-		if (!empty($this->entry))
-		{
-			$this->feed['entry'] = $this->entry;
-			$this->entry = array();
-		}
-	}
+    /**
+     * setter for encoding
+     */
+    public function set_encoding($encoding)
+    {
+        return $this->encoding = $encoding;
+    }
 
-	/**
-	 * ouput XML from data collected
-	 *
-	 */
-	public function render() 
-	{	
-		$this->next_entry();
-		switch ($this->format)
-		{
-			case self::FEED_FORMAT_ATOM:
-				$feed = simplexml_load_string('<?xml version="1.0" encoding="'.$encoding.'"?><feed xmlns="http://www.w3.org/2005/Atom"></feed>');
-				$entry_tag = 'entry';
-				break;
-			case self::FEED_FORMAT_RSS2:
-			default:
-				$feed = simplexml_load_string('<?xml version="1.0" encoding="'.$encoding.'"?><rss version="2.0"><channel></channel></rss>');
-				$entry_tag = 'item';
-				break;
+    /**
+     * setter for format
+     */
+    public function set_format($format)
+    {
+        if (in_array($format, array(self::FEED_FORMAT_ATOM, self::FEED_FORMAT_RSS2)))
+        {
+            return $this->format = $format;
+        }
+        throw new Exception('invalid feed format');
+    }
 
-		}
+    /**
+     * add one field to field
+     *
+     */ 
+    public function add_feed_info($field, $value, array $attributes = array())
+    {
+        $this->feed[] = array($field, $value, $attributes);
+    }
 
-		$this->push_fields($this->feed, $feed);
-		foreach ($this->entry as $entry)
-		{
-			$curr_entry = $feed->addChild($entry_tag);
-			$this->push_fields($entry, $curr_entry);
-		}
-
-		// DOM is preferred, as it generates more readable XML
-		if (function_exists('dom_import_simplexml'))
-		{
-			$feed = dom_import_simplexml($feed)->ownerDocument;
-			$feed->formatOutput = TRUE;
-			return $feed->saveXML();
-		}
-	
-		// Export the document as XML
-		return $feed->asXML();
-	}
-
-	/**
-	 * helper which handles pushing sub fields and attributes
-	 *
-	 */
-	protected function push_fields($fields, $sxo)
-	{
-		foreach ($fields as $curr)
-		{
-			list($field, $value, $attributes) = $curr;
-
-			if (is_array($value))
-			{
-				$child = $sxo->addChild($field);
-				foreach ($value as $subfield => $subvalue)
-				{
-					$child->addChild($subfield, $this->scrub_field($subfield, $subvalue));
-				}
-			}
-			else
-			{	
-				$child = $sxo->addChild($field, $this->scrub_field($field, $value));
-			}
-
-			foreach ($attributes as $attribute_name => $attribute_value)
-			{
-				$child->addAttribute($attribute_name, $this->scrub_field($attribute_name, $attribute_value));
-			}
-		}
-	}
+    /**
+     * add one field to current entry
+     *
+     */
+    public function add_entry_info($field, $value, array $attributes = array())
+    {
+        $this->entry[] = array($field, $value, $attributes);
+    }
 
 
-	/**
-	 * filters field values
-	 *
-	 * currently it tries to detect URL fields and attributes, and set them with current site domain if not already set.
-	 * may be extended to do more.
-	 */
-	protected function scrub_field($field, $value)
-	{
-		if (in_array($field, array('href','url','uri','link'))
-			&& strpos($value, '://') === FALSE)
-		{
-			return URL::site($value, 'http');
-		}
-		return $value;
-	}
+    /**
+     * close current entry and open a new one
+     */
+    public function next_entry()
+    {
+        if (!empty($this->entry))
+        {
+            $this->feed['entry'] = $this->entry;
+            $this->entry = array();
+        }
+    }
 
-	/**
-	 * Parses a remote feed into an array.
-	 *
-	 * @param   string   remote feed URL
-	 * @param   integer  item limit to fetch
-	 * @return  array
-	 */
-	public static function parse($feed, $limit = 0)
-	{
-		// Check if SimpleXML is installed
-		if ( ! function_exists('simplexml_load_file'))
-			throw new Kohana_Exception('SimpleXML must be installed!');
+    /**
+     * ouput XML from data collected
+     *
+     */
+    public function render() 
+    {    
+        $this->next_entry();
+        switch ($this->format)
+        {
+            case self::FEED_FORMAT_ATOM:
+                $feed = simplexml_load_string('<?xml version="1.0" encoding="'.$encoding.'"?><feed xmlns="http://www.w3.org/2005/Atom"></feed>');
+                $entry_tag = 'entry';
+                break;
+            case self::FEED_FORMAT_RSS2:
+            default:
+                $feed = simplexml_load_string('<?xml version="1.0" encoding="'.$encoding.'"?><rss version="2.0"><channel></channel></rss>');
+                $entry_tag = 'item';
+                break;
 
-		// Make limit an integer
-		$limit = (int) $limit;
+        }
 
-		// Disable error reporting while opening the feed
-		$error_level = error_reporting(0);
+        $this->push_fields($this->feed, $feed);
+        foreach ($this->entry as $entry)
+        {
+            $curr_entry = $feed->addChild($entry_tag);
+            $this->push_fields($entry, $curr_entry);
+        }
 
-		// Allow loading by filename or raw XML string
-		$load = (is_file($feed) OR Valid::url($feed)) ? 'simplexml_load_file' : 'simplexml_load_string';
+        // DOM is preferred, as it generates more readable XML
+        if (function_exists('dom_import_simplexml'))
+        {
+            $feed = dom_import_simplexml($feed)->ownerDocument;
+            $feed->formatOutput = TRUE;
+            return $feed->saveXML();
+        }
+    
+        // Export the document as XML
+        return $feed->asXML();
+    }
 
-		// Load the feed
-		$feed = $load($feed, 'SimpleXMLElement', LIBXML_NOCDATA);
+    /**
+     * helper which handles pushing sub fields and attributes
+     *
+     */
+    protected function push_fields($fields, $sxo)
+    {
+        foreach ($fields as $curr)
+        {
+            list($field, $value, $attributes) = $curr;
 
-		// Restore error reporting
-		error_reporting($error_level);
+            if (is_array($value))
+            {
+                $child = $sxo->addChild($field);
+                foreach ($value as $subfield => $subvalue)
+                {
+                    $child->addChild($subfield, $this->scrub_field($subfield, $subvalue));
+                }
+            }
+            else
+            {    
+                $child = $sxo->addChild($field, $this->scrub_field($field, $value));
+            }
 
-		// Feed could not be loaded
-		if ($feed === FALSE)
-			return array();
+            foreach ($attributes as $attribute_name => $attribute_value)
+            {
+                $child->addAttribute($attribute_name, $this->scrub_field($attribute_name, $attribute_value));
+            }
+        }
+    }
 
-		$namespaces = $feed->getNamespaces(true);
 
-		// Detect the feed type. RSS 1.0/2.0 and Atom 1.0 are supported.
-		$feed = isset($feed->channel) ? $feed->xpath('//item') : $feed->entry;
+    /**
+     * filters field values
+     *
+     * currently it tries to detect URL fields and attributes, and set them with current site domain if not already set.
+     * may be extended to do more.
+     */
+    protected function scrub_field($field, $value)
+    {
+        if (in_array($field, array('href','url','uri','link'))
+            && strpos($value, '://') === FALSE)
+        {
+            return URL::site($value, 'http');
+        }
+        return $value;
+    }
 
-		$i = 0;
-		$items = array();
+    /**
+     * Parses a remote feed into an array.
+     *
+     * @param   string   remote feed URL
+     * @param   integer  item limit to fetch
+     * @return  array
+     */
+    public static function parse($feed, $limit = 0)
+    {
+        // Check if SimpleXML is installed
+        if ( ! function_exists('simplexml_load_file'))
+            throw new Kohana_Exception('SimpleXML must be installed!');
 
-		foreach ($feed as $item)
-		{
-			if ($limit > 0 AND $i++ === $limit)
-				break;
-			$item_fields = (array) $item;
+        // Make limit an integer
+        $limit = (int) $limit;
 
-			// get namespaced tags
-			foreach ($namespaces as $ns)
-			{
-				$item_fields += (array) $item->children($ns);
-			}
-			$items[] = $item_fields;
-		}
+        // Disable error reporting while opening the feed
+        $error_level = error_reporting(0);
 
-		return $items;
-	}
+        // Allow loading by filename or raw XML string
+        $load = (is_file($feed) OR Valid::url($feed)) ? 'simplexml_load_file' : 'simplexml_load_string';
 
-	/**
-	 * Creates a feed from the given parameters.
-	 *
-	 * this function provides backwards compatability
-	 *
-	 * @param   array   feed information
-	 * @param   array   items to add to the feed
-	 * @param   string  define which format to use (rss2 or atom)
-	 * @param   string  define which encoding to use
-	 * @return  string
-	 */
-	public static function create($info, $items, $format = self::FEED_FORMAT_RSS2, $encoding = 'UTF-8')
-	{
-		$info += array('title' => 'Generated Feed', 'link' => '', 'generator' => 'KohanaPHP');
+        // Load the feed
+        $feed = $load($feed, 'SimpleXMLElement', LIBXML_NOCDATA);
 
-		$this->set_encoding($encoding);
-		$this->set_format($format);
+        // Restore error reporting
+        error_reporting($error_level);
 
-		foreach ($info as $field => $value)
-		{	
-			$this->set_feed_info($field, $value, array());
-		}
+        // Feed could not be loaded
+        if ($feed === FALSE)
+            return array();
 
-		foreach ($items as $item)
-		{
-			$this->next_entry();
-			foreach ($item as $field => $value) $this->set_entry_info($field, $value, array());
-		}
+        $namespaces = $feed->getNamespaces(true);
 
-		return $this->render();
-	}
+        // Detect the feed type. RSS 1.0/2.0 and Atom 1.0 are supported.
+        $feed = isset($feed->channel) ? $feed->xpath('//item') : $feed->entry;
+
+        $i = 0;
+        $items = array();
+
+        foreach ($feed as $item)
+        {
+            if ($limit > 0 AND $i++ === $limit)
+                break;
+            $item_fields = (array) $item;
+
+            // get namespaced tags
+            foreach ($namespaces as $ns)
+            {
+                $item_fields += (array) $item->children($ns);
+            }
+            $items[] = $item_fields;
+        }
+
+        return $items;
+    }
+
+    /**
+     * Creates a feed from the given parameters.
+     *
+     * this function provides backwards compatability
+     *
+     * @param   array   feed information
+     * @param   array   items to add to the feed
+     * @param   string  define which format to use (rss2 or atom)
+     * @param   string  define which encoding to use
+     * @return  string
+     */
+    public static function create($info, $items, $format = self::FEED_FORMAT_RSS2, $encoding = 'UTF-8')
+    {
+        $info += array('title' => 'Generated Feed', 'link' => '', 'generator' => 'KohanaPHP');
+
+        $this->set_encoding($encoding);
+        $this->set_format($format);
+
+        foreach ($info as $field => $value)
+        {    
+            $this->set_feed_info($field, $value, array());
+        }
+
+        foreach ($items as $item)
+        {
+            $this->next_entry();
+            foreach ($item as $field => $value) $this->set_entry_info($field, $value, array());
+        }
+
+        return $this->render();
+    }
 
 } // End Feed

--- a/classes/kohana/feed.php
+++ b/classes/kohana/feed.php
@@ -7,224 +7,228 @@
  * @license    http://kohanaframework.org/license
  */
 class Kohana_Feed {
-    
-    const FEED_FORMAT_ATOM = 'atom';
-    const FEED_FORMAT_RSS2 = 'rss2';
 
-    private $format = self::FEED_FORMAT_RSS2;
-    private $feed = array();
-    private $entry = array();
-    private $encoding = 'UTF-8';
+	const FEED_FORMAT_ATOM = 'atom';
+	const FEED_FORMAT_RSS2 = 'rss2';
 
+	private $format = self::FEED_FORMAT_RSS2;
+	private $feed = array();
+	private $entry = array();
 
-    /**
-     * setter for encoding
-     */
-    public function set_encoding($encoding)
-    {
-        return $this->encoding = $encoding;
-    }
-
-    /**
-     * setter for format
-     */
-    public function set_format($format)
-    {
-        if (in_array($format, array(self::FEED_FORMAT_ATOM, self::FEED_FORMAT_RSS2)))
-        {
-            return $this->format = $format;
-        }
-        throw new Exception('invalid feed format');
-    }
-
-    /**
-     * add one field to field
-     *
-     */ 
-    public function add_feed_info($field, $value, array $attributes = array())
-    {
-        $this->feed[] = array($field, $value, $attributes);
-    }
-
-    /**
-     * add one field to current entry
-     *
-     */
-    public function add_entry_info($field, $value, array $attributes = array())
-    {
-        $this->entry[] = array($field, $value, $attributes);
-    }
+	private $current_entry = array();
+	private $encoding = 'UTF-8';
 
 
-    /**
-     * close current entry and open a new one
-     */
-    public function next_entry()
-    {
-        if (!empty($this->entry))
-        {
-            $this->feed['entry'] = $this->entry;
-            $this->entry = array();
-        }
-    }
+	/**
+	 * setter for encoding
+	 */
+	public function set_encoding($encoding)
+	{
+		return $this->encoding = $encoding;
+	}
 
-    /**
-     * ouput XML from data collected
-     *
-     */
-    public function render() 
-    {    
-        $this->next_entry();
-        switch ($this->format)
-        {
-            case self::FEED_FORMAT_ATOM:
-                $feed = simplexml_load_string('<?xml version="1.0" encoding="'.$encoding.'"?><feed xmlns="http://www.w3.org/2005/Atom"></feed>');
-                $entry_tag = 'entry';
-                break;
-            case self::FEED_FORMAT_RSS2:
-            default:
-                $feed = simplexml_load_string('<?xml version="1.0" encoding="'.$encoding.'"?><rss version="2.0"><channel></channel></rss>');
-                $entry_tag = 'item';
-                break;
+	/**
+	 * setter for format
+	 */
+	public function set_format($format)
+	{
+		if (in_array($format, array(self::FEED_FORMAT_ATOM, self::FEED_FORMAT_RSS2)))
+		{
+			return $this->format = $format;
+		}
+		throw new Exception('invalid feed format');
+	}
 
-        }
+	/**
+	 * add one field to field
+	 *
+	 */ 
+	public function add_feed_info($field, $value, array $attributes = array())
+	{
+		$this->feed[] = array($field, $value, $attributes);
+	}
 
-        $this->push_fields($this->feed, $feed);
-        foreach ($this->entry as $entry)
-        {
-            $curr_entry = $feed->addChild($entry_tag);
-            $this->push_fields($entry, $curr_entry);
-        }
-
-        // DOM is preferred, as it generates more readable XML
-        if (function_exists('dom_import_simplexml'))
-        {
-            $feed = dom_import_simplexml($feed)->ownerDocument;
-            $feed->formatOutput = TRUE;
-            return $feed->saveXML();
-        }
-    
-        // Export the document as XML
-        return $feed->asXML();
-    }
-
-    /**
-     * helper which handles pushing sub fields and attributes
-     *
-     */
-    protected function push_fields($fields, $sxo)
-    {
-        foreach ($fields as $curr)
-        {
-            list($field, $value, $attributes) = $curr;
-
-            if (is_array($value))
-            {
-                $child = $sxo->addChild($field);
-                foreach ($value as $subfield => $subvalue)
-                {
-                    $child->addChild($subfield, $this->scrub_field($subfield, $subvalue));
-                }
-            }
-            else
-            {    
-                $child = $sxo->addChild($field, $this->scrub_field($field, $value));
-            }
-
-            foreach ($attributes as $attribute_name => $attribute_value)
-            {
-                $child->addAttribute($attribute_name, $this->scrub_field($attribute_name, $attribute_value));
-            }
-        }
-    }
+	/**
+	 * add one field to current entry
+	 *
+	 */
+	public function add_entry_info($field, $value, array $attributes = array())
+	{
+		$this->current_entry[] = array($field, $value, $attributes);
+	}
 
 
-    /**
-     * filters field values
-     *
-     * currently it tries to detect URL fields and attributes, and set them with current site domain if not already set.
-     * may be extended to do more.
-     */
-    protected function scrub_field($field, $value)
-    {
-        if (in_array($field, array('href','url','uri','link'))
-            && strpos($value, '://') === FALSE)
-        {
-            return URL::site($value, 'http');
-        }
-        return $value;
-    }
+	/**
+	 * close current entry and open a new one
+	 */
+	public function next_entry()
+	{
+		if (!empty($this->current_entry))
+		{
+			$this->entry[] = $this->current_entry;
+			$this->current_entry = array();
+		}
+	}
 
-    /**
-     * Parses a remote feed into an array.
-     *
-     * @param   string   remote feed URL
-     * @param   integer  item limit to fetch
-     * @return  array
-     */
-    public static function parse($feed, $limit = 0)
-    {
-        // Check if SimpleXML is installed
-        if ( ! function_exists('simplexml_load_file'))
-            throw new Kohana_Exception('SimpleXML must be installed!');
+	/**
+	 * ouput XML from data collected
+	 *
+	 */
+	public function render() 
+	{	
+		$this->next_entry();
+		switch ($this->format)
+		{
+			case self::FEED_FORMAT_ATOM:
+				$feed = simplexml_load_string('<?xml version="1.0" encoding="'.$this->encoding.'"?><feed xmlns="http://www.w3.org/2005/Atom"></feed>');
+				$entry_tag = 'entry';
+				break;
+			case self::FEED_FORMAT_RSS2:
+			default:
+				$feed = simplexml_load_string('<?xml version="1.0" encoding="'.$this->encoding.'"?><rss version="2.0"><channel></channel></rss>');
+				$entry_tag = 'item';
+				break;
 
-        // Make limit an integer
-        $limit = (int) $limit;
+		}
 
-        // Disable error reporting while opening the feed
-        $error_level = error_reporting(0);
+		$this->push_fields($this->feed, $feed);
+		foreach ($this->entry as $entry)
+		{
+			$curr_entry = $feed->addChild($entry_tag);
+			$this->push_fields($entry, $curr_entry);
+		}
 
-        // Allow loading by filename or raw XML string
-        $load = (is_file($feed) OR Valid::url($feed)) ? 'simplexml_load_file' : 'simplexml_load_string';
+		// DOM is preferred, as it generates more readable XML
+		if (function_exists('dom_import_simplexml'))
+		{
+			$feed = dom_import_simplexml($feed)->ownerDocument;
+			$feed->formatOutput = TRUE;
+			return $feed->saveXML();
+		}
 
-        // Load the feed
-        $feed = $load($feed, 'SimpleXMLElement', LIBXML_NOCDATA);
+		// Export the document as XML
+		return $feed->asXML();
+	}
 
-        // Restore error reporting
-        error_reporting($error_level);
+	/**
+	 * helper which handles pushing sub fields and attributes
+	 *
+	 */
+	protected function push_fields($fields, $sxo)
+	{
+		foreach ($fields as $curr)
+		{
+			list($field, $value, $attributes) = $curr;
 
-        // Feed could not be loaded
-        if ($feed === FALSE)
-            return array();
+			if (is_array($value))
+			{
+				$child = $sxo->addChild($field);
+				foreach ($value as $subfield => $subvalue)
+				{
+					$child->addChild($subfield, $this->scrub_field($subfield, $subvalue));
+				}
+			}
+			else
+			{	
+				$child = $sxo->addChild($field, $this->scrub_field($field, $value));
+			}
+			foreach ($attributes as $attribute_name => $attribute_value)
+			{
+				$child->addAttribute($attribute_name, $this->scrub_field($attribute_name, $attribute_value));
+			}
+		}
+	}
 
-        $namespaces = $feed->getNamespaces(true);
 
-        // Detect the feed type. RSS 1.0/2.0 and Atom 1.0 are supported.
-        $feed = isset($feed->channel) ? $feed->xpath('//item') : $feed->entry;
+	/**
+	 * filters field values
+	 *
+	 * currently it tries to detect URL fields and attributes, and set them with current site domain if not already set.
+	 * may be extended to do more.
+	 */
+	protected function scrub_field($field, $value)
+	{
+		if (in_array($field, array('href','url','uri','link'))
+			&& strpos($value, '://') === FALSE
+			&& !empty($value)
+		)
+		{
+			return URL::site($value, 'http');
+		}
+		return $value;
+	}
 
-        $i = 0;
-        $items = array();
+	/**
+	 * Parses a remote feed into an array.
+	 *
+	 * @param   string   remote feed URL
+	 * @param   integer  item limit to fetch
+	 * @return  array
+	 */
+	public static function parse($feed, $limit = 0)
+	{
+		// Check if SimpleXML is installed
+		if ( ! function_exists('simplexml_load_file'))
+			throw new Kohana_Exception('SimpleXML must be installed!');
 
-        foreach ($feed as $item)
-        {
-            if ($limit > 0 AND $i++ === $limit)
-                break;
-            $item_fields = (array) $item;
+		// Make limit an integer
+		$limit = (int) $limit;
 
-            // get namespaced tags
-            foreach ($namespaces as $ns)
-            {
-                $item_fields += (array) $item->children($ns);
-            }
-            $items[] = $item_fields;
-        }
+		// Disable error reporting while opening the feed
+		$error_level = error_reporting(0);
 
-        return $items;
-    }
+		// Allow loading by filename or raw XML string
+		$load = (is_file($feed) OR Valid::url($feed)) ? 'simplexml_load_file' : 'simplexml_load_string';
 
-    /**
-     * Creates a feed from the given parameters.
-     *
-     * this function provides backwards compatability
-     *
-     * @param   array   feed information
-     * @param   array   items to add to the feed
-     * @param   string  define which format to use (rss2 or atom)
-     * @param   string  define which encoding to use
-     * @return  string
-     */
-    public static function create($info, $items, $format = self::FEED_FORMAT_RSS2, $encoding = 'UTF-8')
-    {
+		// Load the feed
+		$feed = $load($feed, 'SimpleXMLElement', LIBXML_NOCDATA);
+
+		// Restore error reporting
+		error_reporting($error_level);
+
+		// Feed could not be loaded
+		if ($feed === FALSE)
+			return array();
+
+		$namespaces = $feed->getNamespaces(true);
+
+		// Detect the feed type. RSS 1.0/2.0 and Atom 1.0 are supported.
+		$feed = isset($feed->channel) ? $feed->xpath('//item') : $feed->entry;
+
+		$i = 0;
+		$items = array();
+
+		foreach ($feed as $item)
+		{
+			if ($limit > 0 AND $i++ === $limit)
+				break;
+			$item_fields = (array) $item;
+
+			// get namespaced tags
+			foreach ($namespaces as $ns)
+			{
+				$item_fields += (array) $item->children($ns);
+			}
+			$items[] = $item_fields;
+		}
+
+		return $items;
+	}
+
+	/**
+	 * Creates a feed from the given parameters.
+	 *
+	 * this function provides backwards compatability
+	 *
+	 * @param   array   feed information
+	 * @param   array   items to add to the feed
+	 * @param   string  define which format to use (rss2 or atom)
+	 * @param   string  define which encoding to use
+	 * @return  string
+	 */
+	public static function create($info, $items, $format = self::FEED_FORMAT_RSS2, $encoding = 'UTF-8')
+	{
+
         $info += array('title' => 'Generated Feed', 'link' => '', 'generator' => 'KohanaPHP');
 
 		$feed = new self();
@@ -234,16 +238,17 @@ class Kohana_Feed {
 
         foreach ($info as $field => $value)
         {    
-            $feed->set_feed_info($field, $value, array());
+            $feed->add_feed_info($field, $value, array());
         }
 
         foreach ($items as $item)
         {
             $feed->next_entry();
-            foreach ($item as $field => $value) $feed->set_entry_info($field, $value, array());
+            foreach ($item as $field => $value) $feed->add_entry_info($field, $value, array());
         }
 
         return $feed->render();
-    }
+
+	}
 
 } // End Feed

--- a/classes/kohana/feed.php
+++ b/classes/kohana/feed.php
@@ -11,7 +11,7 @@ class Kohana_Feed {
     const FEED_FORMAT_ATOM = 'atom';
     const FEED_FORMAT_RSS2 = 'rss2';
 
-    private $format = self::FEED_FORMAT_RSS2;
+    private $format = Feed::FEED_FORMAT_RSS2;
     private $encoding = 'UTF-8';
 
     private $feed = array();
@@ -32,7 +32,7 @@ class Kohana_Feed {
      */
     public function set_format($format)
     {
-    	if (in_array($format, array(self::FEED_FORMAT_ATOM, self::FEED_FORMAT_RSS2)))
+    	if (in_array($format, array(Feed::FEED_FORMAT_ATOM, Feed::FEED_FORMAT_RSS2)))
     	{
     		return $this->format = $format;
     	}
@@ -94,11 +94,11 @@ class Kohana_Feed {
     	$this->next_entry();
     	switch ($this->format)
     	{
-    		case self::FEED_FORMAT_ATOM:
+    		case Feed::FEED_FORMAT_ATOM:
     			$feed = simplexml_load_string('<?xml version="1.0" encoding="'.$this->encoding.'"?><feed xmlns="http://www.w3.org/2005/Atom"></feed>');
     			$entry_tag = 'entry';
     			break;
-    		case self::FEED_FORMAT_RSS2:
+    		case Feed::FEED_FORMAT_RSS2:
     		default:
     			$feed = simplexml_load_string('<?xml version="1.0" encoding="'.$this->encoding.'"?><rss version="2.0"><channel></channel></rss>');
     			$entry_tag = 'item';
@@ -248,12 +248,12 @@ class Kohana_Feed {
      * @param   string  define which encoding to use
      * @return  string
      */
-    public static function create($info, $items, $format = self::FEED_FORMAT_RSS2, $encoding = 'UTF-8')
+    public static function create($info, $items, $format = Feed::FEED_FORMAT_RSS2, $encoding = 'UTF-8')
     {
 
         $info += array('title' => 'Generated Feed', 'link' => '', 'generator' => 'KohanaPHP');
 
-    	$feed = new self();
+    	$feed = new Feed();
 
         $feed->set_encoding($encoding);
         $feed->set_format($format);

--- a/classes/kohana/feed.php
+++ b/classes/kohana/feed.php
@@ -12,11 +12,11 @@ class Kohana_Feed {
 	const FEED_FORMAT_RSS2 = 'rss2';
 
 	private $format = self::FEED_FORMAT_RSS2;
+	private $encoding = 'UTF-8';
+
 	private $feed = array();
 	private $entry = array();
-
 	private $current_entry = array();
-	private $encoding = 'UTF-8';
 
 
 	/**
@@ -41,9 +41,24 @@ class Kohana_Feed {
 
 	/**
 	 * add one field to field
+	 * 
+	 * when $value is a scalar
+	 * <field attribue1="foo">value</field>
+	 * 
+	 * when $value is an array
+	 * <field attribue1="foo">
+	 *   <name>foo</name>
+	 *   <url>example.com</url>
+	 * </field>
 	 *
+	 * when $value is null
+	 * <field attribute1="foo" />
+	 *
+	 * @param	string 	tag name
+	 * @param	mixed  	tag value
+	 * @param	array   set of tag attributes as key value pairs
 	 */ 
-	public function add_feed_info($field, $value, array $attributes = array())
+	public function add_feed_info($field, $value = null, array $attributes = array())
 	{
 		$this->feed[] = array($field, $value, $attributes);
 	}
@@ -52,7 +67,7 @@ class Kohana_Feed {
 	 * add one field to current entry
 	 *
 	 */
-	public function add_entry_info($field, $value, array $attributes = array())
+	public function add_entry_info($field, $value = null, array $attributes = array())
 	{
 		$this->current_entry[] = array($field, $value, $attributes);
 	}
@@ -113,6 +128,8 @@ class Kohana_Feed {
 	/**
 	 * helper which handles pushing sub fields and attributes
 	 *
+	 * @param array 
+	 * @param simplexml object
 	 */
 	protected function push_fields($fields, $sxo)
 	{
@@ -145,6 +162,10 @@ class Kohana_Feed {
 	 *
 	 * currently it tries to detect URL fields and attributes, and set them with current site domain if not already set.
 	 * may be extended to do more.
+	 * 
+	 * @param 	string	tag name
+	 * @param   string	tag value
+	 * @return	string  scrubbed value
 	 */
 	protected function scrub_field($field, $value)
 	{
@@ -218,6 +239,7 @@ class Kohana_Feed {
 	/**
 	 * Creates a feed from the given parameters.
 	 *
+	 * Deprecated
 	 * this function provides backwards compatability
 	 *
 	 * @param   array   feed information

--- a/classes/kohana/feed.php
+++ b/classes/kohana/feed.php
@@ -227,21 +227,23 @@ class Kohana_Feed {
     {
         $info += array('title' => 'Generated Feed', 'link' => '', 'generator' => 'KohanaPHP');
 
-        $this->set_encoding($encoding);
-        $this->set_format($format);
+		$feed = new self();
+
+        $feed->set_encoding($encoding);
+        $feed->set_format($format);
 
         foreach ($info as $field => $value)
         {    
-            $this->set_feed_info($field, $value, array());
+            $feed->set_feed_info($field, $value, array());
         }
 
         foreach ($items as $item)
         {
-            $this->next_entry();
-            foreach ($item as $field => $value) $this->set_entry_info($field, $value, array());
+            $feed->next_entry();
+            foreach ($item as $field => $value) $feed->set_entry_info($field, $value, array());
         }
 
-        return $this->render();
+        return $feed->render();
     }
 
 } // End Feed

--- a/classes/kohana/feed.php
+++ b/classes/kohana/feed.php
@@ -1,14 +1,159 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php //defined('SYSPATH') or die('No direct script access.');
 /**
  * RSS and Atom feed helper.
  *
  * @package    Kohana
  * @category   Helpers
- * @author     Kohana Team
- * @copyright  (c) 2007-2011 Kohana Team
  * @license    http://kohanaframework.org/license
  */
 class Kohana_Feed {
+	
+	const FEED_FORMAT_ATOM = 'atom';
+	const FEED_FORMAT_RSS2 = 'rss2';
+
+	private $format = self::FEED_FORMAT_RSS2;
+	private $feed = array();
+	private $entry = array();
+	private $encoding = 'UTF-8';
+
+
+	/**
+	 * setter for encoding
+	 */
+	public function set_encoding($encoding)
+	{
+		return $this->encoding = $encoding;
+	}
+
+	/**
+	 * setter for format
+	 */
+	public function set_format($format)
+	{
+		if (in_array($format, array(self::FEED_FORMAT_ATOM, self::FEED_FORMAT_RSS2)))
+		{
+			return $this->format = $format;
+		}
+		throw new Exception('invalid feed format');
+	}
+
+	/**
+	 * add one field to field
+	 *
+	 */ 
+	public function add_feed_info($field, $value, array $attributes = array())
+	{
+		$this->feed[] = array($field, $value, $attributes);
+	}
+
+	/**
+	 * add one field to current entry
+	 *
+	 */
+	public function add_entry_info($field, $value, array $attributes = array())
+	{
+		$this->entry[] = array($field, $value, $attributes);
+	}
+
+
+	/**
+	 * close current entry and open a new one
+	 */
+	public function next_entry()
+	{
+		if (!empty($this->entry))
+		{
+			$this->feed['entry'] = $this->entry;
+			$this->entry = array();
+		}
+	}
+
+	/**
+	 * ouput XML from data collected
+	 *
+	 */
+	public function render() 
+	{	
+		$this->next_entry();
+		switch ($this->format)
+		{
+			case self::FEED_FORMAT_ATOM:
+				$feed = simplexml_load_string('<?xml version="1.0" encoding="'.$encoding.'"?><feed xmlns="http://www.w3.org/2005/Atom"></feed>');
+				$entry_tag = 'entry';
+				break;
+			case self::FEED_FORMAT_RSS2:
+			default:
+				$feed = simplexml_load_string('<?xml version="1.0" encoding="'.$encoding.'"?><rss version="2.0"><channel></channel></rss>');
+				$entry_tag = 'item';
+				break;
+
+		}
+
+		$this->push_fields($this->feed, $feed);
+		foreach ($this->entry as $entry)
+		{
+			$curr_entry = $feed->addChild($entry_tag);
+			$this->push_fields($entry, $curr_entry);
+		}
+
+		// DOM is preferred, as it generates more readable XML
+		if (function_exists('dom_import_simplexml'))
+		{
+			$feed = dom_import_simplexml($feed)->ownerDocument;
+			$feed->formatOutput = TRUE;
+			return $feed->saveXML();
+		}
+	
+		// Export the document as XML
+		return $feed->asXML();
+	}
+
+	/**
+	 * helper which handles pushing sub fields and attributes
+	 *
+	 */
+	protected function push_fields($fields, $sxo)
+	{
+		foreach ($fields as $curr)
+		{
+			list($field, $value, $attributes) = $curr;
+
+			if (is_array($value))
+			{
+				$child = $sxo->addChild($field);
+				foreach ($value as $subfield => $subvalue)
+				{
+					$child->addChild($subfield, $this->scrub_field($subfield, $subvalue));
+				}
+			}
+			else
+			{	
+				$child = $sxo->addChild($field, $this->scrub_field($field, $value));
+			}
+
+			foreach ($attributes as $attribute_name => $attribute_value)
+			{
+				$child->addAttribute($attribute_name, $this->scrub_field($attribute_name, $attribute_value));
+			}
+		}
+	}
+
+
+	/**
+	 * filters field values
+	 *
+	 * currently it tries to detect URL fields and attributes, and set them with current site domain if not already set.
+	 * may be extended to do more.
+	 */
+	protected function scrub_field($field, $value)
+	{
+		if (in_array($field, array('href','url','uri','link'))
+			&& strpos($value, '://') === FALSE)
+		{
+			return URL::site($value, 'http');
+		}
+		return $value;
+	}
 
 	/**
 	 * Parses a remote feed into an array.
@@ -70,107 +215,33 @@ class Kohana_Feed {
 	/**
 	 * Creates a feed from the given parameters.
 	 *
+	 * this function provides backwards compatability
+	 *
 	 * @param   array   feed information
 	 * @param   array   items to add to the feed
-	 * @param   string  define which format to use (only rss2 is supported)
+	 * @param   string  define which format to use (rss2 or atom)
 	 * @param   string  define which encoding to use
 	 * @return  string
 	 */
-	public static function create($info, $items, $format = 'rss2', $encoding = 'UTF-8')
+	public static function create($info, $items, $format = self::FEED_FORMAT_RSS2, $encoding = 'UTF-8')
 	{
 		$info += array('title' => 'Generated Feed', 'link' => '', 'generator' => 'KohanaPHP');
 
-		$feed = '<?xml version="1.0" encoding="'.$encoding.'"?><rss version="2.0"><channel></channel></rss>';
-		$feed = simplexml_load_string($feed);
+		$this->set_encoding($encoding);
+		$this->set_format($format);
 
-		foreach ($info as $name => $value)
-		{
-			if ($name === 'image')
-			{
-				// Create an image element
-				$image = $feed->channel->addChild('image');
-
-				if ( ! isset($value['link'], $value['url'], $value['title']))
-				{
-					throw new Kohana_Exception('Feed images require a link, url, and title');
-				}
-
-				if (strpos($value['link'], '://') === FALSE)
-				{
-					// Convert URIs to URLs
-					$value['link'] = URL::site($value['link'], 'http');
-				}
-
-				if (strpos($value['url'], '://') === FALSE)
-				{
-					// Convert URIs to URLs
-					$value['url'] = URL::site($value['url'], 'http');
-				}
-
-				// Create the image elements
-				$image->addChild('link', $value['link']);
-				$image->addChild('url', $value['url']);
-				$image->addChild('title', $value['title']);
-			}
-			else
-			{
-				if (($name === 'pubDate' OR $name === 'lastBuildDate') AND (is_int($value) OR ctype_digit($value)))
-				{
-					// Convert timestamps to RFC 822 formatted dates
-					$value = date('r', $value);
-				}
-				elseif (($name === 'link' OR $name === 'docs') AND strpos($value, '://') === FALSE)
-				{
-					// Convert URIs to URLs
-					$value = URL::site($value, 'http');
-				}
-
-				// Add the info to the channel
-				$feed->channel->addChild($name, $value);
-			}
+		foreach ($info as $field => $value)
+		{	
+			$this->set_feed_info($field, $value, array());
 		}
 
 		foreach ($items as $item)
 		{
-			// Add the item to the channel
-			$row = $feed->channel->addChild('item');
-
-			foreach ($item as $name => $value)
-			{
-				if ($name === 'pubDate' AND (is_int($value) OR ctype_digit($value)))
-				{
-					// Convert timestamps to RFC 822 formatted dates
-					$value = date('r', $value);
-				}
-				elseif (($name === 'link' OR $name === 'guid') AND strpos($value, '://') === FALSE)
-				{
-					// Convert URIs to URLs
-					$value = URL::site($value, 'http');
-				}
-
-				// Add the info to the row
-				$row->addChild($name, $value);
-			}
+			$this->next_entry();
+			foreach ($item as $field => $value) $this->set_entry_info($field, $value, array());
 		}
 
-		if (function_exists('dom_import_simplexml'))
-		{
-			// Convert the feed object to a DOM object
-			$feed = dom_import_simplexml($feed)->ownerDocument;
-
-			// DOM generates more readable XML
-			$feed->formatOutput = TRUE;
-
-			// Export the document as XML
-			$feed = $feed->saveXML();
-		}
-		else
-		{
-			// Export the document as XML
-			$feed = $feed->asXML();
-		}
-
-		return $feed;
+		return $this->render();
 	}
 
 } // End Feed


### PR DESCRIPTION
I modified the feed helper to handle ATOM format as well as providing the ability to assign nested tags and to handle tag attributes.  The static function create() was preserved but considered deprecated, and should be regarded as an example of the new usage.
