### PR TITLE
Include detailed exception message when cannot read session data.

### DIFF
--- a/classes/Kohana/Session.php
+++ b/classes/Kohana/Session.php
@@ -321,7 +321,7 @@ abstract class Kohana_Session {
 		catch (Exception $e)
 		{
 			// Error reading the session, usually a corrupt session.
-			throw new Session_Exception('Error reading session data.', NULL, Session_Exception::SESSION_CORRUPT);
+			throw new Session_Exception('Error reading session data. ' . $e->getMessage(), NULL, Session_Exception::SESSION_CORRUPT);
 		}
 
 		if (is_array($data))


### PR DESCRIPTION
When the session data cannot be read, PHP throws an exception, which is caught by Kohana. Kohana then throws a new exception with a generic message "Error reading session data.". So, in between, the real reason why the session cannot be read has been lost.

As a fix, I suggest to simply add the PHP built-in message to the basic Kohana one. That would change this kind of errors (which I recently got in PHPunit):

```
Error reading session data.
Error reading session data.
Error reading session data.
```

to something like this:

```
Error reading session data. session_start(): Cannot send session cookie - headers already sent by (output started at application/tests/ControllerTest.php:2)
Error reading session data. A session had already been started - ignoring session_start()
Error reading session data. A session had already been started - ignoring session_start()
```
