### PR TITLE
#4201 - Issue with validation labels

### DIFF
--- a/classes/kohana/validation.php
+++ b/classes/kohana/validation.php
@@ -219,7 +219,7 @@ class Kohana_Validation implements ArrayAccess {
 		if ($field !== TRUE AND ! isset($this->_labels[$field]))
 		{
 			// Set the field label to the field name
-			$this->_labels[$field] = preg_replace('/[^\pL]+/u', ' ', $field);
+			$this->_labels[$field] = $field);
 		}
 
 		// Store the rule and params for this rule

--- a/classes/kohana/validation.php
+++ b/classes/kohana/validation.php
@@ -219,7 +219,7 @@ class Kohana_Validation implements ArrayAccess {
 		if ($field !== TRUE AND ! isset($this->_labels[$field]))
 		{
 			// Set the field label to the field name
-			$this->_labels[$field] = $field);
+			$this->_labels[$field] = $field;
 		}
 
 		// Store the rule and params for this rule

--- a/tests/kohana/ValidationTest.php
+++ b/tests/kohana/ValidationTest.php
@@ -665,4 +665,48 @@ class Kohana_ValidationTest extends Unittest_TestCase
 		$this->assertSame($errors, $validation->errors('validation'));
 	}
 
+	/**
+	 * Provides test data for test_rule_label_regex
+	 *
+	 * @return array
+	 */
+	public function provider_rule_label_regex()
+	{
+		// $data, $field, $rules, $expected
+		return array(
+			array(
+				array(
+					'email1' => '',
+				),
+				'email1',
+				array(
+					array(
+						'not_empty'
+					)
+				),
+				array(
+					'email1' => 'email1 must not be empty'
+				),
+			)
+		);
+	}
+
+	/**
+	 * http://dev.kohanaframework.org/issues/4201
+	 *
+	 * @test
+	 * @ticket 4201
+	 * @covers Validation::rule
+	 * @dataProvider provider_rule_label_regex
+	 */
+	public function test_rule_label_regex($data, $field, $rules, $expected)
+	{
+		$validation = Validation::factory($data)->rules($field, $rules);
+
+		$validation->check();
+
+		$errors = $validation->errors('');
+
+		$this->assertSame($errors, $expected);
+	}
 }


### PR DESCRIPTION
When fields such as 'field1', 'field2' etc. were used, the preg_replace changed their label to 'field', stripping the number out. Test included.

See: http://dev.kohanaframework.org/issues/4201#change-17077
