### PR TITLE
Refix #4079: Decode slashes back after rawurlencode

### DIFF
--- a/classes/kohana/route.php
+++ b/classes/kohana/route.php
@@ -458,7 +458,10 @@ class Kohana_Route {
 	{
 		if ($params)
 		{
+			// @issue #4079 rawurlencode parameters
 			$params = array_map('rawurlencode', $params);
+			// decode slashes back, see Apache docs about AllowEncodedSlashes and AcceptPathInfo
+			$params = str_replace(array('%2F', '%5C'), array('/', '\\'), $params);
 		}
 
 		// Start with the routed URI

--- a/tests/kohana/RouteTest.php
+++ b/tests/kohana/RouteTest.php
@@ -733,7 +733,7 @@ class Kohana_RouteTest extends Unittest_TestCase
 				),
 				'article_name',
 				'Article name with special chars \\ ##',
-				'blog/article/Article%20name%20with%20special%20chars%20%5C%20%23%23'
+				'blog/article/Article%20name%20with%20special%20chars%20\\%20%23%23'
 			)
 		);
 	}


### PR DESCRIPTION
Apache's `AllowEncodedSlashes` directive is `Off` by default.
URLs with encoded slashes will bypass Apache's `AcceptPathInfo` setting.
Such URLs will not be redirected to index.php
