### PR TITLE
Do not start sessions if they are already started

### DIFF
--- a/classes/Kohana/Session/Native.php
+++ b/classes/Kohana/Session/Native.php
@@ -40,7 +40,10 @@ class Kohana_Session_Native extends Session {
 		}
 
 		// Start the session
-		session_start();
+		if (session_status() == PHP_SESSION_DISABLED)
+		{
+			session_start();
+		}
 
 		// Use the $_SESSION global for storing data
 		$this->_data =& $_SESSION;


### PR DESCRIPTION
If output buffering has been disabled and output has been sent before sessions have started, this line throws an ErrorException with the message "A session had already been started - ignoring session_start()" .
