### PR TITLE
Detect secure HTTPS request via proxy

### DIFF
--- a/classes/Kohana/Request.php
+++ b/classes/Kohana/Request.php
@@ -80,7 +80,7 @@ class Kohana_Request implements HTTP_Request {
 			}
 
 			if (( ! empty($_SERVER['HTTPS']) AND filter_var($_SERVER['HTTPS'], FILTER_VALIDATE_BOOLEAN))
-			    OR (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https'))
+			    OR (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) AND $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https'))
 			{
 				// This request is secure
 				$secure = TRUE;

--- a/classes/Kohana/Request.php
+++ b/classes/Kohana/Request.php
@@ -79,7 +79,8 @@ class Kohana_Request implements HTTP_Request {
 				$method = HTTP_Request::GET;
 			}
 
-			if ( ! empty($_SERVER['HTTPS']) AND filter_var($_SERVER['HTTPS'], FILTER_VALIDATE_BOOLEAN))
+			if (( ! empty($_SERVER['HTTPS']) AND filter_var($_SERVER['HTTPS'], FILTER_VALIDATE_BOOLEAN))
+			    OR (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https'))
 			{
 				// This request is secure
 				$secure = TRUE;


### PR DESCRIPTION
Other properties already support proxy related attributes (eg. HTTP_X_FORWARDED_FOR) but not to determine whether the initial request was made via a secure HTTPS connection. This is useful if the web server is behind a proxy server.
