### PR TITLE
UTF8: fixed typos and bugs

### DIFF
--- a/classes/Kohana/UTF8.php
+++ b/classes/Kohana/UTF8.php
@@ -1,30 +1,30 @@
 <?php defined('SYSPATH') OR die('No direct script access.');
 /**
- * A port of [phputf8](http://phputf8.sourceforge.net/) to a unified set
- * of files. Provides multi-byte aware replacement string functions.
+ * A port of [phputf8](http://phputf8.sourceforge.net) to a unified set of files.
+ * Provides multi-byte aware replacement string functions.
  *
  * For UTF-8 support to work correctly, the following requirements must be met:
  *
  * - PCRE needs to be compiled with UTF-8 support (--enable-utf8)
- * - Support for [Unicode properties](http://php.net/manual/reference.pcre.pattern.modifiers.php)
+ * - Support for [Unicode properties](http://php.net/reference.pcre.pattern.modifiers)
  *   is highly recommended (--enable-unicode-properties)
  * - The [mbstring extension](http://php.net/mbstring) is highly recommended,
  *   but must not be overloading string functions
  *
  * [!!] This file is licensed differently from the rest of Kohana. As a port of
- * [phputf8](http://phputf8.sourceforge.net/), this file is released under the LGPL.
+ * [phputf8](http://phputf8.sourceforge.net), this file is released under the LGPL.
  *
  * @package    Kohana
  * @category   Base
  * @author     Kohana Team
- * @copyright  (c) 2007-2012 Kohana Team
+ * @copyright  (c) 2007-2014 Kohana Team
  * @copyright  (c) 2005 Harry Fuecks
- * @license    http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt
+ * @license    http://gnu.org/licenses/old-licenses/lgpl-2.1.txt
  */
-class Kohana_UTF8 {
+abstract class Kohana_UTF8 {
 
 	/**
-	 * @var  boolean  Does the server support UTF-8 natively?
+	 * @var  bool  Does the server support UTF-8 natively?
 	 */
 	public static $server_utf8 = NULL;
 
@@ -40,22 +40,20 @@ class Kohana_UTF8 {
 	 *
 	 *     UTF8::clean($_GET); // Clean GET data
 	 *
-	 * @param   mixed   $var        variable to clean
-	 * @param   string  $charset    character set, defaults to Kohana::$charset
+	 * @param   mixed   $var      Variable to clean
+	 * @param   string  $charset  Character set, defaults to Kohana::$charset
 	 * @return  mixed
-	 * @uses    UTF8::clean
-	 * @uses    UTF8::strip_ascii_ctrl
-	 * @uses    UTF8::is_ascii
+	 * @uses    Kohana::$charset
 	 */
 	public static function clean($var, $charset = NULL)
 	{
-		if ( ! $charset)
+		if ($charset === NULL)
 		{
 			// Use the application character set
 			$charset = Kohana::$charset;
 		}
 
-		if (is_array($var) OR is_object($var))
+		if (Arr::is_array($var))
 		{
 			foreach ($var as $key => $val)
 			{
@@ -68,7 +66,7 @@ class Kohana_UTF8 {
 			// Remove control characters
 			$var = UTF8::strip_ascii_ctrl($var);
 
-			if ( ! UTF8::is_ascii($var))
+			if ( ! UTF8::is_ascii($var) AND UTF8::$server_utf8)
 			{
 				// Disable notices
 				$error_reporting = error_reporting(~E_NOTICE);
@@ -84,13 +82,13 @@ class Kohana_UTF8 {
 	}
 
 	/**
-	 * Tests whether a string contains only 7-bit ASCII bytes. This is used to
+	 * Tests whether a string contains only 7-bit ASCII bytes, used to
 	 * determine when to use native functions or UTF-8 functions.
 	 *
 	 *     $ascii = UTF8::is_ascii($str);
 	 *
-	 * @param   mixed   $str    string or array of strings to check
-	 * @return  boolean
+	 * @param   mixed  $str  String or array of strings to check
+	 * @return  bool
 	 */
 	public static function is_ascii($str)
 	{
@@ -107,7 +105,7 @@ class Kohana_UTF8 {
 	 *
 	 *     $str = UTF8::strip_ascii_ctrl($str);
 	 *
-	 * @param   string  $str    string to clean
+	 * @param   string  $str  String to clean
 	 * @return  string
 	 */
 	public static function strip_ascii_ctrl($str)
@@ -120,7 +118,7 @@ class Kohana_UTF8 {
 	 *
 	 *     $str = UTF8::strip_non_ascii($str);
 	 *
-	 * @param   string  $str    string to clean
+	 * @param   string  $str  String to clean
 	 * @return  string
 	 */
 	public static function strip_non_ascii($str)
@@ -134,16 +132,16 @@ class Kohana_UTF8 {
 	 *     $ascii = UTF8::transliterate_to_ascii($utf8);
 	 *
 	 * @author  Andreas Gohr <andi@splitbrain.org>
-	 * @param   string  $str    string to transliterate
-	 * @param   integer $case   -1 lowercase only, +1 uppercase only, 0 both cases
+	 * @param   string   $str   String to transliterate
+	 * @param   integer  $case  -1 lowercase only, +1 uppercase only, 0 both cases
 	 * @return  string
+	 * @uses    Kohana::find_file
 	 */
 	public static function transliterate_to_ascii($str, $case = 0)
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require Kohana::find_file('utf8', __FUNCTION__);
-
+			require_once Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -152,25 +150,26 @@ class Kohana_UTF8 {
 	}
 
 	/**
-	 * Returns the length of the given string. This is a UTF8-aware version
-	 * of [strlen](http://php.net/strlen).
+	 * Returns the length of the given string. 
+	 * This is a UTF8-aware version of [strlen](http://php.net/strlen).
 	 *
 	 *     $length = UTF8::strlen($str);
 	 *
-	 * @param   string  $str    string being measured for length
-	 * @return  integer
-	 * @uses    UTF8::$server_utf8
+	 * @param   string  $str  String being measured for length
+	 * @return  int
 	 * @uses    Kohana::$charset
+	 * @uses    Kohana::find_file
 	 */
 	public static function strlen($str)
 	{
 		if (UTF8::$server_utf8)
+		{
 			return mb_strlen($str, Kohana::$charset);
+		}
 
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require Kohana::find_file('utf8', __FUNCTION__);
-
+			require_once Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -179,29 +178,29 @@ class Kohana_UTF8 {
 	}
 
 	/**
-	 * Finds position of first occurrence of a UTF-8 string. This is a
-	 * UTF8-aware version of [strpos](http://php.net/strpos).
+	 * Finds position of first occurrence of a UTF-8 string.
+	 * This is a UTF8-aware version of [strpos](http://php.net/strpos).
 	 *
 	 *     $position = UTF8::strpos($str, $search);
 	 *
 	 * @author  Harry Fuecks <hfuecks@gmail.com>
-	 * @param   string  $str    haystack
-	 * @param   string  $search needle
-	 * @param   integer $offset offset from which character in haystack to start searching
-	 * @return  integer position of needle
-	 * @return  boolean FALSE if the needle is not found
-	 * @uses    UTF8::$server_utf8
+	 * @param   string  $str     Haystack
+	 * @param   string  $search  Needle
+	 * @param   int     $offset  Offset from which character in haystack to start searching
+	 * @return  int|bool  Position of needle, FALSE if the needle is not found
 	 * @uses    Kohana::$charset
+	 * @uses    Kohana::find_file
 	 */
 	public static function strpos($str, $search, $offset = 0)
 	{
 		if (UTF8::$server_utf8)
+		{
 			return mb_strpos($str, $search, $offset, Kohana::$charset);
+		}
 
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require Kohana::find_file('utf8', __FUNCTION__);
-
+			require_once Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -210,28 +209,29 @@ class Kohana_UTF8 {
 	}
 
 	/**
-	 * Finds position of last occurrence of a char in a UTF-8 string. This is
-	 * a UTF8-aware version of [strrpos](http://php.net/strrpos).
+	 * Finds position of last occurrence of a char in a UTF-8 string.
+	 * This is a UTF8-aware version of [strrpos](http://php.net/strrpos).
 	 *
 	 *     $position = UTF8::strrpos($str, $search);
 	 *
 	 * @author  Harry Fuecks <hfuecks@gmail.com>
-	 * @param   string  $str    haystack
-	 * @param   string  $search needle
-	 * @param   integer $offset offset from which character in haystack to start searching
-	 * @return  integer position of needle
-	 * @return  boolean FALSE if the needle is not found
-	 * @uses    UTF8::$server_utf8
+	 * @param   string  $str     Haystack
+	 * @param   string  $search  Needle
+	 * @param   int     $offset  Offset from which character in haystack to start searching
+	 * @return  int|bool  Position of needle, FALSE if the needle is not found
+	 * @uses    Kohana::$charset
+	 * @uses    Kohana::find_file
 	 */
 	public static function strrpos($str, $search, $offset = 0)
 	{
 		if (UTF8::$server_utf8)
+		{
 			return mb_strrpos($str, $search, $offset, Kohana::$charset);
+		}
 
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require Kohana::find_file('utf8', __FUNCTION__);
-
+			require_once Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -240,30 +240,31 @@ class Kohana_UTF8 {
 	}
 
 	/**
-	 * Returns part of a UTF-8 string. This is a UTF8-aware version
-	 * of [substr](http://php.net/substr).
+	 * Returns part of a UTF-8 string.
+	 * This is a UTF8-aware version of [substr](http://php.net/substr).
 	 *
 	 *     $sub = UTF8::substr($str, $offset);
 	 *
 	 * @author  Chris Smith <chris@jalakai.co.uk>
-	 * @param   string  $str    input string
-	 * @param   integer $offset offset
-	 * @param   integer $length length limit
+	 * @param   string  $str     Input string
+	 * @param   int     $offset  Offset
+	 * @param   int     $length  Length limit
 	 * @return  string
-	 * @uses    UTF8::$server_utf8
 	 * @uses    Kohana::$charset
+	 * @uses    Kohana::find_file
 	 */
 	public static function substr($str, $offset, $length = NULL)
 	{
 		if (UTF8::$server_utf8)
-			return ($length === NULL)
+		{
+			return $length === NULL
 				? mb_substr($str, $offset, mb_strlen($str), Kohana::$charset)
 				: mb_substr($str, $offset, $length, Kohana::$charset);
+		}
 
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require Kohana::find_file('utf8', __FUNCTION__);
-
+			require_once Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -272,23 +273,24 @@ class Kohana_UTF8 {
 	}
 
 	/**
-	 * Replaces text within a portion of a UTF-8 string. This is a UTF8-aware
-	 * version of [substr_replace](http://php.net/substr_replace).
+	 * Replaces text within a portion of a UTF-8 string.
+	 * This is a UTF8-aware version of [substr_replace](http://php.net/substr_replace).
 	 *
 	 *     $str = UTF8::substr_replace($str, $replacement, $offset);
 	 *
 	 * @author  Harry Fuecks <hfuecks@gmail.com>
-	 * @param   string  $str            input string
-	 * @param   string  $replacement    replacement string
-	 * @param   integer $offset         offset
+	 * @param   string  $str          Input string
+	 * @param   string  $replacement  Replacement string
+	 * @param   int     $offset       Offset
 	 * @return  string
+	 * @uses    Kohana::$charset
+	 * @uses    Kohana::find_file
 	 */
 	public static function substr_replace($str, $replacement, $offset, $length = NULL)
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require Kohana::find_file('utf8', __FUNCTION__);
-
+			require_once Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -297,26 +299,27 @@ class Kohana_UTF8 {
 	}
 
 	/**
-	 * Makes a UTF-8 string lowercase. This is a UTF8-aware version
-	 * of [strtolower](http://php.net/strtolower).
+	 * Makes a UTF-8 string lowercase.
+	 * This is a UTF8-aware version of [strtolower](http://php.net/strtolower).
 	 *
 	 *     $str = UTF8::strtolower($str);
 	 *
 	 * @author  Andreas Gohr <andi@splitbrain.org>
-	 * @param   string  $str mixed case string
+	 * @param   string  $str  Mixed case string
 	 * @return  string
-	 * @uses    UTF8::$server_utf8
 	 * @uses    Kohana::$charset
+	 * @uses    Kohana::find_file
 	 */
 	public static function strtolower($str)
 	{
 		if (UTF8::$server_utf8)
+		{
 			return mb_strtolower($str, Kohana::$charset);
+		}
 
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require Kohana::find_file('utf8', __FUNCTION__);
-
+			require_once Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -325,24 +328,25 @@ class Kohana_UTF8 {
 	}
 
 	/**
-	 * Makes a UTF-8 string uppercase. This is a UTF8-aware version
-	 * of [strtoupper](http://php.net/strtoupper).
+	 * Makes a UTF-8 string uppercase.
+	 * This is a UTF8-aware version of [strtoupper](http://php.net/strtoupper).
 	 *
 	 * @author  Andreas Gohr <andi@splitbrain.org>
-	 * @param   string  $str mixed case string
+	 * @param   string  $str  Mixed case string
 	 * @return  string
-	 * @uses    UTF8::$server_utf8
 	 * @uses    Kohana::$charset
+	 * @uses    Kohana::find_file
 	 */
 	public static function strtoupper($str)
 	{
 		if (UTF8::$server_utf8)
+		{
 			return mb_strtoupper($str, Kohana::$charset);
+		}
 
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require Kohana::find_file('utf8', __FUNCTION__);
-
+			require_once Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -351,21 +355,21 @@ class Kohana_UTF8 {
 	}
 
 	/**
-	 * Makes a UTF-8 string's first character uppercase. This is a UTF8-aware
-	 * version of [ucfirst](http://php.net/ucfirst).
+	 * Makes a UTF-8 string's first character uppercase.
+	 * This is a UTF8-aware version of [ucfirst](http://php.net/ucfirst).
 	 *
 	 *     $str = UTF8::ucfirst($str);
 	 *
 	 * @author  Harry Fuecks <hfuecks@gmail.com>
-	 * @param   string  $str mixed case string
+	 * @param   string  $str  Mixed case string
 	 * @return  string
+	 * @uses    Kohana::find_file
 	 */
 	public static function ucfirst($str)
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require Kohana::find_file('utf8', __FUNCTION__);
-
+			require_once Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -380,15 +384,15 @@ class Kohana_UTF8 {
 	 *     $str = UTF8::ucwords($str);
 	 *
 	 * @author  Harry Fuecks <hfuecks@gmail.com>
-	 * @param   string  $str mixed case string
+	 * @param   string  $str  mixed case string
 	 * @return  string
+	 * @uses    Kohana::find_file
 	 */
 	public static function ucwords($str)
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require Kohana::find_file('utf8', __FUNCTION__);
-
+			require_once Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -397,24 +401,24 @@ class Kohana_UTF8 {
 	}
 
 	/**
-	 * Case-insensitive UTF-8 string comparison. This is a UTF8-aware version
-	 * of [strcasecmp](http://php.net/strcasecmp).
+	 * Case-insensitive UTF-8 string comparison.
+	 * This is a UTF8-aware version of [strcasecmp](http://php.net/strcasecmp).
 	 *
 	 *     $compare = UTF8::strcasecmp($str1, $str2);
 	 *
 	 * @author  Harry Fuecks <hfuecks@gmail.com>
-	 * @param   string  $str1   string to compare
-	 * @param   string  $str2   string to compare
-	 * @return  integer less than 0 if str1 is less than str2
-	 * @return  integer greater than 0 if str1 is greater than str2
-	 * @return  integer 0 if they are equal
+	 * @param   string  $str1  String to compare
+	 * @param   string  $str2  String to compare
+	 * @return  int  Less than 0 if str1 is less than str2
+	 * @return  int  Greater than 0 if str1 is greater than str2
+	 * @return  int  0 if they are equal
+	 * @uses    Kohana::find_file
 	 */
 	public static function strcasecmp($str1, $str2)
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require Kohana::find_file('utf8', __FUNCTION__);
-
+			require_once Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -424,26 +428,26 @@ class Kohana_UTF8 {
 
 	/**
 	 * Returns a string or an array with all occurrences of search in subject
-	 * (ignoring case) and replaced with the given replace value. This is a
-	 * UTF8-aware version of [str_ireplace](http://php.net/str_ireplace).
+	 * (ignoring case) and replaced with the given replace value.
+	 * This is a UTF8-aware version of [str_ireplace](http://php.net/str_ireplace).
 	 *
 	 * [!!] This function is very slow compared to the native version. Avoid
 	 * using it when possible.
 	 *
 	 * @author  Harry Fuecks <hfuecks@gmail.com
-	 * @param   string|array    $search     text to replace
-	 * @param   string|array    $replace    replacement text
-	 * @param   string|array    $str        subject text
-	 * @param   integer         $count      number of matched and replaced needles will be returned via this parameter which is passed by reference
-	 * @return  string  if the input was a string
-	 * @return  array   if the input was an array
+	 * @param   string|array  $search   Text to replace
+	 * @param   string|array  $replace  Replacement text
+	 * @param   string|array  $str      Subject text
+	 * @param   integer       $count    Number of matched and replaced needles will be returned via this parameter which is passed by reference
+	 * @return  string  If the input was a string
+	 * @return  array   If the input was an array
+	 * @uses    Kohana::find_file
 	 */
 	public static function str_ireplace($search, $replace, $str, & $count = NULL)
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require Kohana::find_file('utf8', __FUNCTION__);
-
+			require_once Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -452,24 +456,22 @@ class Kohana_UTF8 {
 	}
 
 	/**
-	 * Case-insensitive UTF-8 version of strstr. Returns all of input string
-	 * from the first occurrence of needle to the end. This is a UTF8-aware
-	 * version of [stristr](http://php.net/stristr).
+	 * Case-insensitive UTF-8 version of [stristr](http://php.net/stristr).
+	 * Returns all of input string from the first occurrence of needle to the end.
 	 *
 	 *     $found = UTF8::stristr($str, $search);
 	 *
 	 * @author  Harry Fuecks <hfuecks@gmail.com>
-	 * @param   string  $str    input string
-	 * @param   string  $search needle
-	 * @return  string  matched substring if found
-	 * @return  FALSE   if the substring was not found
+	 * @param   string  $str     Input string
+	 * @param   string  $search  Needle
+	 * @return  string|bool  Matched substring if found, FALSE if the substring was not found
+	 * @uses    Kohana::find_file
 	 */
 	public static function stristr($str, $search)
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require Kohana::find_file('utf8', __FUNCTION__);
-
+			require_once Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -478,24 +480,24 @@ class Kohana_UTF8 {
 	}
 
 	/**
-	 * Finds the length of the initial segment matching mask. This is a
-	 * UTF8-aware version of [strspn](http://php.net/strspn).
+	 * Finds the length of the initial segment matching mask. 
+	 * This is a UTF8-aware version of [strspn](http://php.net/strspn).
 	 *
 	 *     $found = UTF8::strspn($str, $mask);
 	 *
 	 * @author  Harry Fuecks <hfuecks@gmail.com>
-	 * @param   string  $str    input string
-	 * @param   string  $mask   mask for search
-	 * @param   integer $offset start position of the string to examine
-	 * @param   integer $length length of the string to examine
-	 * @return  integer length of the initial segment that contains characters in the mask
+	 * @param   string  $str     Input string
+	 * @param   string  $mask    Mask for search
+	 * @param   int     $offset  Start position of the string to examine
+	 * @param   int     $length  Length of the string to examine
+	 * @return  int  Length of the initial segment that contains characters in the mask
+	 * @uses    Kohana::find_file
 	 */
 	public static function strspn($str, $mask, $offset = NULL, $length = NULL)
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require Kohana::find_file('utf8', __FUNCTION__);
-
+			require_once Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -504,24 +506,24 @@ class Kohana_UTF8 {
 	}
 
 	/**
-	 * Finds the length of the initial segment not matching mask. This is a
-	 * UTF8-aware version of [strcspn](http://php.net/strcspn).
+	 * Finds the length of the initial segment not matching mask. 
+	 * This is a UTF8-aware version of [strcspn](http://php.net/strcspn).
 	 *
 	 *     $found = UTF8::strcspn($str, $mask);
 	 *
 	 * @author  Harry Fuecks <hfuecks@gmail.com>
-	 * @param   string  $str    input string
-	 * @param   string  $mask   mask for search
-	 * @param   integer $offset start position of the string to examine
-	 * @param   integer $length length of the string to examine
-	 * @return  integer length of the initial segment that contains characters not in the mask
+	 * @param   string  $str     Input string
+	 * @param   string  $mask    Mask for search
+	 * @param   int     $offset  Start position of the string to examine
+	 * @param   int     $length  Length of the string to examine
+	 * @return  int  Length of the initial segment that contains characters not in the mask
+	 * @uses    Kohana::find_file
 	 */
 	public static function strcspn($str, $mask, $offset = NULL, $length = NULL)
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require Kohana::find_file('utf8', __FUNCTION__);
-
+			require_once Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -530,24 +532,24 @@ class Kohana_UTF8 {
 	}
 
 	/**
-	 * Pads a UTF-8 string to a certain length with another string. This is a
-	 * UTF8-aware version of [str_pad](http://php.net/str_pad).
+	 * Pads a UTF-8 string to a certain length with another string.
+	 * This is a UTF8-aware version of [str_pad](http://php.net/str_pad).
 	 *
 	 *     $str = UTF8::str_pad($str, $length);
 	 *
 	 * @author  Harry Fuecks <hfuecks@gmail.com>
-	 * @param   string  $str                input string
-	 * @param   integer $final_str_length   desired string length after padding
-	 * @param   string  $pad_str            string to use as padding
-	 * @param   string  $pad_type           padding type: STR_PAD_RIGHT, STR_PAD_LEFT, or STR_PAD_BOTH
+	 * @param   string  $str               Input string
+	 * @param   int     $final_str_length  Desired string length after padding
+	 * @param   string  $pad_str           String to use as padding
+	 * @param   string  $pad_type          Padding type: STR_PAD_RIGHT, STR_PAD_LEFT, or STR_PAD_BOTH
 	 * @return  string
+	 * @uses    Kohana::find_file
 	 */
 	public static function str_pad($str, $final_str_length, $pad_str = ' ', $pad_type = STR_PAD_RIGHT)
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require Kohana::find_file('utf8', __FUNCTION__);
-
+			require_once Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -556,22 +558,22 @@ class Kohana_UTF8 {
 	}
 
 	/**
-	 * Converts a UTF-8 string to an array. This is a UTF8-aware version of
-	 * [str_split](http://php.net/str_split).
+	 * Converts a UTF-8 string to an array. 
+	 * This is a UTF8-aware version of [str_split](http://php.net/str_split).
 	 *
 	 *     $array = UTF8::str_split($str);
 	 *
 	 * @author  Harry Fuecks <hfuecks@gmail.com>
-	 * @param   string  $str            input string
-	 * @param   integer $split_length   maximum length of each chunk
+	 * @param   string  $str           Input string
+	 * @param   int     $split_length  Maximum length of each chunk
 	 * @return  array
+	 * @uses    Kohana::find_file
 	 */
 	public static function str_split($str, $split_length = 1)
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require Kohana::find_file('utf8', __FUNCTION__);
-
+			require_once Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -580,20 +582,21 @@ class Kohana_UTF8 {
 	}
 
 	/**
-	 * Reverses a UTF-8 string. This is a UTF8-aware version of [strrev](http://php.net/strrev).
+	 * Reverses a UTF-8 string. 
+	 * This is a UTF8-aware version of [strrev](http://php.net/strrev).
 	 *
 	 *     $str = UTF8::strrev($str);
 	 *
 	 * @author  Harry Fuecks <hfuecks@gmail.com>
-	 * @param   string  $str string to be reversed
+	 * @param   string  $str  String to be reversed
 	 * @return  string
+	 * @uses    Kohana::find_file
 	 */
 	public static function strrev($str)
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require Kohana::find_file('utf8', __FUNCTION__);
-
+			require_once Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -608,16 +611,16 @@ class Kohana_UTF8 {
 	 *     $str = UTF8::trim($str);
 	 *
 	 * @author  Andreas Gohr <andi@splitbrain.org>
-	 * @param   string  $str        input string
-	 * @param   string  $charlist   string of characters to remove
+	 * @param   string  $str       Input string
+	 * @param   string  $charlist  String of characters to remove
 	 * @return  string
+	 * @uses    Kohana::find_file
 	 */
 	public static function trim($str, $charlist = NULL)
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require Kohana::find_file('utf8', __FUNCTION__);
-
+			require_once Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -626,22 +629,22 @@ class Kohana_UTF8 {
 	}
 
 	/**
-	 * Strips whitespace (or other UTF-8 characters) from the beginning of
-	 * a string. This is a UTF8-aware version of [ltrim](http://php.net/ltrim).
+	 * Strips whitespace (or other UTF-8 characters) from the beginning of a string.
+	 * This is a UTF8-aware version of [ltrim](http://php.net/ltrim).
 	 *
 	 *     $str = UTF8::ltrim($str);
 	 *
 	 * @author  Andreas Gohr <andi@splitbrain.org>
-	 * @param   string  $str        input string
-	 * @param   string  $charlist   string of characters to remove
+	 * @param   string  $str       Input string
+	 * @param   string  $charlist  String of characters to remove
 	 * @return  string
+	 * @uses    Kohana::find_file
 	 */
 	public static function ltrim($str, $charlist = NULL)
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require Kohana::find_file('utf8', __FUNCTION__);
-
+			require_once Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -656,16 +659,16 @@ class Kohana_UTF8 {
 	 *     $str = UTF8::rtrim($str);
 	 *
 	 * @author  Andreas Gohr <andi@splitbrain.org>
-	 * @param   string  $str        input string
-	 * @param   string  $charlist   string of characters to remove
+	 * @param   string  $str       Input string
+	 * @param   string  $charlist  String of characters to remove
 	 * @return  string
+	 * @uses    Kohana::find_file
 	 */
 	public static function rtrim($str, $charlist = NULL)
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require Kohana::find_file('utf8', __FUNCTION__);
-
+			require_once Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -674,21 +677,21 @@ class Kohana_UTF8 {
 	}
 
 	/**
-	 * Returns the unicode ordinal for a character. This is a UTF8-aware
-	 * version of [ord](http://php.net/ord).
+	 * Returns the unicode ordinal for a character.
+	 * This is a UTF8-aware version of [ord](http://php.net/ord).
 	 *
 	 *     $digit = UTF8::ord($character);
 	 *
 	 * @author  Harry Fuecks <hfuecks@gmail.com>
-	 * @param   string  $chr    UTF-8 encoded character
-	 * @return  integer
+	 * @param   string  $chr  UTF-8 encoded character
+	 * @return  int
+	 * @uses    Kohana::find_file
 	 */
 	public static function ord($chr)
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require Kohana::find_file('utf8', __FUNCTION__);
-
+			require_once Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -709,16 +712,15 @@ class Kohana_UTF8 {
 	 * Ported to PHP by Henri Sivonen <hsivonen@iki.fi>, see <http://hsivonen.iki.fi/php-utf8/>
 	 * Slight modifications to fit with phputf8 library by Harry Fuecks <hfuecks@gmail.com>
 	 *
-	 * @param   string  $str    UTF-8 encoded string
-	 * @return  array   unicode code points
-	 * @return  FALSE   if the string is invalid
+	 * @param   string  $str  UTF-8 encoded string
+	 * @return  array|bool  Unicode code points, FALSE if the string is invalid
+	 * @uses    Kohana::find_file
 	 */
 	public static function to_unicode($str)
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require Kohana::find_file('utf8', __FUNCTION__);
-
+			require_once Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -739,16 +741,16 @@ class Kohana_UTF8 {
 	 * Ported to PHP by Henri Sivonen <hsivonen@iki.fi>, see http://hsivonen.iki.fi/php-utf8/
 	 * Slight modifications to fit with phputf8 library by Harry Fuecks <hfuecks@gmail.com>.
 	 *
-	 * @param   array   $str    unicode code points representing a string
-	 * @return  string  utf8 string of characters
-	 * @return  boolean FALSE if a code point cannot be found
+	 * @param   array   $str  Unicode code points representing a string
+	 * @return  string  utf8  String of characters
+	 * @return  bool  FALSE if a code point cannot be found
+	 * @uses    Kohana::find_file
 	 */
 	public static function from_unicode($arr)
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require Kohana::find_file('utf8', __FUNCTION__);
-
+			require_once Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -758,8 +760,8 @@ class Kohana_UTF8 {
 
 }
 
-if (Kohana_UTF8::$server_utf8 === NULL)
+if (UTF8::$server_utf8 === NULL)
 {
 	// Determine if this server supports UTF-8 natively
-	Kohana_UTF8::$server_utf8 = extension_loaded('mbstring');
+	UTF8::$server_utf8 = extension_loaded('mbstring');
 }

--- a/classes/Kohana/UTF8.php
+++ b/classes/Kohana/UTF8.php
@@ -141,7 +141,7 @@ abstract class Kohana_UTF8 {
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require_once Kohana::find_file('utf8', __FUNCTION__);
+			require Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -169,7 +169,7 @@ abstract class Kohana_UTF8 {
 
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require_once Kohana::find_file('utf8', __FUNCTION__);
+			require Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -200,7 +200,7 @@ abstract class Kohana_UTF8 {
 
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require_once Kohana::find_file('utf8', __FUNCTION__);
+			require Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -231,7 +231,7 @@ abstract class Kohana_UTF8 {
 
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require_once Kohana::find_file('utf8', __FUNCTION__);
+			require Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -264,7 +264,7 @@ abstract class Kohana_UTF8 {
 
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require_once Kohana::find_file('utf8', __FUNCTION__);
+			require Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -290,7 +290,7 @@ abstract class Kohana_UTF8 {
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require_once Kohana::find_file('utf8', __FUNCTION__);
+			require Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -319,7 +319,7 @@ abstract class Kohana_UTF8 {
 
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require_once Kohana::find_file('utf8', __FUNCTION__);
+			require Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -346,7 +346,7 @@ abstract class Kohana_UTF8 {
 
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require_once Kohana::find_file('utf8', __FUNCTION__);
+			require Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -369,7 +369,7 @@ abstract class Kohana_UTF8 {
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require_once Kohana::find_file('utf8', __FUNCTION__);
+			require Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -392,7 +392,7 @@ abstract class Kohana_UTF8 {
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require_once Kohana::find_file('utf8', __FUNCTION__);
+			require Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -418,7 +418,7 @@ abstract class Kohana_UTF8 {
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require_once Kohana::find_file('utf8', __FUNCTION__);
+			require Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -447,7 +447,7 @@ abstract class Kohana_UTF8 {
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require_once Kohana::find_file('utf8', __FUNCTION__);
+			require Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -471,7 +471,7 @@ abstract class Kohana_UTF8 {
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require_once Kohana::find_file('utf8', __FUNCTION__);
+			require Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -497,7 +497,7 @@ abstract class Kohana_UTF8 {
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require_once Kohana::find_file('utf8', __FUNCTION__);
+			require Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -523,7 +523,7 @@ abstract class Kohana_UTF8 {
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require_once Kohana::find_file('utf8', __FUNCTION__);
+			require Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -549,7 +549,7 @@ abstract class Kohana_UTF8 {
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require_once Kohana::find_file('utf8', __FUNCTION__);
+			require Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -573,7 +573,7 @@ abstract class Kohana_UTF8 {
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require_once Kohana::find_file('utf8', __FUNCTION__);
+			require Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -596,7 +596,7 @@ abstract class Kohana_UTF8 {
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require_once Kohana::find_file('utf8', __FUNCTION__);
+			require Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -620,7 +620,7 @@ abstract class Kohana_UTF8 {
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require_once Kohana::find_file('utf8', __FUNCTION__);
+			require Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -644,7 +644,7 @@ abstract class Kohana_UTF8 {
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require_once Kohana::find_file('utf8', __FUNCTION__);
+			require Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -668,7 +668,7 @@ abstract class Kohana_UTF8 {
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require_once Kohana::find_file('utf8', __FUNCTION__);
+			require Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -691,7 +691,7 @@ abstract class Kohana_UTF8 {
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require_once Kohana::find_file('utf8', __FUNCTION__);
+			require Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -720,7 +720,7 @@ abstract class Kohana_UTF8 {
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require_once Kohana::find_file('utf8', __FUNCTION__);
+			require Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}
@@ -750,7 +750,7 @@ abstract class Kohana_UTF8 {
 	{
 		if ( ! isset(UTF8::$called[__FUNCTION__]))
 		{
-			require_once Kohana::find_file('utf8', __FUNCTION__);
+			require Kohana::find_file('utf8', __FUNCTION__);
 			// Function has been called
 			UTF8::$called[__FUNCTION__] = TRUE;
 		}


### PR DESCRIPTION
Bugs: 
UTF8::clean():
check UTF8::$server_utf8 not specified
Error result: http://kohanaframework.org/3.3/guide-api/Kohana ErrorException [Fatal Error]: Call to undefined function mb_convert_encoding().

UTF8::$server_utf8:
Set Kohana_UTF8::$server_utf8 not true, because UTF8 use property as UTF8::$server_utf8
