### PR TITLE
Fixes #4819 replace preg replace with /e preg replace callback

### DIFF
--- a/classes/kohana/text.php
+++ b/classes/kohana/text.php
@@ -269,6 +269,9 @@ class Kohana_Text {
 	 *         'frick' => '#####',
 	 *     ));
 	 *
+	 * If argument $replacement is a single character, it will be used to replace
+	 * the characters in the badword, otherwise it will replace the badword completely
+	 *
 	 * @param   string  $str                    phrase to replace words in
 	 * @param   array   $badwords               words to replace
 	 * @param   string  $replacement            replacement string
@@ -293,12 +296,16 @@ class Kohana_Text {
 
 		$regex = '!'.$regex.'!ui';
 
+		// if $replacement is a single character: replace each of the characters of the badword with $replacement
 		if (UTF8::strlen($replacement) == 1)
 		{
-			$regex .= 'e';
-			return preg_replace($regex, 'str_repeat($replacement, UTF8::strlen(\'$1\'))', $str);
+			// issue #4819: use preg_replace_callback, preg_replace with /e modifier is depricated for PHP 5.5.0
+			$callback = create_function('$matches', 'return str_repeat("' . $replacement . '", UTF8::strlen($matches[1]));');
+
+			return preg_replace_callback($regex, $callback, $str);
 		}
 
+		// if $replacement is not a single character, fully replace the badword with $replacement
 		return preg_replace($regex, $replacement, $str);
 	}
 

--- a/utf8/ucwords.php
+++ b/utf8/ucwords.php
@@ -7,6 +7,7 @@
  * @copyright  (c) 2007-2012 Kohana Team
  * @copyright  (c) 2005 Harry Fuecks
  * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt
+ * @uses _ucwords_preg_replace_callback callback for preg_replace_callback
  */
 function _ucwords($str)
 {
@@ -15,9 +16,19 @@ function _ucwords($str)
 
 	// [\x0c\x09\x0b\x0a\x0d\x20] matches form feeds, horizontal tabs, vertical tabs, linefeeds and carriage returns.
 	// This corresponds to the definition of a 'word' defined at http://php.net/ucwords
-	return preg_replace(
-		'/(?<=^|[\x0c\x09\x0b\x0a\x0d\x20])[^\x0c\x09\x0b\x0a\x0d\x20]/ue',
-		'UTF8::strtoupper(\'$0\')',
+	return preg_replace_callback(
+		'/(?<=^|[\x0c\x09\x0b\x0a\x0d\x20])[^\x0c\x09\x0b\x0a\x0d\x20]/u',
+		'_ucwords_preg_replace_callback',
 		$str
 	);
+}
+/**
+ * helper callback function for _ucwords' preg_replace_callback
+ *
+ * @param array $matches
+ * @return string
+ */
+function _ucwords_preg_replace_callback($matches)
+{
+	return UTF8::strtoupper($matches[0]);
 }


### PR DESCRIPTION
uses `create_function` to support both PHP 5.2 and PHP 5.5
`create_function` uses `eval` internally so probably it's
better to have this fix only for Kohana v.3.2

Thank you @Zeelot for the help
