### PR TITLE
Added function Arr::filter()

### DIFF
--- a/classes/Kohana/Arr.php
+++ b/classes/Kohana/Arr.php
@@ -303,6 +303,29 @@ class Kohana_Arr {
 
 		return $found;
 	}
+	
+	/**
+	* Retrieves multiple keys from an array only if they exist.
+	*
+	* // Get the values "username", "password" from $_POST
+	* $auth = Arr::filter($_POST, array('username', 'password'));
+	*
+	* @param array array to filter keys from
+	* @param array list of key names to search for
+	* @return array
+	*/
+	public static function filter($array, array $keys)
+	{
+		$found = array();
+		foreach ($keys as $key)
+		{
+			if(isset($array[$key]))
+			{
+				$found[$key] = $array[$key];
+			}
+		}
+		return $found;
+	}
 
 	/**
 	 * Retrieves muliple single-key values from a list of arrays.


### PR DESCRIPTION
Similar to extract except that it doesnt return keys that arnt set in the first array.

EX.. 
Arr::filter(
  array('a' => 'foo', 'b' => 'bar'),
  array('a','c')
);
Returns array('a' => 'foo')
Key b is removed from results altogether.

This is particularly useful for extracting fields from $_POST for Model without leaveing unset values as NULL.
Regular extract in this situation will end up saving value "C" above as NULL even if your only attempting to change "A".
