### PR TITLE
Update the license url, fixes #4778

### DIFF
--- a/classes/kohana/config/group.php
+++ b/classes/kohana/config/group.php
@@ -12,7 +12,7 @@
  * @category   Configuration
  * @author     Kohana Team
  * @copyright  (c) 2012 Kohana Team
- * @license    http://kohanaphp.com/license
+ * @license    http://kohanaframework.org/license
  */
 class Kohana_Config_Group extends ArrayObject {
 

--- a/classes/kohana/config/source.php
+++ b/classes/kohana/config/source.php
@@ -8,7 +8,7 @@
  * @category   Configuration
  * @author     Kohana Team
  * @copyright  (c) 2012 Kohana Team
- * @license    http://kohanaphp.com/license
+ * @license    http://kohanaframework.org/license
  */
 
 interface Kohana_Config_Source {}

--- a/classes/kohana/config/writer.php
+++ b/classes/kohana/config/writer.php
@@ -8,7 +8,7 @@
  * @package Kohana
  * @author  Kohana Team
  * @copyright  (c) 2008-2012 Kohana Team
- * @license    http://kohanaphp.com/license
+ * @license    http://kohanaframework.org/license
  */
 interface Kohana_Config_Writer extends Kohana_Config_Source
 {

--- a/classes/kohana/debug.php
+++ b/classes/kohana/debug.php
@@ -6,7 +6,7 @@
  * @category   Base
  * @author     Kohana Team
  * @copyright  (c) 2008-2012 Kohana Team
- * @license    http://kohanaphp.com/license
+ * @license    http://kohanaframework.org/license
  */
 class Kohana_Debug {
 

--- a/classes/kohana/http.php
+++ b/classes/kohana/http.php
@@ -12,7 +12,7 @@
  * @author     Kohana Team
  * @since      3.1.0
  * @copyright  (c) 2008-2012 Kohana Team
- * @license    http://kohanaphp.com/license
+ * @license    http://kohanaframework.org/license
  */
 abstract class Kohana_HTTP {
 

--- a/classes/kohana/http/header.php
+++ b/classes/kohana/http/header.php
@@ -10,7 +10,7 @@
  * @author     Kohana Team
  * @since      3.1.0
  * @copyright  (c) 2008-2012 Kohana Team
- * @license    http://kohanaphp.com/license
+ * @license    http://kohanaframework.org/license
  */
 class Kohana_HTTP_Header extends ArrayObject {
 

--- a/classes/kohana/http/message.php
+++ b/classes/kohana/http/message.php
@@ -8,7 +8,7 @@
  * @author     Kohana Team
  * @since      3.1.0
  * @copyright  (c) 2008-2012 Kohana Team
- * @license    http://kohanaphp.com/license
+ * @license    http://kohanaframework.org/license
  */
 interface Kohana_HTTP_Message {
 

--- a/classes/kohana/http/request.php
+++ b/classes/kohana/http/request.php
@@ -9,7 +9,7 @@
  * @author     Kohana Team
  * @since      3.1.0
  * @copyright  (c) 2008-2012 Kohana Team
- * @license    http://kohanaphp.com/license
+ * @license    http://kohanaframework.org/license
  */
 interface Kohana_HTTP_Request extends HTTP_Message {
 

--- a/classes/kohana/http/response.php
+++ b/classes/kohana/http/response.php
@@ -9,7 +9,7 @@
  * @author     Kohana Team
  * @since      3.1.0
  * @copyright  (c) 2008-2012 Kohana Team
- * @license    http://kohanaphp.com/license
+ * @license    http://kohanaframework.org/license
  */
 interface Kohana_HTTP_Response extends HTTP_Message {
 

--- a/classes/kohana/log/stderr.php
+++ b/classes/kohana/log/stderr.php
@@ -6,7 +6,7 @@
  * @category   Logging
  * @author     Kohana Team
  * @copyright  (c) 2008-2012 Kohana Team
- * @license    http://kohanaphp.com/license
+ * @license    http://kohanaframework.org/license
  */
 class Kohana_Log_StdErr extends Log_Writer {
 	/**

--- a/classes/kohana/log/stdout.php
+++ b/classes/kohana/log/stdout.php
@@ -6,7 +6,7 @@
  * @category   Logging
  * @author     Kohana Team
  * @copyright  (c) 2008-2012 Kohana Team
- * @license    http://kohanaphp.com/license
+ * @license    http://kohanaframework.org/license
  */
 class Kohana_Log_StdOut extends Log_Writer {
 	/**

--- a/classes/kohana/response.php
+++ b/classes/kohana/response.php
@@ -8,7 +8,7 @@
  * @category   Base
  * @author     Kohana Team
  * @copyright  (c) 2008-2012 Kohana Team
- * @license    http://kohanaphp.com/license
+ * @license    http://kohanaframework.org/license
  * @since      3.1.0
  */
 class Kohana_Response implements HTTP_Response {

--- a/tests/kohana/Config/File/ReaderTest.php
+++ b/tests/kohana/Config/File/ReaderTest.php
@@ -11,7 +11,7 @@
  * @author     Jeremy Bush <contractfrombelow@gmail.com>
  * @author     Matt Button <matthew@sigswitch.com>
  * @copyright  (c) 2008-2012 Kohana Team
- * @license    http://kohanaphp.com/license
+ * @license    http://kohanaframework.org/license
  */
 class Kohana_Config_File_ReaderTest extends Kohana_Unittest_TestCase {
 

--- a/tests/kohana/Config/GroupTest.php
+++ b/tests/kohana/Config/GroupTest.php
@@ -11,7 +11,7 @@
  * @author     Jeremy Bush <contractfrombelow@gmail.com>
  * @author     Matt Button <matthew@sigswitch.com>
  * @copyright  (c) 2008-2012 Kohana Team
- * @license    http://kohanaphp.com/license
+ * @license    http://kohanaframework.org/license
  */
 class Kohana_Config_GroupTest extends Kohana_Unittest_TestCase
 {

--- a/tests/kohana/DebugTest.php
+++ b/tests/kohana/DebugTest.php
@@ -14,7 +14,7 @@
  * @author     Kohana Team
  * @author     Jeremy Bush <contractfrombelow@gmail.com>
  * @copyright  (c) 2008-2012 Kohana Team
- * @license    http://kohanaphp.com/license
+ * @license    http://kohanaframework.org/license
  */
 class Kohana_DebugTest extends Unittest_TestCase
 {

--- a/tests/kohana/Http/HeaderTest.php
+++ b/tests/kohana/Http/HeaderTest.php
@@ -12,7 +12,7 @@
  * @category   Tests
  * @author     Kohana Team
  * @copyright  (c) 2008-2012 Kohana Team
- * @license    http://kohanaphp.com/license
+ * @license    http://kohanaframework.org/license
  */
 class Kohana_HTTP_HeaderTest extends Unittest_TestCase {
 


### PR DESCRIPTION
**Description:**

> The license location in the phpdoc comments are pointing to http://kohanaphp.com/license instead of http://kohanaframework.org/license.

**Ticket**:
http://dev.kohanaframework.org/issues/4778
