### PR TITLE
Add native_utf8, fix _load, clean, is_ascii

### DIFF
--- a/classes/Kohana/UTF8.php
+++ b/classes/Kohana/UTF8.php
@@ -54,18 +54,23 @@ abstract class Kohana_UTF8 {
 	 * Include once file with "utf8" function.
 	 *
 	 * @param   string  $function  Function name
-	 * @return  void
+	 * @return  bool
 	 * @uses    Kohana::find_file
 	 */
 	protected static function _load($function)
 	{
 		if ( ! isset(UTF8::$called[$function]))
 		{
-			require_once Kohana::find_file('utf8', $function);
+			if ($file = Kohana::find_file('utf8', $function))
+			{
+				require_once $file;
+			}
 
-			// Function has been called
-			UTF8::$called[$function] = TRUE;
+			// Set loading status of function
+			UTF8::$called[$function] = ! empty($file);
 		}
+
+		return UTF8::$called[$function];
 	}
 
 	/**
@@ -634,7 +639,7 @@ abstract class Kohana_UTF8 {
 	 * Astral planes are supported i.e. the ints in the input can be > 0xFFFF.
 	 * Occurrences of the BOM are ignored. Surrogates are not allowed.
 	 *
-	 *     $str = UTF8::to_unicode($array);
+	 *     $str = UTF8::from_unicode($array);
 	 *
 	 * The Original Code is Mozilla Communicator client code.
 	 * The Initial Developer of the Original Code is Netscape Communications Corporation.

--- a/classes/Kohana/UTF8.php
+++ b/classes/Kohana/UTF8.php
@@ -495,7 +495,7 @@ abstract class Kohana_UTF8 {
 	 * @param   string  $str               Input string
 	 * @param   int     $final_str_length  Desired string length after padding
 	 * @param   string  $pad_str           String to use as padding
-	 * @param   string  $pad_type          Padding type: STR_PAD_RIGHT, STR_PAD_LEFT or STR_PAD_BOTH
+	 * @param   string  $pad_type          Padding type: STR_PAD_RIGHT, STR_PAD_LEFT, STR_PAD_BOTH
 	 * @return  string
 	 */
 	public static function str_pad($str, $final_str_length, $pad_str = ' ', $pad_type = STR_PAD_RIGHT)


### PR DESCRIPTION
`UTF8::native_utf8()`: added to preserve purity of class file

`UTF8::_load()`: need use require_once because `UTF8::$called` is public property:

```
unset(UTF8::$called['strlen']);
UTF8::strlen($str);
```

`UTF8::clean()`: reordered `UTF8::native_utf8()` and `UTF8::is_ansii()` - basic condition "server_utf8 = true".

`UTF8::is_ascii()`: added support for traversable objects
