### PR TITLE
Update Header.php

### DIFF
--- a/classes/Kohana/HTTP/Header.php
+++ b/classes/Kohana/HTTP/Header.php
@@ -295,8 +295,11 @@ class Kohana_HTTP_Header extends ArrayObject {
 		 * HTTP header declarations should be treated as case-insensitive
 		 */
 		$input = array_change_key_case( (array) $input, CASE_LOWER);
-
-		parent::__construct($input, $flags, $iterator_class);
+		/**
+		 * @link https://github.com/facebook/hiphop-php
+		 * on hiphop is wrong! fix!
+		 * /
+		parent::__construct($input, (int)$flags, $iterator_class);
 	}
 
 	/**


### PR DESCRIPTION
run in hiphop-php 
pHipHop Fatal error: Uncaught exception 'ErrorException' with message 'Argument 2 passed to ArrayObject::__construct() must be an instance of int, null given' in /var/www/system/classes/Kohana/HTTP/Header.php:299\nStack trace:\n#0 (): Kohana_Core::error_handler()
#1 /var/www/system/classes/Kohana/HTTP/Header.php(299): ArrayObject->__construct()
#2 /var/www/system/classes/Kohana/Request.php(659): Kohana_HTTP_Header->__construct()
#3 /var/www/system/classes/Kohana/Request.php(160): Kohana_Request->__construct()
#4 /var/www/index.php(117): Kohana_Request::factory()
#5 {main}
