### PR TITLE
Use the current exception handler during shutdown

### DIFF
--- a/classes/kohana/core.php
+++ b/classes/kohana/core.php
@@ -968,7 +968,6 @@ class Kohana_Core {
 	/**
 	 * Catches errors that are not caught by the error handler, such as E_PARSE.
 	 *
-	 * @uses    Kohana_Exception::handler
 	 * @return  void
 	 */
 	public static function shutdown_handler()
@@ -978,6 +977,12 @@ class Kohana_Core {
 			// Do not execute when not active
 			return;
 		}
+
+		// Retrieve the current exception handler
+		$handler = set_exception_handler(array('Kohana_Exception', 'handler'));
+
+		// Restore it back to it's previous state
+		restore_exception_handler();
 
 		try
 		{
@@ -990,7 +995,7 @@ class Kohana_Core {
 		catch (Exception $e)
 		{
 			// Pass the exception to the handler
-			Kohana_Exception::handler($e);
+			call_user_func($handler, $e);
 		}
 
 		if (Kohana::$errors AND $error = error_get_last() AND in_array($error['type'], Kohana::$shutdown_errors))
@@ -999,7 +1004,7 @@ class Kohana_Core {
 			ob_get_level() and ob_clean();
 
 			// Fake an exception for nice debugging
-			Kohana_Exception::handler(new ErrorException($error['message'], $error['type'], 0, $error['file'], $error['line']));
+			call_user_func($handler, new ErrorException($error['message'], $error['type'], 0, $error['file'], $error['line']));
 
 			// Shutdown now to avoid a "death loop"
 			exit(1);


### PR DESCRIPTION
It's possible that a different exception handler is defined than the
default `Kohana_Exception::hander`.

Refs [#4627](http://dev.kohanaframework.org/issues/4627)
