### PR TITLE
Set the request context on caught HTTP_Exceptions

### DIFF
--- a/classes/Kohana/Request/Client/Internal.php
+++ b/classes/Kohana/Request/Client/Internal.php
@@ -104,6 +104,12 @@ class Kohana_Request_Client_Internal extends Request_Client {
 		}
 		catch (HTTP_Exception $e)
 		{
+			// Store the request context in the Exception
+			if ($e->request() === NULL)
+			{
+				$e->request($request);
+			}
+
 			// Get the response via the Exception
 			$response = $e->get_response();
 		}


### PR DESCRIPTION
When HTTP_Exceptions are caught inside of the Internal Request Client,
the current request will be set inside of the Exception using the
HTTP_Exception::request() method.

This fixes #4635
