### PR TITLE
Set secure based on X-FORWARDED-PROTO

### DIFF
--- a/classes/kohana/request.php
+++ b/classes/kohana/request.php
@@ -126,7 +126,8 @@ class Kohana_Request implements HTTP_Request {
 					$method = HTTP_Request::GET;
 				}
 
-				if ( ! empty($_SERVER['HTTPS']) AND filter_var($_SERVER['HTTPS'], FILTER_VALIDATE_BOOLEAN))
+				if (( !empty($_SERVER['HTTPS']) AND filter_var($_SERVER['HTTPS'], FILTER_VALIDATE_BOOLEAN) )
+				   OR (isset($_SERVER["HTTP_X_FORWARDED_PROTO"]) AND $_SERVER["HTTP_X_FORWARDED_PROTO"] == 'https' ))
 				{
 					// This request is secure
 					$secure = TRUE;


### PR DESCRIPTION
If the HTTPS flag is not set, check the
X-FORWARDED-PROTO header to check if the
load balancer received a secure request
