### PR TITLE
refs #4709: openssl_random_pseudo_bytes in Security::token

### DIFF
--- a/classes/Kohana/Security.php
+++ b/classes/Kohana/Security.php
@@ -50,7 +50,7 @@ class Kohana_Security {
 			// Generate a new unique token
 			if (function_exists('openssl_random_pseudo_bytes'))
 			{
-				// Generate a random pseudo bytes token if openssl_pseudo_random_bytes is available
+				// Generate a random pseudo bytes token if openssl_random_pseudo_bytes is available
 				// This is more secure than uniqid, because uniqid relies on microtime, which is predictable
 				$token = base64_encode(openssl_random_pseudo_bytes(32));
 			}

--- a/classes/Kohana/Security.php
+++ b/classes/Kohana/Security.php
@@ -48,7 +48,17 @@ class Kohana_Security {
 		if ($new === TRUE OR ! $token)
 		{
 			// Generate a new unique token
-			$token = sha1(uniqid(NULL, TRUE));
+			if (function_exists('openssl_random_pseudo_bytes'))
+			{
+				// Generate a random pseudo bytes token if openssl_pseudo_random_bytes is available
+				// This is more secure than uniqid, because uniqid relies on microtime, which is predictable
+				$token = base64_encode(openssl_random_pseudo_bytes(32));
+			}
+			else
+			{
+				// Otherwise, fall back to a hashed uniqid
+				$token = sha1(uniqid(NULL, TRUE));
+			}
 
 			// Store the new token
 			$session->set(Security::$token_name, $token);


### PR DESCRIPTION
More secure CSRF token generation, using openssl_random_pseudo_bytes with a fallback to uniqid if the function is not available.

This is more secure due to the fact that uniqid relies on microtime, which is predictable.

As addressed in: http://dev.kohanaframework.org/issues/4709
