### PR TITLE
Fixes #3604: default to ini setting if Cookie::$domain not available

### DIFF
--- a/classes/kohana/session/native.php
+++ b/classes/kohana/session/native.php
@@ -31,7 +31,7 @@ class Kohana_Session_Native extends Session {
 		// see issue #3604
 		//
 		// set to Cookie::$domain if available, otherwise default to ini setting, 
-		$session_cookie_domain = empty(Cookie::$domain) ?
+		$session_cookie_domain = Cookie::$domain ?
 			Cookie::$domain :
 			ini_get('session.cookie_domain');
 		

--- a/classes/kohana/session/native.php
+++ b/classes/kohana/session/native.php
@@ -30,11 +30,11 @@ class Kohana_Session_Native extends Session {
 		//
 		// see issue #3604
 		//
-		// set to Cookie::$domain if available, otherwise default to ini setting, 
-		$session_cookie_domain = Cookie::$domain
-		    ? Cookie::$domain
-		    : ini_get('session.cookie_domain');
-		
+		// set to Cookie::$domain if available, otherwise default to ini setting
+		$session_cookie_domain = empty(Cookie::$domain)
+		    ? ini_get('session.cookie_domain')
+		    : Cookie::$domain;
+
 		// Sync up the session cookie with Cookie parameters
 		session_set_cookie_params(
 			$this->_lifetime,

--- a/classes/kohana/session/native.php
+++ b/classes/kohana/session/native.php
@@ -25,7 +25,14 @@ class Kohana_Session_Native extends Session {
 	protected function _read($id = NULL)
 	{
 		// Sync up the session cookie with Cookie parameters
-		session_set_cookie_params($this->_lifetime, Cookie::$path, Cookie::$domain, Cookie::$secure, Cookie::$httponly);
+		session_set_cookie_params(
+			$this->_lifetime,
+			Cookie::$path,
+			// set to Cookie::$domain if available, otherwise default to ini setting, see issue #3604
+			Cookie::$domain ? : ini_get('session.cookie_domain'),
+			Cookie::$secure,
+			Cookie::$httponly
+		);
 
 		// Do not allow PHP to send Cache-Control headers
 		session_cache_limiter(FALSE);

--- a/classes/kohana/session/native.php
+++ b/classes/kohana/session/native.php
@@ -31,9 +31,9 @@ class Kohana_Session_Native extends Session {
 		// see issue #3604
 		//
 		// set to Cookie::$domain if available, otherwise default to ini setting, 
-		$session_cookie_domain = Cookie::$domain ?
-			Cookie::$domain :
-			ini_get('session.cookie_domain');
+		$session_cookie_domain = Cookie::$domain
+		    ? Cookie::$domain
+		    : ini_get('session.cookie_domain');
 		
 		// Sync up the session cookie with Cookie parameters
 		session_set_cookie_params(

--- a/classes/kohana/session/native.php
+++ b/classes/kohana/session/native.php
@@ -24,12 +24,22 @@ class Kohana_Session_Native extends Session {
 	 */
 	protected function _read($id = NULL)
 	{
+		// session_set_cookie_params will override php ini settings
+		// If a NULL or empty string is passed, PHP will sent cookies with
+		// the host name of the server which generated the cookie
+		//
+		// see issue #3604
+		//
+		// set to Cookie::$domain if available, otherwise default to ini setting, 
+		$session_cookie_domain = empty(Cookie::$domain) ?
+			Cookie::$domain :
+			ini_get('session.cookie_domain');
+		
 		// Sync up the session cookie with Cookie parameters
 		session_set_cookie_params(
 			$this->_lifetime,
 			Cookie::$path,
-			// set to Cookie::$domain if available, otherwise default to ini setting, see issue #3604
-			Cookie::$domain ? : ini_get('session.cookie_domain'),
+			$session_cookie_domain,
 			Cookie::$secure,
 			Cookie::$httponly
 		);


### PR DESCRIPTION
We are using Cookie parameters for Session Native with session_set_cookie_params.

session_set_cookie_params overrides `session.cookie_domain` ini setting.

When the developer specifies `session.cookie_domain` ini setting and keeps Cookie::$domain NULL, PHP defaults to server name (which is not what the developer wants).

From PHP manual:

> Default is none at all meaning the host name of the server which generated the cookie

http://www.php.net/manual/en/session.configuration.php#ini.session.cookie-domain
