### PR TITLE
Replaced '://' with '//' for SDN URL's

### DIFF
--- a/classes/Kohana/HTML.php
+++ b/classes/Kohana/HTML.php
@@ -118,7 +118,7 @@ class Kohana_HTML {
 		}
 		else
 		{
-			if (strpos($uri, '://') !== FALSE)
+			if (strpos($uri, '//') !== FALSE)
 			{
 				if (HTML::$windowed_urls === TRUE AND empty($attributes['target']))
 				{
@@ -206,7 +206,7 @@ class Kohana_HTML {
 	 */
 	public static function style($file, array $attributes = NULL, $protocol = NULL, $index = FALSE)
 	{
-		if (strpos($file, '://') === FALSE)
+		if (strpos($file, '//') === FALSE)
 		{
 			// Add the base URL
 			$file = URL::site($file, $protocol, $index);
@@ -239,7 +239,7 @@ class Kohana_HTML {
 	 */
 	public static function script($file, array $attributes = NULL, $protocol = NULL, $index = FALSE)
 	{
-		if (strpos($file, '://') === FALSE)
+		if (strpos($file, '//') === FALSE)
 		{
 			// Add the base URL
 			$file = URL::site($file, $protocol, $index);
@@ -269,7 +269,7 @@ class Kohana_HTML {
 	 */
 	public static function image($file, array $attributes = NULL, $protocol = NULL, $index = FALSE)
 	{
-		if (strpos($file, '://') === FALSE)
+		if (strpos($file, '//') === FALSE)
 		{
 			// Add the base URL
 			$file = URL::site($file, $protocol, $index);


### PR DESCRIPTION
The current check doesn't handle propperly SDN addresses, for example:

```
HTML::script('//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js');
```
