### PR TITLE
3.4/bugfix/add prefix useage to num helper

### DIFF
--- a/classes/Kohana/Num.php
+++ b/classes/Kohana/Num.php
@@ -56,6 +56,19 @@ class Kohana_Num {
 		'YiB' => 80,
 	);
 
+	public static $si_prefixes = array
+	(
+		'B'   => 0,
+		'KB'  => 3,
+		'MB'  => 6,
+		'GB'  => 9,
+		'TB'  => 12,
+		'PB'  => 15,
+		'EB'  => 18,
+		'ZB'  => 21,
+		'YB'  => 24,
+	);
+
 	/**
 	 * Returns the English ordinal suffix (th, st, nd, etc) of a number.
 	 *
@@ -202,7 +215,7 @@ class Kohana_Num {
 	 * @param   string  $bytes  file size in SB format
 	 * @return  float
 	 */
-	public static function bytes($size)
+	public static function bytes($size, $si = TRUE)
 	{
 		// Prepare the size
 		$size = trim( (string) $size);
@@ -225,8 +238,16 @@ class Kohana_Num {
 		// Find the actual unit, assume B if no unit specified
 		$unit = Arr::get($matches, 2, 'B');
 
-		// Convert the size into bytes
-		$bytes = $size * pow(2, Num::$byte_units[$unit]);
+		if(array_key_exists($unit, Num::$si_prefixes) AND $si === TRUE)
+		{
+			// Convert the size into bytes using SI prefixes (decimal)
+			$bytes = $size * pow(10, Num::$si_prefixes[$unit]);
+		}
+		else
+		{
+			// Convert the size into bytes
+			$bytes = $size * pow(2, Num::$byte_units[$unit]);
+		}
 
 		return $bytes;
 	}

--- a/classes/Kohana/Num.php
+++ b/classes/Kohana/Num.php
@@ -56,6 +56,9 @@ class Kohana_Num {
 		'YiB' => 80,
 	);
 
+	/**
+	 * @var  array  SI looking prefixes
+	 */
 	public static $si_prefixes = array
 	(
 		'B'   => 0,
@@ -210,10 +213,14 @@ class Kohana_Num {
 	 *     echo Num::bytes('200K');  // 204800
 	 *     echo Num::bytes('5MiB');  // 5242880
 	 *     echo Num::bytes('1000');  // 1000
-	 *     echo Num::bytes('2.5GB'); // 2684354560
+	 *     echo Num::bytes('2.5GB', FALSE); // 2684354560
+	 *     echo Num::bytes('2.5GB'); // 2500000000
+	 *     echo Num::bytes('2.5GiB'); // 2684354560
 	 *
-	 * @param   string  $bytes  file size in SB format
+	 * @param   string  $size  file size in SB format
+	 * @param   bool  $si Use SI prefixes
 	 * @return  float
+	 * @throws Kohana_Exception
 	 */
 	public static function bytes($size, $si = TRUE)
 	{

--- a/tests/kohana/NumTest.php
+++ b/tests/kohana/NumTest.php
@@ -52,7 +52,10 @@ class Kohana_NumTest extends Unittest_TestCase
 			array(204800.0, '200K'),
 			array(5242880.0, '5MiB'),
 			array(1000.0, 1000),
-			array(2684354560.0, '2.5GB'),
+			array(2684354560.0, '2.5GB', FALSE),
+			array(2684354560.0, '2.5GiB', FALSE),
+			array(2684354560.0, '2.5GiB', TRUE),
+			array(2500000000.0, '2.5GB'),
 		);
 	}
 	
@@ -65,9 +68,9 @@ class Kohana_NumTest extends Unittest_TestCase
 	 * @param integer Expected Value
 	 * @param string  Input value
 	 */
-	public function test_bytes($expected, $size)
+	public function test_bytes($expected, $size, $si = TRUE)
 	{
-		$this->assertSame($expected, Num::bytes($size));
+		$this->assertSame($expected, Num::bytes($size, $si));
 	}
 	
 	/**


### PR DESCRIPTION
This fixes the issue of MB and MiB returning the same value
http://dev.kohanaframework.org/issues/4178
http://forum.kohanaframework.org/discussion/9445/textbytes-numbytes250mb-doesnt-return-250-mb-whyss-ko3.1

Someone please run the tests for me. I couldn't test them.
