### PR TITLE
Fixes #3499: widont with html tags

### DIFF
--- a/classes/kohana/text.php
+++ b/classes/kohana/text.php
@@ -595,15 +595,16 @@ class Kohana_Text {
 	 */
 	public static function widont($str)
 	{
- 		$widont_regex = "
+		// use '%' as delimiter and 'x' as modifier 
+ 		$widont_regex = "%
 			((?:</?(?:a|em|span|strong|i|b)[^>]*>)|[^<>\s]) # must be proceeded by an approved inline opening or closing tag or a nontag/nonspace
 			\s+                                             # the space to replace
 			([^<>\s]+                                       # must be flollowed by non-tag non-space characters
 			\s*                                             # optional white space!
 			(</(a|em|span|strong|i|b)>\s*)*                 # optional closing inline tags with optional white space after each
 			((</(p|h[1-6]|li|dt|dd)>)|$))                   # end with a closing p, h1-6, li or the end of the string
-		";
-		return preg_replace($widont_regex, '&nbsp;$2', $str);
+		%x";
+		return preg_replace($widont_regex, '$1&nbsp;$2', $str);
 	}
 
 } // End text

--- a/tests/kohana/TextTest.php
+++ b/tests/kohana/TextTest.php
@@ -384,6 +384,66 @@ class Kohana_TextTest extends Unittest_TestCase
 	{
 		return array
 			(
+				// A very simple widont test
+				array(
+					'A very simple&nbsp;test',
+					'A very simple test',
+				),
+				// Single word items shouldn't be changed
+				array(
+					'Test',
+					'Test',
+				),
+				// Single word after single space shouldn't be changed either
+				array(
+					' Test',
+					' Test',
+				),
+				// Single word with HTML all around
+				array(
+					'<ul><li><p>Test</p></li><ul>',
+					'<ul><li><p>Test</p></li><ul>',
+				),
+				// Single word after single space with HTML all around
+				array(
+					'<ul><li><p> Test</p></li><ul>',
+					'<ul><li><p> Test</p></li><ul>',
+				),
+				// Widont with more than one paragraph
+				array(
+					'<p>In a couple of&nbsp;paragraphs</p><p>paragraph&nbsp;two</p>',
+					'<p>In a couple of paragraphs</p><p>paragraph two</p>',
+				),
+				// a link inside a heading
+				array(
+					'<h1><a href="#">In a link inside a&nbsp;heading </a></h1>',
+					'<h1><a href="#">In a link inside a heading </a></h1>',
+				),
+				// a link followed by text
+				array(
+					'<h1><a href="#">In a link</a> followed by other&nbsp;text</h1>',
+					'<h1><a href="#">In a link</a> followed by other text</h1>',
+				),
+				// empty html, with no text inside
+				array(
+					'<h1><a href="#"></a></h1>',
+					'<h1><a href="#"></a></h1>',
+				),
+				// apparently, we don't love DIVs
+				array(
+					'<div>Divs get no love!</div>',
+					'<div>Divs get no love!</div>',
+				),
+				// we don't love PREs, either
+				array(
+					'<pre>Neither do PREs</pre>',
+					'<pre>Neither do PREs</pre>',
+				),
+				// but we love DIVs with paragraphs
+				array(
+					'<div><p>But divs with paragraphs&nbsp;do!</p></div>',
+					'<div><p>But divs with paragraphs do!</p></div>',
+				),
 				array(
 					'No gain, no&nbsp;pain',
 					'No gain, no pain',
@@ -392,11 +452,18 @@ class Kohana_TextTest extends Unittest_TestCase
 					"spaces?what'rethey?",
 					"spaces?what'rethey?",
 				),
-				// @issue 3499
-				array(
-					'with HTML at the end:&nbsp;<a href="kohanaframework.org" title="Kohana">Kohana</a>',
-					'with HTML at the end: <a href="kohanaframework.org" title="Kohana">Kohana</a>',
-				),
+			/*
+			 * // @issue 3499, with HTML at the end
+			 * array(
+			 * 		'with HTML at the end &nbsp;<strong>Kohana</strong>',
+			 * 		'with HTML at the end <strong>Kohana</strong>',
+			 * 	),
+			 * 	// @issue 3499, with HTML with attributes at the end
+			 * 	array(
+			 * 		'with HTML at the end:&nbsp;<a href="#" title="Kohana">Kohana</a>',
+			 * 		'with HTML at the end: <a href="#" title="Kohana">Kohana</a>',
+			 * 	),
+			 */
 				array(
 					'',
 					'',


### PR DESCRIPTION
This PR will basically fix https://github.com/kohana/core/pull/442
where the regex was without a delimiter and modifier
