### PR TITLE
Fixes #4813 by Using Kohana_UTF8 from version 3.3 to apply all the patches

### DIFF
--- a/classes/kohana/utf8.php
+++ b/classes/kohana/utf8.php
@@ -63,21 +63,21 @@ class Kohana_UTF8 {
 			foreach ($var as $key => $val)
 			{
 				// Recursion!
-				$var[self::clean($key)] = self::clean($val);
+				$var[UTF8::clean($key)] = UTF8::clean($val);
 			}
 		}
 		elseif (is_string($var) AND $var !== '')
 		{
 			// Remove control characters
-			$var = self::strip_ascii_ctrl($var);
+			$var = UTF8::strip_ascii_ctrl($var);
 
-			if ( ! self::is_ascii($var))
+			if ( ! UTF8::is_ascii($var))
 			{
 				// Disable notices
 				$error_reporting = error_reporting(~E_NOTICE);
 
 				// iconv is expensive, so it is only used when needed
-				$var = iconv($charset, $charset.'//IGNORE', $var);
+				$var = mb_convert_encoding($var, $charset, $charset);
 
 				// Turn notices back on
 				error_reporting($error_reporting);
@@ -144,12 +144,12 @@ class Kohana_UTF8 {
 	 */
 	public static function transliterate_to_ascii($str, $case = 0)
 	{
-		if ( ! isset(self::$called[__FUNCTION__]))
+		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
 			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
-			self::$called[__FUNCTION__] = TRUE;
+			UTF8::$called[__FUNCTION__] = TRUE;
 		}
 
 		return _transliterate_to_ascii($str, $case);
@@ -170,12 +170,12 @@ class Kohana_UTF8 {
 		if (UTF8::$server_utf8)
 			return mb_strlen($str, Kohana::$charset);
 
-		if ( ! isset(self::$called[__FUNCTION__]))
+		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
 			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
-			self::$called[__FUNCTION__] = TRUE;
+			UTF8::$called[__FUNCTION__] = TRUE;
 		}
 
 		return _strlen($str);
@@ -200,12 +200,12 @@ class Kohana_UTF8 {
 		if (UTF8::$server_utf8)
 			return mb_strpos($str, $search, $offset, Kohana::$charset);
 
-		if ( ! isset(self::$called[__FUNCTION__]))
+		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
 			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
-			self::$called[__FUNCTION__] = TRUE;
+			UTF8::$called[__FUNCTION__] = TRUE;
 		}
 
 		return _strpos($str, $search, $offset);
@@ -230,12 +230,12 @@ class Kohana_UTF8 {
 		if (UTF8::$server_utf8)
 			return mb_strrpos($str, $search, $offset, Kohana::$charset);
 
-		if ( ! isset(self::$called[__FUNCTION__]))
+		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
 			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
-			self::$called[__FUNCTION__] = TRUE;
+			UTF8::$called[__FUNCTION__] = TRUE;
 		}
 
 		return _strrpos($str, $search, $offset);
@@ -262,12 +262,12 @@ class Kohana_UTF8 {
 				? mb_substr($str, $offset, mb_strlen($str), Kohana::$charset)
 				: mb_substr($str, $offset, $length, Kohana::$charset);
 
-		if ( ! isset(self::$called[__FUNCTION__]))
+		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
 			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
-			self::$called[__FUNCTION__] = TRUE;
+			UTF8::$called[__FUNCTION__] = TRUE;
 		}
 
 		return _substr($str, $offset, $length);
@@ -287,12 +287,12 @@ class Kohana_UTF8 {
 	 */
 	public static function substr_replace($str, $replacement, $offset, $length = NULL)
 	{
-		if ( ! isset(self::$called[__FUNCTION__]))
+		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
 			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
-			self::$called[__FUNCTION__] = TRUE;
+			UTF8::$called[__FUNCTION__] = TRUE;
 		}
 
 		return _substr_replace($str, $replacement, $offset, $length);
@@ -314,12 +314,12 @@ class Kohana_UTF8 {
 		if (UTF8::$server_utf8)
 			return mb_strtolower($str, Kohana::$charset);
 
-		if ( ! isset(self::$called[__FUNCTION__]))
+		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
 			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
-			self::$called[__FUNCTION__] = TRUE;
+			UTF8::$called[__FUNCTION__] = TRUE;
 		}
 
 		return _strtolower($str);
@@ -340,12 +340,12 @@ class Kohana_UTF8 {
 		if (UTF8::$server_utf8)
 			return mb_strtoupper($str, Kohana::$charset);
 
-		if ( ! isset(self::$called[__FUNCTION__]))
+		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
 			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
-			self::$called[__FUNCTION__] = TRUE;
+			UTF8::$called[__FUNCTION__] = TRUE;
 		}
 
 		return _strtoupper($str);
@@ -363,12 +363,12 @@ class Kohana_UTF8 {
 	 */
 	public static function ucfirst($str)
 	{
-		if ( ! isset(self::$called[__FUNCTION__]))
+		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
 			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
-			self::$called[__FUNCTION__] = TRUE;
+			UTF8::$called[__FUNCTION__] = TRUE;
 		}
 
 		return _ucfirst($str);
@@ -387,12 +387,12 @@ class Kohana_UTF8 {
 	 */
 	public static function ucwords($str)
 	{
-		if ( ! isset(self::$called[__FUNCTION__]))
+		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
 			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
-			self::$called[__FUNCTION__] = TRUE;
+			UTF8::$called[__FUNCTION__] = TRUE;
 		}
 
 		return _ucwords($str);
@@ -413,12 +413,12 @@ class Kohana_UTF8 {
 	 */
 	public static function strcasecmp($str1, $str2)
 	{
-		if ( ! isset(self::$called[__FUNCTION__]))
+		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
 			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
-			self::$called[__FUNCTION__] = TRUE;
+			UTF8::$called[__FUNCTION__] = TRUE;
 		}
 
 		return _strcasecmp($str1, $str2);
@@ -442,12 +442,12 @@ class Kohana_UTF8 {
 	 */
 	public static function str_ireplace($search, $replace, $str, & $count = NULL)
 	{
-		if ( ! isset(self::$called[__FUNCTION__]))
+		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
 			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
-			self::$called[__FUNCTION__] = TRUE;
+			UTF8::$called[__FUNCTION__] = TRUE;
 		}
 
 		return _str_ireplace($search, $replace, $str, $count);
@@ -468,12 +468,12 @@ class Kohana_UTF8 {
 	 */
 	public static function stristr($str, $search)
 	{
-		if ( ! isset(self::$called[__FUNCTION__]))
+		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
 			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
-			self::$called[__FUNCTION__] = TRUE;
+			UTF8::$called[__FUNCTION__] = TRUE;
 		}
 
 		return _stristr($str, $search);
@@ -494,12 +494,12 @@ class Kohana_UTF8 {
 	 */
 	public static function strspn($str, $mask, $offset = NULL, $length = NULL)
 	{
-		if ( ! isset(self::$called[__FUNCTION__]))
+		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
 			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
-			self::$called[__FUNCTION__] = TRUE;
+			UTF8::$called[__FUNCTION__] = TRUE;
 		}
 
 		return _strspn($str, $mask, $offset, $length);
@@ -520,12 +520,12 @@ class Kohana_UTF8 {
 	 */
 	public static function strcspn($str, $mask, $offset = NULL, $length = NULL)
 	{
-		if ( ! isset(self::$called[__FUNCTION__]))
+		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
 			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
-			self::$called[__FUNCTION__] = TRUE;
+			UTF8::$called[__FUNCTION__] = TRUE;
 		}
 
 		return _strcspn($str, $mask, $offset, $length);
@@ -546,12 +546,12 @@ class Kohana_UTF8 {
 	 */
 	public static function str_pad($str, $final_str_length, $pad_str = ' ', $pad_type = STR_PAD_RIGHT)
 	{
-		if ( ! isset(self::$called[__FUNCTION__]))
+		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
 			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
-			self::$called[__FUNCTION__] = TRUE;
+			UTF8::$called[__FUNCTION__] = TRUE;
 		}
 
 		return _str_pad($str, $final_str_length, $pad_str, $pad_type);
@@ -570,12 +570,12 @@ class Kohana_UTF8 {
 	 */
 	public static function str_split($str, $split_length = 1)
 	{
-		if ( ! isset(self::$called[__FUNCTION__]))
+		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
 			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
-			self::$called[__FUNCTION__] = TRUE;
+			UTF8::$called[__FUNCTION__] = TRUE;
 		}
 
 		return _str_split($str, $split_length);
@@ -592,12 +592,12 @@ class Kohana_UTF8 {
 	 */
 	public static function strrev($str)
 	{
-		if ( ! isset(self::$called[__FUNCTION__]))
+		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
 			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
-			self::$called[__FUNCTION__] = TRUE;
+			UTF8::$called[__FUNCTION__] = TRUE;
 		}
 
 		return _strrev($str);
@@ -616,12 +616,12 @@ class Kohana_UTF8 {
 	 */
 	public static function trim($str, $charlist = NULL)
 	{
-		if ( ! isset(self::$called[__FUNCTION__]))
+		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
 			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
-			self::$called[__FUNCTION__] = TRUE;
+			UTF8::$called[__FUNCTION__] = TRUE;
 		}
 
 		return _trim($str, $charlist);
@@ -640,12 +640,12 @@ class Kohana_UTF8 {
 	 */
 	public static function ltrim($str, $charlist = NULL)
 	{
-		if ( ! isset(self::$called[__FUNCTION__]))
+		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
 			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
-			self::$called[__FUNCTION__] = TRUE;
+			UTF8::$called[__FUNCTION__] = TRUE;
 		}
 
 		return _ltrim($str, $charlist);
@@ -664,12 +664,12 @@ class Kohana_UTF8 {
 	 */
 	public static function rtrim($str, $charlist = NULL)
 	{
-		if ( ! isset(self::$called[__FUNCTION__]))
+		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
 			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
-			self::$called[__FUNCTION__] = TRUE;
+			UTF8::$called[__FUNCTION__] = TRUE;
 		}
 
 		return _rtrim($str, $charlist);
@@ -687,12 +687,12 @@ class Kohana_UTF8 {
 	 */
 	public static function ord($chr)
 	{
-		if ( ! isset(self::$called[__FUNCTION__]))
+		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
 			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
-			self::$called[__FUNCTION__] = TRUE;
+			UTF8::$called[__FUNCTION__] = TRUE;
 		}
 
 		return _ord($chr);
@@ -717,12 +717,12 @@ class Kohana_UTF8 {
 	 */
 	public static function to_unicode($str)
 	{
-		if ( ! isset(self::$called[__FUNCTION__]))
+		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
 			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
-			self::$called[__FUNCTION__] = TRUE;
+			UTF8::$called[__FUNCTION__] = TRUE;
 		}
 
 		return _to_unicode($str);
@@ -747,18 +747,26 @@ class Kohana_UTF8 {
 	 */
 	public static function from_unicode($arr)
 	{
-		if ( ! isset(self::$called[__FUNCTION__]))
+		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
 			require Kohana::find_file('utf8', __FUNCTION__);
 
 			// Function has been called
-			self::$called[__FUNCTION__] = TRUE;
+			UTF8::$called[__FUNCTION__] = TRUE;
 		}
 
 		return _from_unicode($arr);
 	}
 
 } // End UTF8
+
+/**
+ * Set the mb_substitute_character to "none"
+ *
+ * @link http://www.php.net/manual/function.mb-substitute-character.php
+ */
+
+mb_substitute_character('none');
 
 if (Kohana_UTF8::$server_utf8 === NULL)
 {

--- a/classes/kohana/utf8.php
+++ b/classes/kohana/utf8.php
@@ -73,14 +73,19 @@ class Kohana_UTF8 {
 
 			if ( ! UTF8::is_ascii($var))
 			{
-				// Disable notices
-				$error_reporting = error_reporting(~E_NOTICE);
 
+				// Set the mb_substitute_character() value into temporary variable
+				$mb_substitute_character = mb_substitute_character();
+				
+				// Disable substituting illigal characters with the default '?' character
+				mb_substitute_character('none');
+				
 				// iconv is expensive, so it is only used when needed
 				$var = mb_convert_encoding($var, $charset, $charset);
+				
+				// Reset mb_substitute_character() value back to the original setting
+				mb_substitute_character($mb_substitute_character);
 
-				// Turn notices back on
-				error_reporting($error_reporting);
 			}
 		}
 
@@ -759,14 +764,6 @@ class Kohana_UTF8 {
 	}
 
 } // End UTF8
-
-/**
- * Set the mb_substitute_character to "none"
- *
- * @link http://www.php.net/manual/function.mb-substitute-character.php
- */
-
-mb_substitute_character('none');
 
 if (Kohana_UTF8::$server_utf8 === NULL)
 {

--- a/classes/kohana/utf8.php
+++ b/classes/kohana/utf8.php
@@ -80,7 +80,7 @@ class Kohana_UTF8 {
 				// Disable substituting illigal characters with the default '?' character
 				mb_substitute_character('none');
 				
-				// iconv is expensive, so it is only used when needed
+				// mb_convert_encoding is expensive, so it is only used when needed
 				$var = mb_convert_encoding($var, $charset, $charset);
 				
 				// Reset mb_substitute_character() value back to the original setting


### PR DESCRIPTION
Fixes Kohana_UTF8Test::test_clean with data set no.3
and Kohana_DebugTest::test_dump with data set no.6
