### PR TITLE
Ref #4802: HTTP_Header not compatible with ArrayObject

### DIFF
--- a/classes/Kohana/HTTP/Header.php
+++ b/classes/Kohana/HTTP/Header.php
@@ -287,7 +287,7 @@ class Kohana_HTTP_Header extends ArrayObject {
 	 * @param   int     $flags          Flags
 	 * @param   string  $iterator_class The iterator class to use
 	 */
-	public function __construct(array $input = array(), $flags = NULL, $iterator_class = 'ArrayIterator')
+	public function __construct(array $input = array(), $flags = 0, $iterator_class = 'ArrayIterator')
 	{
 		/**
 		 * @link http://www.w3.org/Protocols/rfc2616/rfc2616.html


### PR DESCRIPTION
HHVM complains about this. The Zend engine silently ignore the bug, probably casting the NULL internally to int 0.

Could not create a test for it, as this works with Zend, but it's fatal in HHVM.
