### PR TITLE
Update license URLs in PHPDoc - Ref: #4821

### DIFF
--- a/classes/Kohana/Config/Group.php
+++ b/classes/Kohana/Config/Group.php
@@ -11,8 +11,8 @@
  * @package    Kohana
  * @category   Configuration
  * @author     Kohana Team
- * @copyright  (c) 2012 Kohana Team
- * @license    http://kohanaphp.com/license
+ * @copyright  (c) 2012-2014 Kohana Team
+ * @license    http://kohanaframework.org/license
  */
 class Kohana_Config_Group extends ArrayObject {
 

--- a/classes/Kohana/Config/Source.php
+++ b/classes/Kohana/Config/Source.php
@@ -7,8 +7,8 @@
  * @package    Kohana
  * @category   Configuration
  * @author     Kohana Team
- * @copyright  (c) 2012 Kohana Team
- * @license    http://kohanaphp.com/license
+ * @copyright  (c) 2012-2014 Kohana Team
+ * @license    http://kohanaframework.org/license
  */
 
 interface Kohana_Config_Source {}

--- a/classes/Kohana/Config/Writer.php
+++ b/classes/Kohana/Config/Writer.php
@@ -7,8 +7,8 @@
  *
  * @package Kohana
  * @author  Kohana Team
- * @copyright  (c) 2008-2012 Kohana Team
- * @license    http://kohanaphp.com/license
+ * @copyright  (c) 2008-2014 Kohana Team
+ * @license    http://kohanaframework.org/license
  */
 interface Kohana_Config_Writer extends Kohana_Config_Source
 {

--- a/classes/Kohana/Debug.php
+++ b/classes/Kohana/Debug.php
@@ -5,8 +5,8 @@
  * @package    Kohana
  * @category   Base
  * @author     Kohana Team
- * @copyright  (c) 2008-2012 Kohana Team
- * @license    http://kohanaphp.com/license
+ * @copyright  (c) 2008-2014 Kohana Team
+ * @license    http://kohanaframework.org/license
  */
 class Kohana_Debug {
 

--- a/classes/Kohana/HTTP.php
+++ b/classes/Kohana/HTTP.php
@@ -11,8 +11,8 @@
  * @category   HTTP
  * @author     Kohana Team
  * @since      3.1.0
- * @copyright  (c) 2008-2012 Kohana Team
- * @license    http://kohanaphp.com/license
+ * @copyright  (c) 2008-2014 Kohana Team
+ * @license    http://kohanaframework.org/license
  */
 abstract class Kohana_HTTP {
 

--- a/classes/Kohana/HTTP/Header.php
+++ b/classes/Kohana/HTTP/Header.php
@@ -9,8 +9,8 @@
  * @category   HTTP
  * @author     Kohana Team
  * @since      3.1.0
- * @copyright  (c) 2008-2012 Kohana Team
- * @license    http://kohanaphp.com/license
+ * @copyright  (c) 2008-2014 Kohana Team
+ * @license    http://kohanaframework.org/license
  */
 class Kohana_HTTP_Header extends ArrayObject {
 

--- a/classes/Kohana/HTTP/Message.php
+++ b/classes/Kohana/HTTP/Message.php
@@ -7,8 +7,8 @@
  * @category   HTTP
  * @author     Kohana Team
  * @since      3.1.0
- * @copyright  (c) 2008-2012 Kohana Team
- * @license    http://kohanaphp.com/license
+ * @copyright  (c) 2008-2014 Kohana Team
+ * @license    http://kohanaframework.org/license
  */
 interface Kohana_HTTP_Message {
 

--- a/classes/Kohana/HTTP/Request.php
+++ b/classes/Kohana/HTTP/Request.php
@@ -8,8 +8,8 @@
  * @category   HTTP
  * @author     Kohana Team
  * @since      3.1.0
- * @copyright  (c) 2008-2012 Kohana Team
- * @license    http://kohanaphp.com/license
+ * @copyright  (c) 2008-2014 Kohana Team
+ * @license    http://kohanaframework.org/license
  */
 interface Kohana_HTTP_Request extends HTTP_Message {
 

--- a/classes/Kohana/HTTP/Response.php
+++ b/classes/Kohana/HTTP/Response.php
@@ -8,8 +8,8 @@
  * @category   HTTP
  * @author     Kohana Team
  * @since      3.1.0
- * @copyright  (c) 2008-2012 Kohana Team
- * @license    http://kohanaphp.com/license
+ * @copyright  (c) 2008-2014 Kohana Team
+ * @license    http://kohanaframework.org/license
  */
 interface Kohana_HTTP_Response extends HTTP_Message {
 

--- a/classes/Kohana/Log/StdErr.php
+++ b/classes/Kohana/Log/StdErr.php
@@ -5,8 +5,8 @@
  * @package    Kohana
  * @category   Logging
  * @author     Kohana Team
- * @copyright  (c) 2008-2012 Kohana Team
- * @license    http://kohanaphp.com/license
+ * @copyright  (c) 2008-2014 Kohana Team
+ * @license    http://kohanaframework.org/license
  */
 class Kohana_Log_StdErr extends Log_Writer {
 	/**

--- a/classes/Kohana/Log/StdOut.php
+++ b/classes/Kohana/Log/StdOut.php
@@ -5,8 +5,8 @@
  * @package    Kohana
  * @category   Logging
  * @author     Kohana Team
- * @copyright  (c) 2008-2012 Kohana Team
- * @license    http://kohanaphp.com/license
+ * @copyright  (c) 2008-2014 Kohana Team
+ * @license    http://kohanaframework.org/license
  */
 class Kohana_Log_StdOut extends Log_Writer {
 

--- a/classes/Kohana/Response.php
+++ b/classes/Kohana/Response.php
@@ -7,8 +7,8 @@
  * @package    Kohana
  * @category   Base
  * @author     Kohana Team
- * @copyright  (c) 2008-2012 Kohana Team
- * @license    http://kohanaphp.com/license
+ * @copyright  (c) 2008-2014 Kohana Team
+ * @license    http://kohanaframework.org/license
  * @since      3.1.0
  */
 class Kohana_Response implements HTTP_Response {

--- a/tests/kohana/Config/File/ReaderTest.php
+++ b/tests/kohana/Config/File/ReaderTest.php
@@ -10,8 +10,8 @@
  * @author     Kohana Team
  * @author     Jeremy Bush <contractfrombelow@gmail.com>
  * @author     Matt Button <matthew@sigswitch.com>
- * @copyright  (c) 2008-2012 Kohana Team
- * @license    http://kohanaphp.com/license
+ * @copyright  (c) 2008-2014 Kohana Team
+ * @license    http://kohanaframework.org/license
  */
 class Kohana_Config_File_ReaderTest extends Kohana_Unittest_TestCase {
 

--- a/tests/kohana/Config/GroupTest.php
+++ b/tests/kohana/Config/GroupTest.php
@@ -10,8 +10,8 @@
  * @author     Kohana Team
  * @author     Jeremy Bush <contractfrombelow@gmail.com>
  * @author     Matt Button <matthew@sigswitch.com>
- * @copyright  (c) 2008-2012 Kohana Team
- * @license    http://kohanaphp.com/license
+ * @copyright  (c) 2008-2014 Kohana Team
+ * @license    http://kohanaframework.org/license
  */
 class Kohana_Config_GroupTest extends Kohana_Unittest_TestCase
 {

--- a/tests/kohana/DebugTest.php
+++ b/tests/kohana/DebugTest.php
@@ -13,8 +13,8 @@
  * @category   Tests
  * @author     Kohana Team
  * @author     Jeremy Bush <contractfrombelow@gmail.com>
- * @copyright  (c) 2008-2012 Kohana Team
- * @license    http://kohanaphp.com/license
+ * @copyright  (c) 2008-2014 Kohana Team
+ * @license    http://kohanaframework.org/license
  */
 class Kohana_DebugTest extends Unittest_TestCase
 {

--- a/tests/kohana/Http/HeaderTest.php
+++ b/tests/kohana/Http/HeaderTest.php
@@ -11,8 +11,8 @@
  * @package    Kohana
  * @category   Tests
  * @author     Kohana Team
- * @copyright  (c) 2008-2012 Kohana Team
- * @license    http://kohanaphp.com/license
+ * @copyright  (c) 2008-2014 Kohana Team
+ * @license    http://kohanaframework.org/license
  */
 class Kohana_HTTP_HeaderTest extends Unittest_TestCase {
 


### PR DESCRIPTION
Found links pointing to old location of license instead of where they are now at http://kohanaframework.org/license

Ref: http://dev.kohanaframework.org/issues/4821
