### PR TITLE
Remove check if cache dir is writable

### DIFF
--- a/classes/kohana/core.php
+++ b/classes/kohana/core.php
@@ -278,12 +278,6 @@ class Kohana_Core {
 			Kohana::$cache_dir = APPPATH.'cache';
 		}
 
-		if ( ! is_writable(Kohana::$cache_dir))
-		{
-			throw new Kohana_Exception('Directory :dir must be writable',
-				array(':dir' => Debug::path(Kohana::$cache_dir)));
-		}
-
 		if (isset($settings['cache_life']))
 		{
 			// Set the default cache lifetime


### PR DESCRIPTION
This check is already done in install.php, and doesn't have to be done
on every page load.

Fixes issue [#3300](http://dev.kohanaframework.org/issues/3300)
