### PR TITLE
3.3/develop

### DIFF
--- a/classes/Kohana/Cookie.php
+++ b/classes/Kohana/Cookie.php
@@ -71,7 +71,7 @@ class Kohana_Cookie {
 			// Separate the salt and the value
 			list ($hash, $value) = explode('~', $cookie, 2);
 
-			if (Cookie::salt($key, $value) === $hash)
+			if (Security::slow_equals(Cookie::salt($key, $value), $hash))
 			{
 				// Cookie signature is valid
 				return $value;

--- a/classes/Kohana/Security.php
+++ b/classes/Kohana/Security.php
@@ -81,8 +81,29 @@ class Kohana_Security {
 	 */
 	public static function check($token)
 	{
-		return Security::token() === $token;
+		return Security::slow_equals(Security::token(), $token);
 	}
+	
+	
+	
+	/**
+	 * Compare two hashes in a time-invariant manner.
+	 * Prevents cryptographic side-channel attacks (timing attacks, specifically)
+	 * 
+	 * @param string $a cryptographic hash
+	 * @param string $b cryptographic hash
+	 * @return boolean
+	 */
+	public static function slow_equals($a, $b) 
+	{
+		$diff = strlen($a) ^ strlen($b);
+		for($i = 0; $i < strlen($a) AND $i < strlen($b); $i++)
+		{
+			$diff |= ord($a[$i]) ^ ord($b[$i]);
+		}
+		return $diff === 0; 
+	}
+
 
 	/**
 	 * Remove image tags from a string.


### PR DESCRIPTION
Now on the correct branch!

When cryptographic hashes are compared with the `===` operator, they are susceptible to remote timing attacks. This patch affects the cookie-based session driver as well as `Security::check($token)`; you may wish to also patch other hash comparison functions.

`slow_equals()` taken from https://defuse.ca/php-pbkdf2.htm
