### PR TITLE
StdOut and StdErr log levels

### DIFF
--- a/classes/kohana/log/stderr.php
+++ b/classes/kohana/log/stderr.php
@@ -19,13 +19,10 @@ class Kohana_Log_StdErr extends Log_Writer {
 	 */
 	public function write(array $messages)
 	{
-		// Set the log line format
-		$format = 'time --- type: body';
-
 		foreach ($messages as $message)
 		{
 			// Writes out each message
-			fwrite(STDERR, PHP_EOL.strtr($format, $message));
+			fwrite(STDERR, PHP_EOL.$message['time'].' --- '.$this->_log_levels[$message['level']].': '.$message['body']);
 		}
 	}
 } // End Kohana_Log_StdErr

--- a/classes/kohana/log/stdout.php
+++ b/classes/kohana/log/stdout.php
@@ -19,13 +19,10 @@ class Kohana_Log_StdOut extends Log_Writer {
 	 */
 	public function write(array $messages)
 	{
-		// Set the log line format
-		$format = 'time --- type: body';
-
 		foreach ($messages as $message)
 		{
 			// Writes out each message
-			fwrite(STDOUT, PHP_EOL.strtr($format, $message));
+			fwrite(STDOUT, PHP_EOL.$message['time'].' --- '.$this->_log_levels[$message['level']].': '.$message['body']);
 		}
 	}
 } // End Kohana_Log_StdOut


### PR DESCRIPTION
StdErr and StdOut Log Writers now use File Log Writer's format to include readable log level.

http://dev.kohanaframework.org/issues/4622
