### PR TITLE
Fixes #4819 replace preg replace with /e preg replace callback

### DIFF
--- a/utf8/ucwords.php
+++ b/utf8/ucwords.php
@@ -7,6 +7,7 @@
  * @copyright  (c) 2007-2012 Kohana Team
  * @copyright  (c) 2005 Harry Fuecks
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt
+ * @uses _ucwords_preg_replace_callback callback for preg_replace_callback
  */
 function _ucwords($str)
 {
@@ -15,9 +16,19 @@ function _ucwords($str)
 
 	// [\x0c\x09\x0b\x0a\x0d\x20] matches form feeds, horizontal tabs, vertical tabs, linefeeds and carriage returns.
 	// This corresponds to the definition of a 'word' defined at http://php.net/ucwords
-	return preg_replace(
-		'/(?<=^|[\x0c\x09\x0b\x0a\x0d\x20])[^\x0c\x09\x0b\x0a\x0d\x20]/ue',
-		'UTF8::strtoupper(\'$0\')',
+	return preg_replace_callback(
+		'/(?<=^|[\x0c\x09\x0b\x0a\x0d\x20])[^\x0c\x09\x0b\x0a\x0d\x20]/u',
+		'_ucwords_preg_replace_callback',
 		$str
 	);
+}
+/**
+ * helper callback function for _ucwords' preg_replace_callback
+ *
+ * @param array $matches
+ * @return string
+ */
+function _ucwords_preg_replace_callback($matches)
+{
+	return UTF8::strtoupper($matches[0]);
 }


### PR DESCRIPTION
contains an ugly hack to support both PHP 5.2 and PHP 5.5:
used a temporary static protected variable to "pass" argument
from function `censor` to `_censor_preg_replace_callback`
