### PR TITLE
regarding http://dev.kohanaframework.org/issues/4695

### DIFF
--- a/classes/Kohana/HTTP/Exception.php
+++ b/classes/Kohana/HTTP/Exception.php
@@ -58,15 +58,4 @@ abstract class Kohana_HTTP_Exception extends Kohana_Exception {
 		return $this;
 	}
 
-	/**
-	 * Generate a Response for the current Exception
-	 *
-	 * @uses   Kohana_Exception::response()
-	 * @return Response
-	 */
-	public function get_response()
-	{
-		return Kohana_Exception::response($this);
-	}
-
 }

--- a/classes/Kohana/Kohana/Exception.php
+++ b/classes/Kohana/Kohana/Exception.php
@@ -103,11 +103,21 @@ class Kohana_Kohana_Exception extends Exception {
 	{
 		try
 		{
-			// Log the exception
-			Kohana_Exception::log($e);
-
-			// Generate the response
-			$response = Kohana_Exception::response($e);
+			if ($e instanceof Kohana_Exception)
+			{
+				$exception_name = get_class($e);
+				$exception_name::log($e);
+				$response = $exception_name::response($e);
+			} 
+            // non Kohana_Exception Exceptions
+			else 
+			{
+				// Log the exception
+				Kohana_Exception::log($e);
+			    
+                // Generate the response
+				$response = Kohana_Exception::response($e);
+			}
 
 			return $response;
 		}

--- a/classes/Kohana/Kohana/Exception.php
+++ b/classes/Kohana/Kohana/Exception.php
@@ -195,6 +195,12 @@ class Kohana_Kohana_Exception extends Exception {
 			$line    = $e->getLine();
 			$trace   = $e->getTrace();
 
+			if ($e instanceof http_exception_expected) 
+			{
+				// never display output for http_exception_expected
+				return $e->get_response();
+			}
+
 			if ( ! headers_sent())
 			{
 				// Make sure the proper http header is sent

--- a/classes/Kohana/Request/Client/Internal.php
+++ b/classes/Kohana/Request/Client/Internal.php
@@ -102,11 +102,6 @@ class Kohana_Request_Client_Internal extends Request_Client {
 				throw new Kohana_Exception('Controller failed to return a Response');
 			}
 		}
-		catch (HTTP_Exception $e)
-		{
-			// Get the response via the Exception
-			$response = $e->get_response();
-		}
 		catch (Exception $e)
 		{
 			// Generate an appropriate Response object


### PR DESCRIPTION
the way HTTP_Exceptions are handled ...exceptionally in the Kohana/Request/Client/Internal.php makes it difficult to override their presentation when exceptions are thrown before Client->execute() such as the case of Route::Filters()

This change allows request to call the overloaded version of the function instead of always forcing Kohana_Exception::response(), while still using it as the default in the case of non kohana exceptions.
