### PR TITLE
Fixed links to tutorial for template driven site

### DIFF
--- a/guide/kohana/tutorials/templates.md
+++ b/guide/kohana/tutorials/templates.md
@@ -1,7 +1,7 @@
 Making a template driven site.
 
-<http://kerkness.ca/wiki/doku.php?id=template-site:create_the_template>
+<http://kerkness.ca/kowiki/doku.php?id=template-site:create_the_template>
 	
-<http://kerkness.ca/wiki/doku.php?id=template-site:extending_the_template_controller>
+<http://kerkness.ca/kowiki/doku.php?id=template-site:extending_the_template_controller>
 
-<http://kerkness.ca/wiki/doku.php?id=template-site:basic_page_controller>
+<http://kerkness.ca/kowiki/doku.php?id=template-site:basic_page_controller>


### PR DESCRIPTION
Might want to include the content instead and credit that site, just in case it changes again.
