### PR TITLE
Improved examples in DocBlock.

### DIFF
--- a/classes/Kohana/Text.php
+++ b/classes/Kohana/Text.php
@@ -686,7 +686,10 @@ class Kohana_Text {
 	/**
 	 * Turns an array of strings/ints into a readable, comma separated list.
 	 *
-	 * For example: array('eggs', 'milk', 'cheese') => "eggs, milk and cheese".
+	 * Examples:
+	 *     array('eggs', 'milk', 'cheese') => "eggs, milk, and cheese".
+	 *     array('eggs', 'milk', 'cheese', '&') => "eggs, milk, & cheese".
+	 *     array('eggs', 'milk', 'cheese', '&', FALSE) => "eggs, milk & cheese".
 	 *
 	 * @throws  InvalidArgumentException
 	 * @param   array   $words         An array of words.


### PR DESCRIPTION
This pull request adds improved examples which explicitly show how you can use the _readable_text()_ method.

This also clears up an inconsistency in the previous example, reported in the [original feature request](http://dev.kohanaframework.org/issues/4626#note-16).
