### PR TITLE
Initialize UTF8::$server_utf8 moved into Kohana_UTF8::native_utf8()

### DIFF
--- a/classes/UTF8.php
+++ b/classes/UTF8.php
@@ -1,9 +1,3 @@
 <?php defined('SYSPATH') OR die('No direct script access.');
 
 class UTF8 extends Kohana_UTF8 {}
-
-if (UTF8::$server_utf8 === NULL)
-{
-	// Determine if this server supports UTF-8 natively
-	UTF8::$server_utf8 = extension_loaded('mbstring');
-}


### PR DESCRIPTION
Class file should contain only class itself. Initialize UTF8::$server_utf8 moved into Kohana_UTF8::native_utf8().
