### PR TITLE
Fixes #4718: Duplicate unnecessary line that is not used anymore

### DIFF
--- a/classes/Kohana/Kohana/Exception.php
+++ b/classes/Kohana/Kohana/Exception.php
@@ -185,12 +185,6 @@ class Kohana_Kohana_Exception extends Exception {
 			$line    = $e->getLine();
 			$trace   = $e->getTrace();
 
-			if ( ! headers_sent())
-			{
-				// Make sure the proper http header is sent
-				$http_header_status = ($e instanceof HTTP_Exception) ? $code : 500;
-			}
-
 			/**
 			 * HTTP_Exceptions are constructed in the HTTP_Exception::factory()
 			 * method. We need to remove that entry from the trace and overwrite


### PR DESCRIPTION
This line has been moved to line 253 so the upper one is not used anymore.

http://dev.kohanaframework.org/issues/4718
