### PR TITLE
Add IS.METHOD functions

### DIFF
--- a/classes/kohana/request.php
+++ b/classes/kohana/request.php
@@ -1264,7 +1264,43 @@ class Kohana_Request implements HTTP_Request {
 
 		return $this;
 	}
-
+	
+	/**
+	 * Returns whether this request is GET
+	 *
+	 * @return  boolean
+	 */
+	public function is_get() {
+		return ($this->method() === 'GET');
+	}
+	
+	/**
+	 * Returns whether this request is POST
+	 *
+	 * @return  boolean
+	 */
+	public function is_post() {
+		return ($this->method() === 'POST');
+	}
+	
+	/**
+	 * Returns whether this request is PUT
+	 *
+	 * @return  boolean
+	 */
+	public function is_put() {
+		return ($this->method() === 'PUT');
+	}
+	
+	/**
+	 * Returns whether this request is DELETE
+	 *
+	 * @return  boolean
+	 */
+	public function is_delete() {
+		return ($this->method() === 'DELETE');
+	}
+	
 	/**
 	 * Gets or sets the HTTP protocol. If there is no current protocol set,
 	 * it will use the default set in HTTP::$protocol


### PR DESCRIPTION
Little fix that's fix annoying problem
-- all the time i need to check type of request 0method in controller i should make ugly check like 
$this->request->method() === 'POST'
it can be reason of some bugs e.g.

$this->request->method() === 'post'

is think 
$this->request->is_post() 
is more readable and more bug less way  
