### PR TITLE
Only copy original request headers when following redirects [fixes #4790]

### DIFF
--- a/classes/Kohana/Request/Client.php
+++ b/classes/Kohana/Request/Client.php
@@ -405,10 +405,13 @@ abstract class Kohana_Request_Client {
 					break;
 			}
 
-			// Prepare the additional request
+			// Prepare the additional request, copying any follow_headers that were present on the original request
+			$orig_headers = $request->headers()->getArrayCopy();
+			$follow_headers = array_intersect_assoc($orig_headers, array_fill_keys($client->follow_headers(), TRUE));
+
 			$follow_request = Request::factory($response->headers('Location'))
 			                         ->method($follow_method)
-			                         ->headers(Arr::extract($request->headers(), $client->follow_headers()));
+			                         ->headers($follow_headers);
 
 			if ($follow_method !== Request::GET)
 			{

--- a/tests/kohana/request/ClientTest.php
+++ b/tests/kohana/request/ClientTest.php
@@ -176,6 +176,29 @@ class Kohana_Request_ClientTest extends Unittest_TestCase
 	}
 
 	/**
+	 * Tests that the follow_headers are only added to a redirect request if they were present in the original
+	 *
+	 * @ticket 4790
+	 */
+	public function test_follow_does_not_add_extra_headers()
+	{
+		$response = Request::factory(
+			            $this->_dummy_redirect_uri(301),
+			            array(
+			                 'follow' => TRUE,
+			                 'follow_headers' => array('Authorization')
+			            ))
+		            ->headers(array())
+		            ->execute();
+
+		$data = json_decode($response->body(),TRUE);
+		$headers = $data['rq_headers'];
+
+		$this->assertArrayNotHasKey('authorization', $headers, 'Empty headers should not be added when following redirects');
+	}
+
+
+	/**
 	 * Provider for test_follows_with_strict_method
 	 *
 	 * @return array


### PR DESCRIPTION
When following a redirect, the client should not add NULL headers
from the follow_headers list that were not set on the original
request. This prevents problems when requesting URLs that
include an authorization signature calculated from the request URL
and headers.

Fixes http://dev.kohanaframework.org/issues/4790
