### PR TITLE
Arr::get work with ArrayAccess and NULL values

### DIFF
--- a/classes/Kohana/Arr.php
+++ b/classes/Kohana/Arr.php
@@ -267,14 +267,32 @@ class Kohana_Arr {
 	 *     // Get the value "sorting" from $_GET, if it exists
 	 *     $sorting = Arr::get($_GET, 'sorting');
 	 *
-	 * @param   array   $array      array to extract from
-	 * @param   string  $key        key name
-	 * @param   mixed   $default    default value
+	 * @param   array|ArrayAccess|NULL   $array      array to extract from
+	 * @param   int|string               $key        key name
+	 * @param   mixed                    $default    default value
 	 * @return  mixed
+	 * @throws Kohana_Exception If $array is not of expected types
 	 */
 	public static function get($array, $key, $default = NULL)
 	{
-		return isset($array[$key]) ? $array[$key] : $default;
+		// using isset for performance reasons
+		if (isset($array[$key]))
+			return $array[$key];
+
+		if ($array === NULL)
+			return $default;
+
+		if (is_array($array))
+		{
+			return array_key_exists($key, $array) ? $array[$key] : $default;
+		}
+
+		if ($array instanceof ArrayAccess)
+		{
+			return $array->offsetExists($key) ? $array[$key]: $default;
+		}
+
+		throw new Kohana_Exception('Argument 1 to Arr::get() must be an array or an instance of ArrayAccess');
 	}
 
 	/**
@@ -283,7 +301,7 @@ class Kohana_Arr {
 	 *
 	 *     // Get the values "username", "password" from $_POST
 	 *     $auth = Arr::extract($_POST, array('username', 'password'));
-	 *     
+	 *
 	 *     // Get the value "level1.level2a" from $data
 	 *     $data = array('level1' => array('level2a' => 'value 1', 'level2b' => 'value 2'));
 	 *     Arr::extract($data, array('level1.level2a', 'password'));

--- a/tests/kohana/ArrTest.php
+++ b/tests/kohana/ArrTest.php
@@ -173,13 +173,41 @@ class Kohana_ArrTest extends Unittest_TestCase
 	public function provider_get()
 	{
 		return array(
+			/**
+			 * Test with array
+			 */
 			array(array('uno', 'dos', 'tress'), 1, NULL, 'dos'),
 			array(array('we' => 'can', 'make' => 'change'), 'we', NULL, 'can'),
+			array(array('we' => 'can', 'make' => 'change'), 1, 'default', 'default'),
 
 			array(array('uno', 'dos', 'tress'), 10, NULL, NULL),
 			array(array('we' => 'can', 'make' => 'change'), 'he', NULL, NULL),
 			array(array('we' => 'can', 'make' => 'change'), 'he', 'who', 'who'),
 			array(array('we' => 'can', 'make' => 'change'), 'he', array('arrays'), array('arrays')),
+
+			array(array('we' => NULL, 'make' => 'change'), 'we', NULL, NULL),
+			array(array('we' => NULL, 'make' => 'change'), 'we', 'default', NULL),
+
+			/**
+			 * Test with instance of ArrayAccess
+			 */
+			array(new ArrayObject(array('uno', 'dos', 'tress')), 1, NULL, 'dos'),
+			array(new ArrayObject(array('we' => 'can', 'make' => 'change')), 'we', NULL, 'can'),
+			array(new ArrayObject(array('we' => 'can', 'make' => 'change')), 1, 'default', 'default'),
+
+			array(new ArrayObject(array('uno', 'dos', 'tress')), 10, NULL, NULL),
+			array(new ArrayObject(array('we' => 'can', 'make' => 'change')), 'he', NULL, NULL),
+			array(new ArrayObject(array('we' => 'can', 'make' => 'change')), 'he', 'who', 'who'),
+			array(new ArrayObject(array('we' => 'can', 'make' => 'change')), 'he', array('arrays'), array('arrays')),
+
+			array(new ArrayObject(array('we' => NULL, 'make' => 'change')), 'we', NULL, NULL),
+			array(new ArrayObject(array('we' => NULL, 'make' => 'change')), 'we', 'default', NULL),
+
+			/**
+			 * Test with NULL
+			 */
+			array(NULL, 'key', NULL, NULL),
+			array(NULL, 'key', 'default', 'default'),
 		);
 	}
 
@@ -188,17 +216,50 @@ class Kohana_ArrTest extends Unittest_TestCase
 	 *
 	 * @test
 	 * @dataProvider provider_get()
-	 * @param array          $array      Array to look in
-	 * @param string|integer $key        Key to look for
-	 * @param mixed          $default    What to return if $key isn't set
-	 * @param mixed          $expected   The expected value returned
+	 * @param array|ArrayAccess|NULL $array      Array to look in
+	 * @param string|integer         $key        Key to look for
+	 * @param mixed                  $default    What to return if $key isn't set
+	 * @param mixed                  $expected   The expected value returned
 	 */
-	public function test_get(array $array, $key, $default, $expected)
+	public function test_get($array, $key, $default, $expected)
 	{
 		$this->assertSame(
 			$expected,
 			Arr::get($array, $key, $default)
 		);
+	}
+
+	/**
+	 * Provides test data for test_get_exception()
+	 * @return array
+	 */
+	public function provider_get_exception()
+	{
+		return array(
+			array('string'),
+			array(1),
+			array(0),
+			array(TRUE),
+			array(FALSE),
+			array(new stdClass),
+			array(''),
+			array(1.5),
+		);
+	}
+
+	/**
+	 * Tests the exception thrown by Arr::get() when something different than
+	 * array or ArrayAccess instance.
+	 *
+	 * @test
+	 * @dataProvider provider_get_exception()
+	 * @expectedException Kohana_Exception
+	 * @expectedExceptionMessage Argument 1 to Arr::get() must be an array or an instance of ArrayAccess
+	 * @param mixed $array Array to look in
+	 */
+	public function test_get_exception($array)
+	{
+		Arr::get($array, 'some key');
 	}
 
 	/**


### PR DESCRIPTION
This is my take on new `Arr::get()` based on the discussions on #301 and #299 and the many issues related to them.

---

Passing `NULL` as first argument would return the default.

Passing something else than `array` or instance of `ArrayAccess` would throw an exception.

Using `isset()` for performance reasons.

Using `array_key_exists()` for arrays and `ArrayAccess::offsetExists()` otherwise.

---

This change might throw an exception which was not discussed before. Please let me know if you disagree with that.
