### PR TITLE
Fixes #3604: default to original ini setting if Cookie::$domain not set

### DIFF
--- a/classes/kohana/session/native.php
+++ b/classes/kohana/session/native.php
@@ -24,17 +24,19 @@ class Kohana_Session_Native extends Session {
 	 */
 	protected function _read($id = NULL)
 	{
-		// session_set_cookie_params will override php ini settings
-		// If Cookie::$domain is NULL or empty and is passed, PHP
-		// will override ini and sent cookies with the host name
-		// of the server which generated the cookie
-		//
-		// see issue #3604
-		//
-		// see http://www.php.net/manual/en/function.session-set-cookie-params.php
-		// see http://www.php.net/manual/en/session.configuration.php#ini.session.cookie-domain
-		//
-		// set to Cookie::$domain if available, otherwise default to ini setting
+		/**
+		 * session_set_cookie_params will override php ini settings
+		 * If Cookie::$domain is NULL or empty and is passed, PHP
+		 * will override ini and sent cookies with the host name
+		 * of the server which generated the cookie
+		 * 
+		 * see issue #3604
+		 * 
+		 * see http://www.php.net/manual/en/function.session-set-cookie-params.php
+		 * see http://www.php.net/manual/en/session.configuration.php#ini.session.cookie-domain
+		 * 
+		 * set to Cookie::$domain if available, otherwise default to ini setting
+		 * /
 		$session_cookie_domain = empty(Cookie::$domain)
 		    ? ini_get('session.cookie_domain')
 		    : Cookie::$domain;

--- a/classes/kohana/session/native.php
+++ b/classes/kohana/session/native.php
@@ -24,8 +24,29 @@ class Kohana_Session_Native extends Session {
 	 */
 	protected function _read($id = NULL)
 	{
+		// session_set_cookie_params will override php ini settings
+		// If Cookie::$domain is NULL or empty and is passed, PHP
+		// will override ini and sent cookies with the host name
+		// of the server which generated the cookie
+		//
+		// see issue #3604
+		//
+		// see http://www.php.net/manual/en/function.session-set-cookie-params.php
+		// see http://www.php.net/manual/en/session.configuration.php#ini.session.cookie-domain
+		//
+		// set to Cookie::$domain if available, otherwise default to ini setting
+		$session_cookie_domain = empty(Cookie::$domain)
+		    ? ini_get('session.cookie_domain')
+		    : Cookie::$domain;
+
 		// Sync up the session cookie with Cookie parameters
-		session_set_cookie_params($this->_lifetime, Cookie::$path, Cookie::$domain, Cookie::$secure, Cookie::$httponly);
+		session_set_cookie_params(
+			$this->_lifetime,
+			Cookie::$path,
+			$session_cookie_domain,
+			Cookie::$secure,
+			Cookie::$httponly
+		);
 
 		// Do not allow PHP to send Cache-Control headers
 		session_cache_limiter(FALSE);


### PR DESCRIPTION
We should not let PHP override the default setting if Cookie::$domain is not set. Otherwise it will send cookies with the host name of the server which generated the cookie.
