### PR TITLE
Changed the token() method to only get_once the generated token

### DIFF
--- a/classes/kohana/security.php
+++ b/classes/kohana/security.php
@@ -43,7 +43,7 @@ class Kohana_Security {
 		$session = Session::instance();
 
 		// Get the current token
-		$token = $session->get(Security::$token_name);
+		$token = $session->get_once(Security::$token_name);
 
 		if ($new === TRUE OR ! $token)
 		{


### PR DESCRIPTION
if the user uses the form with CSRF protection once, it will generate the token, store it in the session and  when the form is submitted it will (or should) be validated using the check() method.

This is all fine, the check() will basically get the token and validate if the submitted value matches the existing in the form. All good, the process continues.

... however if the user, crafts a form post (using, for example, javascript) with the same CSRF token defined, submitting it to the same 'action' that processes the form... It will be as valid as the previous one, because it's re-using the token in the session.

With the get_once, the token is generated and returned, checked and _puff_... vanished from the session.

What do you think?
