### PR TITLE
doc: use "303 See Other" redirects after POST

### DIFF
--- a/guide/kohana/mvc/controllers.md
+++ b/guide/kohana/mvc/controllers.md
@@ -128,7 +128,7 @@ A user login action.
 			// Try to login
 			if (Auth::instance()->login($this->request->post('username'), $this->request->post('password')))
 			{
-				$this->redirect('home', 302);
+				$this->redirect('home', 303);
 			}
 
 			$view->errors = 'Invalid email or password';

--- a/guide/kohana/security/validation.md
+++ b/guide/kohana/security/validation.md
@@ -230,7 +230,7 @@ Next, we need a controller and action to process the registration, which will be
                 $user->register($this->request->post());
 
                 // Always redirect after a successful POST to prevent refresh warnings
-                $this->redirect('user/profile', 302);
+                $this->redirect('user/profile', 303);
             }
 
             // Validation failed, collect the errors


### PR DESCRIPTION
Per RFC 2616 (HTTP 1.1), the HTTP response status code "303 See Other" is the correct way to redirect a client after an HTTP POST. Adjust the documentation to use a 303 redirect instead of 302.

This is filed in Redmine as  http://dev.kohanaframework.org/issues/4720

Previously erroneously submitted against 3.3/master as #339 . In that ticket, @zombor pointed out that there may have been a historic reason for choosing 302 explicitly. From Googling around, it appears that pre-HTTP/1.1 clients may have not supported 303 redirects in the past. However, it is a valid HTTP/1.1 operation, and speaking anecdotally, I've been doing this in my own web applications with no problem. I've been testing on Firefox, Chromium, and mobile Safari.
