### PR TITLE
Changed the Security::token() method to remove the token from the Session

### DIFF
--- a/classes/Kohana/Security.php
+++ b/classes/Kohana/Security.php
@@ -43,7 +43,7 @@ class Kohana_Security {
 		$session = Session::instance();
 
 		// Get the current token
-		$token = $session->get(Security::$token_name);
+		$token = $session->get_once(Security::$token_name);
 
 		if ($new === TRUE OR ! $token)
 		{


### PR DESCRIPTION
Changed the token() method to make a get_once, so that the token does not remain in the Session.
Check the case where, the user actually uses your form once, and it is validated correctly and does the desired process.
The CSRF protection's token used in the whole process remains in the Session, therefore allowing the user to ignore your form and make posts directly to the endpoint of your form, therefore only validating with the token in the Session, until the Session ends.
