### PR TITLE
Fixing returns in PHPdoc

### DIFF
--- a/classes/Kohana/Kohana/Exception.php
+++ b/classes/Kohana/Kohana/Exception.php
@@ -79,7 +79,7 @@ class Kohana_Kohana_Exception extends Exception {
 	 *
 	 * @uses    Kohana_Exception::response
 	 * @param   Exception  $e
-	 * @return  boolean
+	 * @return  void
 	 */
 	public static function handler(Exception $e)
 	{
@@ -97,7 +97,7 @@ class Kohana_Kohana_Exception extends Exception {
 	 *
 	 * @uses    Kohana_Exception::response
 	 * @param   Exception  $e
-	 * @return  boolean
+	 * @return  Response
 	 */
 	public static function _handler(Exception $e)
 	{


### PR DESCRIPTION
My IntelliJ (IDE) complains in the method handler() because the PHPdoc for Kohana_Exception::_handler() told it that a boolean was returned. The "boolean" was then used as an Response object. Since a Response was the actual returned value, I fixed the PHPdoc.
