### PR TITLE
Create shim Kohana_Exception_Starter for before modules are loaded

### DIFF
--- a/classes/Kohana/Core.php
+++ b/classes/Kohana/Core.php
@@ -211,7 +211,7 @@ class Kohana_Core {
 		if (Kohana::$errors === TRUE)
 		{
 			// Enable Kohana exception handling, adds stack traces and error source.
-			set_exception_handler(array('Kohana_Exception', 'handler'));
+			set_exception_handler(array('Kohana_Exception_Starter', 'handler'));
 
 			// Enable Kohana error handling, converts all PHP errors to exceptions.
 			set_error_handler(array('Kohana', 'error_handler'));
@@ -603,6 +603,15 @@ class Kohana_Core {
 			}
 		}
 
+		if (Kohana::$errors === TRUE)
+		{
+			// Go back to the previous exception handler
+			restore_exception_handler();
+			
+			// Enable Kohana exception handling, adds stack traces and error source.
+			set_exception_handler(array('Kohana_Exception', 'handler'));
+		}
+		
 		return Kohana::$_modules;
 	}
 

--- a/classes/Kohana/Exception/Starter.php
+++ b/classes/Kohana/Exception/Starter.php
@@ -1,0 +1,3 @@
+<?php defined('SYSPATH') OR die('No direct script access.');
+
+class Kohana_Exception_Starter extends Kohana_Kohana_Exception {}


### PR DESCRIPTION
This will allow Kohana::$_path to be updated with all the module paths before they are used to load the real exception handler.
This (maybe) should be targeted to 3.4/develop, but that does not exist yet.

(This is working in production for me.)

Replaces https://github.com/kohana/core/pull/269

http://dev.kohanaframework.org/issues/4614
