### PR TITLE
Fix documentation mention of Request::instance

### DIFF
--- a/classes/kohana/form.php
+++ b/classes/kohana/form.php
@@ -28,7 +28,7 @@ class Kohana_Form {
 	 * @param   mixed   $action     form action, defaults to the current request URI, or [Request] class to use
 	 * @param   array   $attributes html attributes
 	 * @return  string
-	 * @uses    Request::instance
+	 * @uses    Request
 	 * @uses    URL::site
 	 * @uses    HTML::attributes
 	 */

--- a/classes/kohana/request.php
+++ b/classes/kohana/request.php
@@ -38,7 +38,7 @@ class Kohana_Request implements HTTP_Request {
 
 	/**
 	 * Creates a new request object for the given URI. New requests should be
-	 * created using the [Request::instance] or [Request::factory] methods.
+	 * created using the [Request::factory] method.
 	 *
 	 *     $request = Request::factory($uri);
 	 *
@@ -758,7 +758,7 @@ class Kohana_Request implements HTTP_Request {
 
 	/**
 	 * Creates a new request object for the given URI. New requests should be
-	 * created using the [Request::instance] or [Request::factory] methods.
+	 * created using the [Request::factory] method.
 	 *
 	 *     $request = new Request($uri);
 	 *

--- a/guide/kohana/flow.md
+++ b/guide/kohana/flow.md
@@ -16,7 +16,7 @@ Every application follows the same flow:
 		* Includes each module's `init.php` file, if it exists. 
 	    * The `init.php` file can perform additional environment setup, including adding routes.
 	10. [Route::set] is called multiple times to define the [application routes](routing).
-	11. [Request::instance] is called to start processing the request.
+	11. [Request::factory] is called to start processing the request.
 		1. Checks each route that has been set until a match is found.
 		2. Creates the controller instance and passes the request to it.
 		3. Calls the [Controller::before] method.

--- a/guide/kohana/mvc/controllers.md
+++ b/guide/kohana/mvc/controllers.md
@@ -55,7 +55,7 @@ You can also have a controller extend another controller to share common things,
 
 Every controller has the `$this->request` property which is the [Request] object that called the controller.  You can use this to get information about the current request, as well as set the response body via `$this->response->body($ouput)`.
 
-Here is a partial list of the properties and methods available to `$this->request`.  These can also be accessed via `Request::instance()`, but `$this->request` is provided as a shortcut.  See the [Request] class for more information on any of these. 
+Here is a partial list of the properties and methods available to `$this->request`.  See the [Request] class for more information on any of these.
 
 Property/method | What it does
 --- | ---

--- a/guide/kohana/routing.md
+++ b/guide/kohana/routing.md
@@ -248,11 +248,11 @@ Let's say you decided later to make that route definition more verbose by changi
 
 One method you might use frequently is the shortcut [Request::uri] which is the same as the above except it assumes the current route, directory, controller and action. If our current route is the default and the uri was `users/list`, we can do the following to generate uris in the format `users/view/$id`:
 
-    $this->request->uri(array('action' => 'view', 'id' => $user_id));
-    
+    $this->request->route()->uri(array('action' => 'view', 'id' => $user_id));
+
 Or if within a view, the preferable method is:
 
-    Request::instance()->uri(array('action' => 'view', 'id' => $user_id));
+    Route::url('default', array('action' => 'view', 'id' => $user_id));
 
 TODO: examples of using html::anchor in addition to the above examples
 


### PR DESCRIPTION
Various place in guide and php comments were mentionning
Request::instance() to be used. I replaced it either by
Request::factory() or something more appropriate.
