### PR TITLE
fixed array to string conversion bug for the log writer

### DIFF
--- a/classes/Kohana/Log/Writer.php
+++ b/classes/Kohana/Log/Writer.php
@@ -12,21 +12,21 @@ abstract class Kohana_Log_Writer {
 
 	/**
 	 * @var  string  timestamp format for log entries.
-	 * 
+	 *
 	 * Defaults to Date::$timestamp_format
 	 */
 	public static $timestamp;
 
 	/**
 	 * @var  string  timezone for log entries
-	 * 
+	 *
 	 * Defaults to Date::$timezone, which defaults to date_default_timezone_get()
 	 */
 	public static $timezone;
 
 	/**
 	 * Numeric log level to string lookup table.
-	 * @var array 
+	 * @var array
 	 */
 	protected $_log_levels = array(
 		LOG_EMERG   => 'EMERGENCY',
@@ -68,22 +68,25 @@ abstract class Kohana_Log_Writer {
 
 	/**
 	 * Formats a log entry.
-	 * 
+	 *
 	 * @param   array   $message
 	 * @param   string  $format
 	 * @return  string
 	 */
 	public function format_message(array $message, $format = "time --- level: body in file:line")
 	{
+		$exception = isset($message['additional']['exception']) ? $message['additional']['exception'] : null;
 		$message['time'] = Date::formatted_time('@'.$message['time'], Log_Writer::$timestamp, Log_Writer::$timezone, TRUE);
 		$message['level'] = $this->_log_levels[$message['level']];
+		unset($message['additional']);
+		unset($message['trace']);
 
 		$string = strtr($format, $message);
 
-		if (isset($message['additional']['exception']))
+		if ($exception)
 		{
 			// Re-use as much as possible, just resetting the body to the trace
-			$message['body'] = $message['additional']['exception']->getTraceAsString();
+			$message['body'] = $exception->getTraceAsString();
 			$message['level'] = $this->_log_levels[Log_Writer::$strace_level];
 
 			$string .= PHP_EOL.strtr($format, $message);


### PR DESCRIPTION
http://forum.kohanaframework.org/discussion/11567/kohana-3-3-strtr-array-to-string-conversion-issue-in-kohana_log_writer/p1

https://bugs.php.net/bug.php?id=63893

http://php.net/manual/en/migration54.incompatible.php

On Servers with php 5.4 running, the error log function throws an Exception with the notice that some parts of the message (trace from the exception) can`t be castet to string.

With this Update from the First Forum link the bug will be fixed
