### PR TITLE
Move cookie salt description up.

### DIFF
--- a/guide/kohana/install.md
+++ b/guide/kohana/install.md
@@ -19,6 +19,14 @@
 				'base_url'   => '/mywebsite',
 			));
 		~~~	
+
+	- Define a salt for the `Cookie` class.
+		~~~
+			Cookie::$salt = [really-long-cookie-salt-here]
+		~~~
+
+ [!!] Make sure to use a unique salt for your application and never to share it. Take a look at the [Cookies](cookies) page for more information on how cookies work in Kohana. If you do not define a `Cookie::$salt` value, Kohana will throw an exception when it encounters any cookie on your domain.
+
 6. Make sure the `application/cache` and `application/logs` directories are writable by the web server.
 
 	~~~

--- a/guide/kohana/install.md
+++ b/guide/kohana/install.md
@@ -19,7 +19,6 @@
 				'base_url'   => '/mywebsite',
 			));
 		~~~	
-
 	- Define a salt for the `Cookie` class.
 		~~~
 			Cookie::$salt = [really-long-cookie-salt-here]


### PR DESCRIPTION
The cookie salt description belongs inside the bootstrap.php
documentation. Putting this above the filesystem changes and with the
other bootstrap.php changes just makes sense.
