### PR TITLE
refs #4723 - FIX on URI generation example

### DIFF
--- a/guide/kohana/routing.md
+++ b/guide/kohana/routing.md
@@ -244,11 +244,11 @@ Let's say you decided later to make that route definition more verbose by changi
 
 One method you might use frequently is the shortcut [Request::uri] which is the same as the above except it assumes the current route, directory, controller and action. If our current route is the default and the uri was `users/list`, we can do the following to generate uris in the format `users/view/$id`:
 
-    $this->request->uri(array('action' => 'view', 'id' => $user_id));
+    $this->request->route()->uri(array('action' => 'view', 'id' => $user_id));
     
 Or if within a view, the preferable method is:
 
-    Request::instance()->uri(array('action' => 'view', 'id' => $user_id));
+    Request::current()->route()->uri(array('action' => 'view', 'id' => $user_id));
 
 TODO: examples of using html::anchor in addition to the above examples
 


### PR DESCRIPTION
Basically, confusing uri() function from Route and Request.
`$this->request->uri()` is not the same as `$this->request->route()->uri()`.
Neither `Request::current()->uri` the same as `Request::current()->route()->uri`.

Also, Request::instance() was deprecated in favor of Request::current()
