### PR TITLE
Bug 4235 exclude external routes2

### DIFF
--- a/classes/kohana/request.php
+++ b/classes/kohana/request.php
@@ -578,6 +578,12 @@ class Kohana_Request implements HTTP_Request {
 
 		foreach ($routes as $name => $route)
 		{
+			// Use external routes for reverse routing only
+			if ($route->is_external())
+			{
+				continue;
+			}
+
 			// We found something suitable
 			if ($params = $route->matches($uri))
 			{


### PR DESCRIPTION
Pull request for http://dev.kohanaframework.org/issues/4235. External routes can be used for reverse routing only. (clean version of https://github.com/kohana/core/pull/436)
