### PR TITLE
Fixes issue that would render integer 0 as blank

### DIFF
--- a/classes/Kohana/HTML.php
+++ b/classes/Kohana/HTML.php
@@ -332,7 +332,7 @@ class Kohana_HTML {
 			// Add the attribute key
 			$compiled .= ' '.$key;
 
-			if ($value OR HTML::$strict)
+			if ($value !== FALSE OR HTML::$strict)
 			{
 				// Add the attribute value
 				$compiled .= '="'.HTML::chars($value).'"';


### PR DESCRIPTION
When passing in a 0 (integer) as a value, HTML::attributes would render it blank because it was detecting it as false. With this little change, it'd be looking for a !== match.
