### PR TITLE
bug #503: allow query-only links in HTML::anchor()

### DIFF
--- a/classes/Kohana/HTML.php
+++ b/classes/Kohana/HTML.php
@@ -126,9 +126,9 @@ class Kohana_HTML {
 					$attributes['target'] = '_blank';
 				}
 			}
-			elseif ($uri[0] !== '#')
+			elseif ($uri[0] !== '#' AND $uri[0] !== '?')
 			{
-				// Make the URI absolute for non-id anchors
+				// Make the URI absolute for non-fragment and non-query anchors
 				$uri = URL::site($uri, $protocol, $index);
 			}
 		}

--- a/tests/kohana/HTMLTest.php
+++ b/tests/kohana/HTMLTest.php
@@ -223,6 +223,20 @@ class Kohana_HTMLTest extends Unittest_TestCase
 	public function provider_anchor()
 	{
 		return array(
+			// a fragment-only anchor
+			array(
+				'<a href="#go-to-section-kohana">Kohana</a>',
+				array(),
+				'#go-to-section-kohana',
+				'Kohana',
+			),
+			// a query-only anchor
+			array(
+				'<a href="?cat=a">Category A</a>',
+				array(),
+				'?cat=a',
+				'Category A',
+			),
 			array(
 				'<a href="http://kohanaframework.org">Kohana</a>',
 				array(),


### PR DESCRIPTION
Added tests for query-only and fragment-only links

Ref #503 
