### PR TITLE
doc: fix HTML in validation view example

### DIFF
--- a/guide/kohana/security/validation.md
+++ b/guide/kohana/security/validation.md
@@ -182,6 +182,7 @@ First, we need a [View] that contains the HTML form, which will be placed in `ap
     <?php foreach ($errors as $message): ?>
         <li><?php echo $message ?></li>
     <?php endforeach ?>
+    </ul>
     <?php endif ?>
 
     <dl>


### PR DESCRIPTION
The unordered list in the HTML example was unclosed. Add a closing ul element to fix it.

This is filed in Redmine as http://dev.kohanaframework.org/issues/4721

Previously erroneously submitted against 3.3/master as #340
