### PR TITLE
#4079 - Route::uri() Should encode parameters

### DIFF
--- a/classes/kohana/route.php
+++ b/classes/kohana/route.php
@@ -456,7 +456,7 @@ class Kohana_Route {
 	 */
 	public function uri(array $params = NULL)
 	{
-		if (is_array($params))
+		if ($params)
 		{
 			$params = array_map('rawurlencode', $params);
 		}

--- a/classes/kohana/route.php
+++ b/classes/kohana/route.php
@@ -456,6 +456,11 @@ class Kohana_Route {
 	 */
 	public function uri(array $params = NULL)
 	{
+		if (is_array($params))
+		{
+			$params = array_map('rawurlencode', $params);
+		}
+
 		// Start with the routed URI
 		$uri = $this->_uri;
 

--- a/tests/kohana/RouteTest.php
+++ b/tests/kohana/RouteTest.php
@@ -715,4 +715,41 @@ class Kohana_RouteTest extends Unittest_TestCase
 
 		$this->assertSame($expected_uri, Route::get('test')->uri());
 	}
+
+	/**
+	 * Provides test data for test_route_uri_encode_parameters
+	 *
+	 * @return array
+	 */
+	public function provider_route_uri_encode_parameters()
+	{
+		return array(
+			array(
+				'article',
+				'blog/article/<article_name>',
+				array(
+					'controller' => 'home',
+					'action' => 'index'
+				),
+				'blog/article/Article%20name%20with%20special%20chars%20%5C%20%23%23'
+			)
+		);
+	}
+
+	/**
+	 * http://dev.kohanaframework.org/issues/4079
+	 *
+	 * @test
+	 * @covers Route::get
+	 * @ticket 4079
+	 * @dataProvider provider_route_uri_encode_parameters
+	 */
+	public function test_route_uri_encode_parameters($name, $uri_callback, $defaults, $expected)
+	{
+		Route::set($name, $uri_callback)->defaults($defaults);
+
+		$get_route_uri = Route::get($name)->uri(array('article_name' => 'Article name with special chars \\ ##'));
+
+		$this->assertSame($expected, $get_route_uri);
+	}
 }

--- a/tests/kohana/RouteTest.php
+++ b/tests/kohana/RouteTest.php
@@ -731,6 +731,8 @@ class Kohana_RouteTest extends Unittest_TestCase
 					'controller' => 'home',
 					'action' => 'index'
 				),
+				'article_name',
+				'Article name with special chars \\ ##',
 				'blog/article/Article%20name%20with%20special%20chars%20%5C%20%23%23'
 			)
 		);
@@ -744,11 +746,11 @@ class Kohana_RouteTest extends Unittest_TestCase
 	 * @ticket 4079
 	 * @dataProvider provider_route_uri_encode_parameters
 	 */
-	public function test_route_uri_encode_parameters($name, $uri_callback, $defaults, $expected)
+	public function test_route_uri_encode_parameters($name, $uri_callback, $defaults, $uri_key, $uri_value, $expected)
 	{
 		Route::set($name, $uri_callback)->defaults($defaults);
 
-		$get_route_uri = Route::get($name)->uri(array('article_name' => 'Article name with special chars \\ ##'));
+		$get_route_uri = Route::get($name)->uri(array($uri_key => $uri_value));
 
 		$this->assertSame($expected, $get_route_uri);
 	}


### PR DESCRIPTION
Route::uri() does not currently handle special characters very well.

route.php modification was copied from @jimktrains (#306), but I've used rawurlencode to achieve OP's expected result.

See: http://dev.kohanaframework.org/issues/4079
