### PR TITLE
Fix bug when Kohana::magic_quotes == 1 in php version < 5.4

### DIFF
--- a/classes/kohana/core.php
+++ b/classes/kohana/core.php
@@ -327,7 +327,7 @@ class Kohana_Core {
 		}
 
 		// Determine if the extremely evil magic quotes are enabled
-		Kohana::$magic_quotes = version_compare(PHP_VERSION, '5.4') < 0 AND get_magic_quotes_gpc();
+		Kohana::$magic_quotes = ( version_compare(PHP_VERSION, '5.4') < 0 AND get_magic_quotes_gpc() );
 
 		// Sanitize all request variables
 		$_GET    = Kohana::sanitize($_GET);


### PR DESCRIPTION
In version of PHP < 5.4 Kohana::$magic_quotes is always TRUE
