### PR TITLE
#4482 - Array to string conversion in deep Arr::merge

### DIFF
--- a/classes/kohana/arr.php
+++ b/classes/kohana/arr.php
@@ -445,7 +445,7 @@ class Kohana_Arr {
 
 							foreach ($val as $val_val)
 							{
-								if ( ! in_array($val_val, $result[$key]))
+								if ( ! in_array($val_val, $result[$key], TRUE))
 								{
 									$diff[] = $val_val;
 								}

--- a/classes/kohana/arr.php
+++ b/classes/kohana/arr.php
@@ -441,7 +441,15 @@ class Kohana_Arr {
 						else
 						{
 							// Find the values that are not already present
-							$diff = array_diff($val, $result[$key]);
+							$diff = array();
+
+							foreach ($val as $val_val)
+							{
+								if ( ! in_array($val_val, $result[$key]))
+								{
+									$diff[] = $val_val;
+								}
+							}
 
 							// Indexed arrays are merged to prevent duplicates
 							$result[$key] = array_merge($result[$key], $diff);

--- a/tests/kohana/ArrTest.php
+++ b/tests/kohana/ArrTest.php
@@ -280,6 +280,45 @@ class Kohana_ArrTest extends Unittest_TestCase
 				array('foo'	=> array('bar')),
 				array('foo'	=> 'bar'),
 			),
+			/**
+			 * @ticket 4482
+			 */
+			array(
+				array(
+					'foo' => array(
+						'bar' => array(
+							array(
+								'foo'  => 'bar',
+								'bar' => TRUE,
+							),
+							array(
+								'foo1'  => 'foo',
+								'bar1' => FALSE,
+							),
+						),
+					),
+				),
+				array(
+					'foo' => array(
+						'bar' => array(
+							array(
+								'foo'  => 'bar',
+								'bar' => TRUE,
+							),
+						),
+					),
+				),
+				array(
+					'foo' => array(
+						'bar' => array(
+							array(
+								'foo1'  => 'foo',
+								'bar1' => FALSE,
+							),
+						),
+					),
+				)
+			)
 		);
 	}
 

--- a/tests/kohana/ArrTest.php
+++ b/tests/kohana/ArrTest.php
@@ -287,22 +287,19 @@ class Kohana_ArrTest extends Unittest_TestCase
 				array(
 					'foo' => array(
 						'bar' => array(
+							'foo'  => TRUE,
 							array(
-								'foo'  => 'bar',
 								'bar' => TRUE,
-							),
-							array(
-								'foo1'  => 'foo',
 								'bar1' => FALSE,
 							),
 						),
-					),
+					)
 				),
 				array(
 					'foo' => array(
 						'bar' => array(
+							'foo'  => 'php',
 							array(
-								'foo'  => 'bar',
 								'bar' => TRUE,
 							),
 						),
@@ -311,14 +308,14 @@ class Kohana_ArrTest extends Unittest_TestCase
 				array(
 					'foo' => array(
 						'bar' => array(
+							'foo' => TRUE,
 							array(
-								'foo1'  => 'foo',
 								'bar1' => FALSE,
 							),
 						),
 					),
 				)
-			)
+			),
 		);
 	}
 


### PR DESCRIPTION
When using Arr::merge to merge arrays, the deeper array merges failed and caused a ErrorException [ Notice ]: Array to string conversion

See: http://dev.kohanaframework.org/issues/4482

Also:

Added extra entry to array in test and changed in_array to strict.
Performance:
Non Strinct: http://i.imgur.com/JiRtUxQ.png
Strict: http://i.imgur.com/nRmgHVS.png
