### PR TITLE
Don't set empty body on external curl requests [Fixes #4791]

### DIFF
--- a/classes/kohana/request/client/curl.php
+++ b/classes/kohana/request/client/curl.php
@@ -33,7 +33,10 @@ class Kohana_Request_Client_Curl extends Request_Client_External {
 		// if using a request other than POST. PUT does support this method
 		// and DOES NOT require writing data to disk before putting it, if
 		// reading the PHP docs you may have got that impression. SdF
-		$options[CURLOPT_POSTFIELDS] = $request->body();
+		// This will also add a Content-Type: application/x-www-form-urlencoded header unless you override it
+		if ($body = $request->body()) {
+			$options[CURLOPT_POSTFIELDS] = $body;
+		}
 
 		// Process headers
 		if ($headers = $request->headers())


### PR DESCRIPTION
When the CURLOPT_POSTFIELDS option is present, curl adds a
default Content-Type header which can be changed but not
removed, causing authentication problems with signed requests.

The option should only be set if a request body is being sent.

Fixes http://dev.kohanaframework.org/issues/4791 - see issue discussion regarding tests for this issue and fix.

This is a replacement for #402 which I'd accidentally targeted to 3.3/master instead of 3.3/develop, and I've subsequently rebased back to 3.2/develop.
