### PR TITLE
Simplify Kohana::globals() test

### DIFF
--- a/tests/kohana/CoreTest.php
+++ b/tests/kohana/CoreTest.php
@@ -107,33 +107,15 @@ class Kohana_CoreTest extends Unittest_TestCase
 	 */
 	public function test_globals_removes_user_def_globals()
 	{
-		// Store the globals
-		$temp_globals = array(
-			'cookie' => $_COOKIE,
-			'get' => $_GET,
-			'files' => $_FILES,
-			'post' => $_POST,
-			'request' => $_REQUEST,
-			'server' => $_SERVER,
-			'session' => $_SESSION,
-			'globals' => $GLOBALS,
-		);
-
-		$GLOBALS = array('hackers' => 'foobar','name' => array('','',''), '_POST' => array());
+		$GLOBALS['hackers'] = 'foobar';
+		$GLOBALS['name'] = array('','','');
+		$GLOBALS['_POST'] = array();
 
 		Kohana::globals();
 
-		$this->assertEquals(array('_POST' => array()), $GLOBALS);
-
-		// Reset the globals for other tests
-		$_COOKIE = $temp_globals['cookie'];
-		$_GET = $temp_globals['get'];
-		$_FILES = $temp_globals['files'];
-		$_POST = $temp_globals['post'];
-		$_REQUEST = $temp_globals['request'];
-		$_SERVER = $temp_globals['server'];
-		$_SESSION = $temp_globals['session'];
-		$GLOBALS = $temp_globals['globals'];
+		$this->assertFalse(isset($GLOBALS['hackers']));
+		$this->assertFalse(isset($GLOBALS['name']));
+		$this->assertTrue(isset($GLOBALS['_POST']));
 	}
 
 	/**


### PR DESCRIPTION
This simplifies the `test_globals_removes_user_def_globals` test
to take advantage of PHPUnit's backupGlobals option which is on
by default. There's no need to backup globals.

In addition, changed to avoid directly assigning to $GLOBALS,
since it is not allowed in HHVM. See:
https://github.com/facebook/hhvm/blob/master/hphp/doc/inconsistencies#L127
