### PR TITLE
3.4/develop

### DIFF
--- a/classes/Arr.php
+++ b/classes/Arr.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Arr extends Kohana_Arr {}

--- a/classes/Config.php
+++ b/classes/Config.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Config extends Kohana_Config {}

--- a/classes/Config/File.php
+++ b/classes/Config/File.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Config_File extends Kohana_Config_File {}

--- a/classes/Config/Group.php
+++ b/classes/Config/Group.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Config_Group extends Kohana_Config_Group {}

--- a/classes/Controller.php
+++ b/classes/Controller.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 abstract class Controller extends Kohana_Controller {}

--- a/classes/Controller/Template.php
+++ b/classes/Controller/Template.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 abstract class Controller_Template extends Kohana_Controller_Template {}

--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Cookie extends Kohana_Cookie {}

--- a/classes/Date.php
+++ b/classes/Date.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Date extends Kohana_Date {}

--- a/classes/Debug.php
+++ b/classes/Debug.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Debug extends Kohana_Debug {}

--- a/classes/Encrypt.php
+++ b/classes/Encrypt.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Encrypt extends Kohana_Encrypt {}

--- a/classes/Feed.php
+++ b/classes/Feed.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Feed extends Kohana_Feed {}

--- a/classes/File.php
+++ b/classes/File.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class File extends Kohana_File {}

--- a/classes/Form.php
+++ b/classes/Form.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Form extends Kohana_Form {}

--- a/classes/Fragment.php
+++ b/classes/Fragment.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Fragment extends Kohana_Fragment {}

--- a/classes/HTML.php
+++ b/classes/HTML.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTML extends Kohana_HTML {}

--- a/classes/HTTP.php
+++ b/classes/HTTP.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 abstract class HTTP extends Kohana_HTTP {}

--- a/classes/HTTP/Exception.php
+++ b/classes/HTTP/Exception.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Exception extends Kohana_HTTP_Exception {}

--- a/classes/HTTP/Exception/300.php
+++ b/classes/HTTP/Exception/300.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Exception_300 extends Kohana_HTTP_Exception_300 {}

--- a/classes/HTTP/Exception/301.php
+++ b/classes/HTTP/Exception/301.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Exception_301 extends Kohana_HTTP_Exception_301 {}

--- a/classes/HTTP/Exception/302.php
+++ b/classes/HTTP/Exception/302.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Exception_302 extends Kohana_HTTP_Exception_302 {}

--- a/classes/HTTP/Exception/303.php
+++ b/classes/HTTP/Exception/303.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Exception_303 extends Kohana_HTTP_Exception_303 {}

--- a/classes/HTTP/Exception/304.php
+++ b/classes/HTTP/Exception/304.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Exception_304 extends Kohana_HTTP_Exception_304 {}

--- a/classes/HTTP/Exception/305.php
+++ b/classes/HTTP/Exception/305.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Exception_305 extends Kohana_HTTP_Exception_305 {}

--- a/classes/HTTP/Exception/307.php
+++ b/classes/HTTP/Exception/307.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Exception_307 extends Kohana_HTTP_Exception_307 {}

--- a/classes/HTTP/Exception/400.php
+++ b/classes/HTTP/Exception/400.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Exception_400 extends Kohana_HTTP_Exception_400 {}

--- a/classes/HTTP/Exception/401.php
+++ b/classes/HTTP/Exception/401.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Exception_401 extends Kohana_HTTP_Exception_401 {}

--- a/classes/HTTP/Exception/402.php
+++ b/classes/HTTP/Exception/402.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Exception_402 extends Kohana_HTTP_Exception_402 {}

--- a/classes/HTTP/Exception/403.php
+++ b/classes/HTTP/Exception/403.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Exception_403 extends Kohana_HTTP_Exception_403 {}

--- a/classes/HTTP/Exception/404.php
+++ b/classes/HTTP/Exception/404.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Exception_404 extends Kohana_HTTP_Exception_404 {}

--- a/classes/HTTP/Exception/405.php
+++ b/classes/HTTP/Exception/405.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Exception_405 extends Kohana_HTTP_Exception_405 {}

--- a/classes/HTTP/Exception/406.php
+++ b/classes/HTTP/Exception/406.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Exception_406 extends Kohana_HTTP_Exception_406 {}

--- a/classes/HTTP/Exception/407.php
+++ b/classes/HTTP/Exception/407.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Exception_407 extends Kohana_HTTP_Exception_407 {}

--- a/classes/HTTP/Exception/408.php
+++ b/classes/HTTP/Exception/408.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Exception_408 extends Kohana_HTTP_Exception_408 {}

--- a/classes/HTTP/Exception/409.php
+++ b/classes/HTTP/Exception/409.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Exception_409 extends Kohana_HTTP_Exception_409 {}

--- a/classes/HTTP/Exception/410.php
+++ b/classes/HTTP/Exception/410.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Exception_410 extends Kohana_HTTP_Exception_410 {}

--- a/classes/HTTP/Exception/411.php
+++ b/classes/HTTP/Exception/411.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Exception_411 extends Kohana_HTTP_Exception_411 {}

--- a/classes/HTTP/Exception/412.php
+++ b/classes/HTTP/Exception/412.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Exception_412 extends Kohana_HTTP_Exception_412 {}

--- a/classes/HTTP/Exception/413.php
+++ b/classes/HTTP/Exception/413.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Exception_413 extends Kohana_HTTP_Exception_413 {}

--- a/classes/HTTP/Exception/414.php
+++ b/classes/HTTP/Exception/414.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Exception_414 extends Kohana_HTTP_Exception_414 {}

--- a/classes/HTTP/Exception/415.php
+++ b/classes/HTTP/Exception/415.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Exception_415 extends Kohana_HTTP_Exception_415 {}

--- a/classes/HTTP/Exception/416.php
+++ b/classes/HTTP/Exception/416.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Exception_416 extends Kohana_HTTP_Exception_416 {}

--- a/classes/HTTP/Exception/417.php
+++ b/classes/HTTP/Exception/417.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Exception_417 extends Kohana_HTTP_Exception_417 {}

--- a/classes/HTTP/Exception/500.php
+++ b/classes/HTTP/Exception/500.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Exception_500 extends Kohana_HTTP_Exception_500 {}

--- a/classes/HTTP/Exception/501.php
+++ b/classes/HTTP/Exception/501.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Exception_501 extends Kohana_HTTP_Exception_501 {}

--- a/classes/HTTP/Exception/502.php
+++ b/classes/HTTP/Exception/502.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Exception_502 extends Kohana_HTTP_Exception_502 {}

--- a/classes/HTTP/Exception/503.php
+++ b/classes/HTTP/Exception/503.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Exception_503 extends Kohana_HTTP_Exception_503 {}

--- a/classes/HTTP/Exception/504.php
+++ b/classes/HTTP/Exception/504.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Exception_504 extends Kohana_HTTP_Exception_504 {}

--- a/classes/HTTP/Exception/505.php
+++ b/classes/HTTP/Exception/505.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Exception_505 extends Kohana_HTTP_Exception_505 {}

--- a/classes/HTTP/Exception/Expected.php
+++ b/classes/HTTP/Exception/Expected.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 abstract class HTTP_Exception_Expected extends Kohana_HTTP_Exception_Expected {}

--- a/classes/HTTP/Exception/Redirect.php
+++ b/classes/HTTP/Exception/Redirect.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 abstract class HTTP_Exception_Redirect extends Kohana_HTTP_Exception_Redirect {}

--- a/classes/HTTP/Header.php
+++ b/classes/HTTP/Header.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class HTTP_Header extends Kohana_HTTP_Header {}

--- a/classes/HTTP/Message.php
+++ b/classes/HTTP/Message.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 interface HTTP_Message extends Kohana_HTTP_Message {}

--- a/classes/HTTP/Request.php
+++ b/classes/HTTP/Request.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 interface HTTP_Request extends Kohana_HTTP_Request {}

--- a/classes/HTTP/Response.php
+++ b/classes/HTTP/Response.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 interface HTTP_Response extends Kohana_HTTP_Response {}

--- a/classes/I18n.php
+++ b/classes/I18n.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class I18n extends Kohana_I18n {}

--- a/classes/Inflector.php
+++ b/classes/Inflector.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Inflector extends Kohana_Inflector {}

--- a/classes/Kohana.php
+++ b/classes/Kohana.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana extends Kohana_Core {}

--- a/classes/Kohana/Arr.php
+++ b/classes/Kohana/Arr.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Array helper.
  *

--- a/classes/Kohana/Config.php
+++ b/classes/Kohana/Config.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Wrapper for configuration arrays. Multiple configuration readers can be
  * attached to allow loading configuration from files, database, etc.

--- a/classes/Kohana/Config/File.php
+++ b/classes/Kohana/Config/File.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * File-based configuration reader. Multiple configuration directories can be
  * used by attaching multiple instances of this class to [Config].

--- a/classes/Kohana/Config/File/Reader.php
+++ b/classes/Kohana/Config/File/Reader.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * File-based configuration reader. Multiple configuration directories can be
  * used by attaching multiple instances of this class to [Kohana_Config].

--- a/classes/Kohana/Config/Group.php
+++ b/classes/Kohana/Config/Group.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 /**
  * The group wrapper acts as an interface to all the config directives

--- a/classes/Kohana/Config/Reader.php
+++ b/classes/Kohana/Config/Reader.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 /**
  * Interface for config readers

--- a/classes/Kohana/Config/Source.php
+++ b/classes/Kohana/Config/Source.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Base Config source Interface
  *

--- a/classes/Kohana/Config/Writer.php
+++ b/classes/Kohana/Config/Writer.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 /**
  * Interface for config writers

--- a/classes/Kohana/Controller.php
+++ b/classes/Kohana/Controller.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Abstract controller class. Controllers should only be created using a [Request].
  *

--- a/classes/Kohana/Controller/Template.php
+++ b/classes/Kohana/Controller/Template.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Abstract controller class for automatic templating.
  *

--- a/classes/Kohana/Cookie.php
+++ b/classes/Kohana/Cookie.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Cookie helper.
  *

--- a/classes/Kohana/Core.php
+++ b/classes/Kohana/Core.php
@@ -139,7 +139,7 @@ class Kohana_Core {
 	/**
 	 * @var  array   Include paths that are used to find files
 	 */
-	protected static $_paths = array(APPPATH, SYSPATH);
+	protected static $_paths = array(SYSPATH, APPPATH);
 
 	/**
 	 * @var  array   File path cache, used when caching is true in [Kohana::init]
@@ -563,8 +563,8 @@ class Kohana_Core {
 			return Kohana::$_modules;
 		}
 
-		// Start a new list of include paths, APPPATH first
-		$paths = array(APPPATH);
+		// Start a new list of include paths, SYSPATH first
+		$paths = [SYSPATH];
 
 		foreach ($modules as $name => $path)
 		{
@@ -583,8 +583,8 @@ class Kohana_Core {
 			}
 		}
 
-		// Finish the include paths by adding SYSPATH
-		$paths[] = SYSPATH;
+		// Finish the include paths by adding APPPATH
+		$paths[] = APPPATH;
 
 		// Set the new include paths
 		Kohana::$_paths = $paths;
@@ -681,13 +681,10 @@ class Kohana_Core {
 
 		if ($array OR $dir === 'config' OR $dir === 'i18n' OR $dir === 'messages')
 		{
-			// Include paths must be searched in reverse
-			$paths = array_reverse(Kohana::$_paths);
-
 			// Array of files that have been found
 			$found = array();
 
-			foreach ($paths as $dir)
+			foreach (Kohana::$_paths as $dir)
 			{
 				if (is_file($dir.$path))
 				{

--- a/classes/Kohana/Core.php
+++ b/classes/Kohana/Core.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Contains the most low-level helpers methods in Kohana:
  *
@@ -24,9 +24,6 @@ class Kohana_Core {
 	const STAGING     = 20;
 	const TESTING     = 30;
 	const DEVELOPMENT = 40;
-
-	// Security check that is added to all generated PHP files
-	const FILE_SECURITY = '<?php defined(\'SYSPATH\') OR die(\'No direct script access.\');';
 
 	// Format of cache files: header, cache name, and data
 	const FILE_CACHE = ":header \n\n// :name\n\n:data\n";

--- a/classes/Kohana/Core.php
+++ b/classes/Kohana/Core.php
@@ -134,12 +134,7 @@ class Kohana_Core {
 	/**
 	 * @var  array   Currently active modules
 	 */
-	protected static $_modules = array();
-
-	/**
-	 * @var  array   Include paths that are used to find files
-	 */
-	protected static $_paths = array(SYSPATH, APPPATH);
+	protected static $_modules = ['_core' => SYSPATH, '_application' => APPPATH];
 
 	/**
 	 * @var  array   File path cache, used when caching is true in [Kohana::init]
@@ -370,8 +365,8 @@ class Kohana_Core {
 			Kohana::$log = Kohana::$config = NULL;
 
 			// Reset internal storage
-			Kohana::$_modules = Kohana::$_files = array();
-			Kohana::$_paths   = array(APPPATH, SYSPATH);
+			Kohana::$_modules = ['_core' => SYSPATH, '_application' => APPPATH];
+			Kohana::$_files = [];
 
 			// Reset file cache status
 			Kohana::$_files_changed = FALSE;
@@ -563,15 +558,15 @@ class Kohana_Core {
 			return Kohana::$_modules;
 		}
 
-		// Start a new list of include paths, SYSPATH first
-		$paths = [SYSPATH];
+		// Prepend core module and append application module
+		$modules = array_merge(['_core' => SYSPATH], $modules, ['_application' => APPPATH]);
 
 		foreach ($modules as $name => $path)
 		{
 			if (is_dir($path))
 			{
-				// Add the module to include paths
-				$paths[] = $modules[$name] = realpath($path).DIRECTORY_SEPARATOR;
+				// Filter module path
+				$modules[$name] = realpath($path).DIRECTORY_SEPARATOR;
 			}
 			else
 			{
@@ -582,12 +577,6 @@ class Kohana_Core {
 				));
 			}
 		}
-
-		// Finish the include paths by adding APPPATH
-		$paths[] = APPPATH;
-
-		// Set the new include paths
-		Kohana::$_paths = $paths;
 
 		// Set the current module list
 		Kohana::$_modules = $modules;
@@ -614,7 +603,7 @@ class Kohana_Core {
 	 */
 	public static function include_paths()
 	{
-		return Kohana::$_paths;
+		return array_values(Kohana::$_modules);
 	}
 
 	/**
@@ -684,7 +673,7 @@ class Kohana_Core {
 			// Array of files that have been found
 			$found = array();
 
-			foreach (Kohana::$_paths as $dir)
+			foreach (Kohana::$_modules as $dir)
 			{
 				if (is_file($dir.$path))
 				{
@@ -698,7 +687,7 @@ class Kohana_Core {
 			// The file has not been found yet
 			$found = FALSE;
 
-			foreach (Kohana::$_paths as $dir)
+			foreach (Kohana::$_modules as $dir)
 			{
 				if (is_file($dir.$path))
 				{
@@ -752,7 +741,7 @@ class Kohana_Core {
 		if ($paths === NULL)
 		{
 			// Use the default paths
-			$paths = Kohana::$_paths;
+			$paths = Kohana::$_modules;
 		}
 
 		// Create an array for the files

--- a/classes/Kohana/Core.php
+++ b/classes/Kohana/Core.php
@@ -42,11 +42,6 @@ class Kohana_Core {
 	public static $is_windows = FALSE;
 
 	/**
-	 * @var  boolean  TRUE if PHP safe mode is on
-	 */
-	public static $safe_mode = FALSE;
-
-	/**
 	 * @var  string
 	 */
 	public static $content_type = 'text/html';
@@ -231,9 +226,6 @@ class Kohana_Core {
 
 		// Determine if we are running in a Windows environment
 		Kohana::$is_windows = (DIRECTORY_SEPARATOR === '\\');
-
-		// Determine if we are running in safe mode
-		Kohana::$safe_mode = (bool) ini_get('safe_mode');
 
 		if (isset($settings['cache_dir']))
 		{

--- a/classes/Kohana/Core.php
+++ b/classes/Kohana/Core.php
@@ -42,11 +42,6 @@ class Kohana_Core {
 	public static $is_windows = FALSE;
 
 	/**
-	 * @var  boolean  True if [magic quotes](http://php.net/manual/en/security.magicquotes.php) is enabled.
-	 */
-	public static $magic_quotes = FALSE;
-
-	/**
 	 * @var  boolean  TRUE if PHP safe mode is on
 	 */
 	public static $safe_mode = FALSE;
@@ -149,7 +144,7 @@ class Kohana_Core {
 	/**
 	 * Initializes the environment:
 	 *
-	 * - Disables register_globals and magic_quotes_gpc
+	 * - Disables register_globals
 	 * - Determines the current environment
 	 * - Set global settings
 	 * - Sanitizes GET, POST, and COOKIE variables
@@ -316,9 +311,6 @@ class Kohana_Core {
 			Kohana::$index_file = trim($settings['index_file'], '/');
 		}
 
-		// Determine if the extremely evil magic quotes are enabled
-		Kohana::$magic_quotes = (bool) get_magic_quotes_gpc();
-
 		// Sanitize all request variables
 		$_GET    = Kohana::sanitize($_GET);
 		$_POST   = Kohana::sanitize($_POST);
@@ -426,7 +418,6 @@ class Kohana_Core {
 	/**
 	 * Recursively sanitizes an input variable:
 	 *
-	 * - Strips slashes if magic quotes are enabled
 	 * - Normalizes all newlines to LF
 	 *
 	 * @param   mixed   $value  any variable
@@ -444,12 +435,6 @@ class Kohana_Core {
 		}
 		elseif (is_string($value))
 		{
-			if (Kohana::$magic_quotes === TRUE)
-			{
-				// Remove slashes added by magic quotes
-				$value = stripslashes($value);
-			}
-
 			if (strpos($value, "\r") !== FALSE)
 			{
 				// Standardize newlines

--- a/classes/Kohana/Core.php
+++ b/classes/Kohana/Core.php
@@ -139,7 +139,6 @@ class Kohana_Core {
 	/**
 	 * Initializes the environment:
 	 *
-	 * - Disables register_globals
 	 * - Determines the current environment
 	 * - Set global settings
 	 * - Sanitizes GET, POST, and COOKIE variables
@@ -212,12 +211,6 @@ class Kohana_Core {
 
 		// Enable the Kohana shutdown handler, which catches E_FATAL errors.
 		register_shutdown_function(array('Kohana', 'shutdown_handler'));
-
-		if (ini_get('register_globals'))
-		{
-			// Reverse the effects of register_globals
-			Kohana::globals();
-		}
 
 		if (isset($settings['expose']))
 		{
@@ -357,53 +350,6 @@ class Kohana_Core {
 
 			// Kohana is no longer initialized
 			Kohana::$_init = FALSE;
-		}
-	}
-
-	/**
-	 * Reverts the effects of the `register_globals` PHP setting by unsetting
-	 * all global variables except for the default super globals (GPCS, etc),
-	 * which is a [potential security hole.][ref-wikibooks]
-	 *
-	 * This is called automatically by [Kohana::init] if `register_globals` is
-	 * on.
-	 *
-	 *
-	 * [ref-wikibooks]: http://en.wikibooks.org/wiki/PHP_Programming/Register_Globals
-	 *
-	 * @return  void
-	 */
-	public static function globals()
-	{
-		if (isset($_REQUEST['GLOBALS']) OR isset($_FILES['GLOBALS']))
-		{
-			// Prevent malicious GLOBALS overload attack
-			echo "Global variable overload attack detected! Request aborted.\n";
-
-			// Exit with an error status
-			exit(1);
-		}
-
-		// Get the variable names of all globals
-		$global_variables = array_keys($GLOBALS);
-
-		// Remove the standard global variables from the list
-		$global_variables = array_diff($global_variables, array(
-			'_COOKIE',
-			'_ENV',
-			'_GET',
-			'_FILES',
-			'_POST',
-			'_REQUEST',
-			'_SERVER',
-			'_SESSION',
-			'GLOBALS',
-		));
-
-		foreach ($global_variables as $name)
-		{
-			// Unset the global variable, effectively disabling register_globals
-			unset($GLOBALS[$name]);
 		}
 	}
 

--- a/classes/Kohana/Core.php
+++ b/classes/Kohana/Core.php
@@ -134,7 +134,7 @@ class Kohana_Core {
 	/**
 	 * @var  array   Currently active modules
 	 */
-	protected static $_modules = ['_core' => SYSPATH, '_application' => APPPATH];
+	protected static $_modules = [];
 
 	/**
 	 * @var  array   File path cache, used when caching is true in [Kohana::init]
@@ -365,7 +365,7 @@ class Kohana_Core {
 			Kohana::$log = Kohana::$config = NULL;
 
 			// Reset internal storage
-			Kohana::$_modules = ['_core' => SYSPATH, '_application' => APPPATH];
+			Kohana::$_modules = [];
 			Kohana::$_files = [];
 
 			// Reset file cache status
@@ -555,9 +555,6 @@ class Kohana_Core {
 		// If modules array has been passed
 		if ($modules !== NULL)
 		{
-			// Prepend core module and append application module
-			$modules = array_merge(['_core' => SYSPATH], $modules, ['_application' => APPPATH]);
-
 			foreach ($modules as $name => $path)
 			{
 				// If module directory doesn't exist

--- a/classes/Kohana/Core.php
+++ b/classes/Kohana/Core.php
@@ -475,6 +475,9 @@ class Kohana_Core {
 		// If modules array has been passed
 		if ($modules !== NULL)
 		{
+			// Reset enabled modules
+			Kohana::$_modules = [];
+			
 			foreach ($modules as $name => $path)
 			{
 				// If module directory doesn't exist
@@ -486,10 +489,13 @@ class Kohana_Core {
 						':path'   => Debug::path($path),
 					));
 				}
-
-				// Filter module path
-				$modules[$name] = realpath($path).DIRECTORY_SEPARATOR;
-
+				
+				// Get resolved, absolute path
+				$path = realpath($path).DIRECTORY_SEPARATOR;
+				
+				// Enable module
+				Kohana::$_modules[$name] = $path;
+				
 				// If module init file exists
 				$init_path = $path.'init'.EXT;
 
@@ -499,9 +505,6 @@ class Kohana_Core {
 					require_once $init_path;
 				}
 			}
-
-			// Set the new module list
-			Kohana::$_modules = $modules;
 		}
 
 		// Return enabled modules

--- a/classes/Kohana/Core.php
+++ b/classes/Kohana/Core.php
@@ -167,7 +167,7 @@ class Kohana_Core {
 	 * `string`  | base_url   | The base URL for your application.  This should be the *relative* path from your DOCROOT to your `index.php` file, in other words, if Kohana is in a subfolder, set this to the subfolder name, otherwise leave it as the default.  **The leading slash is required**, trailing slash is optional.   | `"/"`
 	 * `string`  | index_file | The name of the [front controller](http://en.wikipedia.org/wiki/Front_Controller_pattern).  This is used by Kohana to generate relative urls like [HTML::anchor()] and [URL::base()]. This is usually `index.php`.  To [remove index.php from your urls](tutorials/clean-urls), set this to `FALSE`. | `"index.php"`
 	 * `string`  | charset    | Character set used for all input and output    | `"utf-8"`
-	 * `string`  | cache_dir  | Kohana's cache directory.  Used by [Kohana::cache] for simple internal caching, like [Fragments](kohana/fragments) and **\[caching database queries](this should link somewhere)**.  This has nothing to do with the [Cache module](cache). | `APPPATH."cache"`
+	 * `string`  | cache_dir  | Kohana's cache directory.  Used by [Kohana::cache] for simple internal caching, like [Fragments](kohana/fragments) and **\[caching database queries](this should link somewhere)**.  This has nothing to do with the [Cache module](cache). | `"cache"`
 	 * `integer` | cache_life | Lifetime, in seconds, of items cached by [Kohana::cache]         | `60`
 	 * `boolean` | errors     | Should Kohana catch PHP errors and uncaught Exceptions and show the `error_view`. See [Error Handling](kohana/errors) for more info. <br /> <br /> Recommended setting: `TRUE` while developing, `FALSE` on production servers. | `TRUE`
 	 * `boolean` | profile    | Whether to enable the [Profiler](kohana/profiling). <br /> <br />Recommended setting: `TRUE` while developing, `FALSE` on production servers. | `TRUE`
@@ -270,7 +270,7 @@ class Kohana_Core {
 		else
 		{
 			// Use the default cache directory
-			Kohana::$cache_dir = APPPATH.'cache';
+			Kohana::$cache_dir = 'cache';
 		}
 
 		if ( ! is_writable(Kohana::$cache_dir))

--- a/classes/Kohana/Date.php
+++ b/classes/Kohana/Date.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Date helper.
  *

--- a/classes/Kohana/Debug.php
+++ b/classes/Kohana/Debug.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Contains debugging and dumping tools.
  *

--- a/classes/Kohana/Debug.php
+++ b/classes/Kohana/Debug.php
@@ -247,36 +247,41 @@ class Kohana_Debug {
 	}
 
 	/**
-	 * Removes application, system, modpath, or docroot from a filename,
-	 * replacing them with the plain text equivalents. Useful for debugging
-	 * when you want to display a shorter path.
+	 * Shortens a path by replacing the begining snippet with a textual alias.
+	 * Path aliases used are: enabled modules, MODPATH, and DOCROOT.
 	 *
-	 *     // Displays SYSPATH/classes/kohana.php
-	 *     echo Debug::path(Kohana::find_file('classes', 'kohana'));
+	 *     // Returns {module:core}/classes/Kohana.php
+	 *     Debug::path(Kohana::find_file('classes', 'Kohana'));
 	 *
-	 * @param   string  $file   path to debug
-	 * @return  string
+	 * @param string $path Path to shorten
+	 * @return string The shortened path
 	 */
-	public static function path($file)
+	public static function path($path)
 	{
-		if (strpos($file, APPPATH) === 0)
+		$alias_paths = [];
+		
+		// Add enabled modules to alias paths
+		foreach (Kohana::modules() as $module_name => $module_path)
 		{
-			$file = 'APPPATH'.DIRECTORY_SEPARATOR.substr($file, strlen(APPPATH));
+			$alias_paths['module:'.$module_name] = $module_path;
 		}
-		elseif (strpos($file, SYSPATH) === 0)
+		
+		// Add MODPATH and DOCROOT to alias paths
+		$alias_paths = $alias_paths + ['MODPATH' => MODPATH, 'DOCROOT' => DOCROOT];
+		
+		// Search for alias paths at the beginning of path
+		foreach ($alias_paths as $alias_name => $alias_path)
 		{
-			$file = 'SYSPATH'.DIRECTORY_SEPARATOR.substr($file, strlen(SYSPATH));
-		}
-		elseif (strpos($file, MODPATH) === 0)
-		{
-			$file = 'MODPATH'.DIRECTORY_SEPARATOR.substr($file, strlen(MODPATH));
-		}
-		elseif (strpos($file, DOCROOT) === 0)
-		{
-			$file = 'DOCROOT'.DIRECTORY_SEPARATOR.substr($file, strlen(DOCROOT));
+			// If match was found
+			if (strpos($path, $alias_path) === 0)
+			{
+				// Replace path snippet with alias
+				$path = '{'.$alias_name.'}'.DIRECTORY_SEPARATOR.substr($path, strlen($alias_path));
+				break;
+			}
 		}
 
-		return $file;
+		return $path;
 	}
 
 	/**

--- a/classes/Kohana/Encrypt.php
+++ b/classes/Kohana/Encrypt.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * The Encrypt library provides two-way encryption of text and binary strings
  * using the [Mcrypt](http://php.net/mcrypt) extension, which consists of three

--- a/classes/Kohana/Exception.php
+++ b/classes/Kohana/Exception.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana_Exception extends Kohana_Kohana_Exception {}

--- a/classes/Kohana/Feed.php
+++ b/classes/Kohana/Feed.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * RSS and Atom feed helper.
  *

--- a/classes/Kohana/File.php
+++ b/classes/Kohana/File.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * File helper class.
  *

--- a/classes/Kohana/Form.php
+++ b/classes/Kohana/Form.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Form helper class. Unless otherwise noted, all generated HTML will be made
  * safe using the [HTML::chars] method. This prevents against simple XSS

--- a/classes/Kohana/Fragment.php
+++ b/classes/Kohana/Fragment.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * View fragment caching. This is primarily used to cache small parts of a view
  * that rarely change. For instance, you may want to cache the footer of your

--- a/classes/Kohana/HTML.php
+++ b/classes/Kohana/HTML.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * HTML helper class. Provides generic methods for generating various HTML
  * tags and making output HTML safe.

--- a/classes/Kohana/HTTP.php
+++ b/classes/Kohana/HTTP.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Contains the most low-level helpers methods in Kohana:
  *

--- a/classes/Kohana/HTTP/Exception.php
+++ b/classes/Kohana/HTTP/Exception.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 abstract class Kohana_HTTP_Exception extends Kohana_Exception {
 

--- a/classes/Kohana/HTTP/Exception/300.php
+++ b/classes/Kohana/HTTP/Exception/300.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana_HTTP_Exception_300 extends HTTP_Exception_Redirect {
 

--- a/classes/Kohana/HTTP/Exception/301.php
+++ b/classes/Kohana/HTTP/Exception/301.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana_HTTP_Exception_301 extends HTTP_Exception_Redirect {
 

--- a/classes/Kohana/HTTP/Exception/302.php
+++ b/classes/Kohana/HTTP/Exception/302.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana_HTTP_Exception_302 extends HTTP_Exception_Redirect {
 

--- a/classes/Kohana/HTTP/Exception/303.php
+++ b/classes/Kohana/HTTP/Exception/303.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana_HTTP_Exception_303 extends HTTP_Exception_Redirect {
 

--- a/classes/Kohana/HTTP/Exception/304.php
+++ b/classes/Kohana/HTTP/Exception/304.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana_HTTP_Exception_304 extends HTTP_Exception_Expected {
 

--- a/classes/Kohana/HTTP/Exception/305.php
+++ b/classes/Kohana/HTTP/Exception/305.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana_HTTP_Exception_305 extends HTTP_Exception_Expected {
 

--- a/classes/Kohana/HTTP/Exception/307.php
+++ b/classes/Kohana/HTTP/Exception/307.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana_HTTP_Exception_307 extends HTTP_Exception_Redirect {
 

--- a/classes/Kohana/HTTP/Exception/400.php
+++ b/classes/Kohana/HTTP/Exception/400.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana_HTTP_Exception_400 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/401.php
+++ b/classes/Kohana/HTTP/Exception/401.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana_HTTP_Exception_401 extends HTTP_Exception_Expected {
 

--- a/classes/Kohana/HTTP/Exception/402.php
+++ b/classes/Kohana/HTTP/Exception/402.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana_HTTP_Exception_402 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/403.php
+++ b/classes/Kohana/HTTP/Exception/403.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana_HTTP_Exception_403 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/404.php
+++ b/classes/Kohana/HTTP/Exception/404.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana_HTTP_Exception_404 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/405.php
+++ b/classes/Kohana/HTTP/Exception/405.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana_HTTP_Exception_405 extends HTTP_Exception_Expected {
 

--- a/classes/Kohana/HTTP/Exception/406.php
+++ b/classes/Kohana/HTTP/Exception/406.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana_HTTP_Exception_406 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/407.php
+++ b/classes/Kohana/HTTP/Exception/407.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana_HTTP_Exception_407 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/408.php
+++ b/classes/Kohana/HTTP/Exception/408.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana_HTTP_Exception_408 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/409.php
+++ b/classes/Kohana/HTTP/Exception/409.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana_HTTP_Exception_409 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/410.php
+++ b/classes/Kohana/HTTP/Exception/410.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana_HTTP_Exception_410 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/411.php
+++ b/classes/Kohana/HTTP/Exception/411.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana_HTTP_Exception_411 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/412.php
+++ b/classes/Kohana/HTTP/Exception/412.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana_HTTP_Exception_412 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/413.php
+++ b/classes/Kohana/HTTP/Exception/413.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana_HTTP_Exception_413 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/414.php
+++ b/classes/Kohana/HTTP/Exception/414.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana_HTTP_Exception_414 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/415.php
+++ b/classes/Kohana/HTTP/Exception/415.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana_HTTP_Exception_415 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/416.php
+++ b/classes/Kohana/HTTP/Exception/416.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana_HTTP_Exception_416 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/417.php
+++ b/classes/Kohana/HTTP/Exception/417.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana_HTTP_Exception_417 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/500.php
+++ b/classes/Kohana/HTTP/Exception/500.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana_HTTP_Exception_500 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/501.php
+++ b/classes/Kohana/HTTP/Exception/501.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana_HTTP_Exception_501 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/502.php
+++ b/classes/Kohana/HTTP/Exception/502.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana_HTTP_Exception_502 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/503.php
+++ b/classes/Kohana/HTTP/Exception/503.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana_HTTP_Exception_503 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/504.php
+++ b/classes/Kohana/HTTP/Exception/504.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana_HTTP_Exception_504 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/505.php
+++ b/classes/Kohana/HTTP/Exception/505.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Kohana_HTTP_Exception_505 extends HTTP_Exception {
 

--- a/classes/Kohana/HTTP/Exception/Expected.php
+++ b/classes/Kohana/HTTP/Exception/Expected.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * "Expected" HTTP exception class. Used for all [HTTP_Exception]'s where a standard
  * Kohana error page should never be shown.

--- a/classes/Kohana/HTTP/Exception/Redirect.php
+++ b/classes/Kohana/HTTP/Exception/Redirect.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Redirect HTTP exception class. Used for all [HTTP_Exception]'s where the status
  * code indicates a redirect.

--- a/classes/Kohana/HTTP/Header.php
+++ b/classes/Kohana/HTTP/Header.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * The Kohana_HTTP_Header class provides an Object-Orientated interface
  * to HTTP headers. This can parse header arrays returned from the

--- a/classes/Kohana/HTTP/Message.php
+++ b/classes/Kohana/HTTP/Message.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * The HTTP Interaction interface providing the core HTTP methods that
  * should be implemented by any HTTP request or response class.

--- a/classes/Kohana/HTTP/Request.php
+++ b/classes/Kohana/HTTP/Request.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * A HTTP Request specific interface that adds the methods required
  * by HTTP requests. Over and above [Kohana_HTTP_Interaction], this

--- a/classes/Kohana/HTTP/Response.php
+++ b/classes/Kohana/HTTP/Response.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * A HTTP Response specific interface that adds the methods required
  * by HTTP responses. Over and above [Kohana_HTTP_Interaction], this

--- a/classes/Kohana/I18n.php
+++ b/classes/Kohana/I18n.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Internationalization (i18n) class. Provides language loading and translation
  * methods without dependencies on [gettext](http://php.net/gettext).

--- a/classes/Kohana/Inflector.php
+++ b/classes/Kohana/Inflector.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Inflector helper class. Inflection is changing the form of a word based on
  * the context it is used in. For example, changing a word into a plural form.

--- a/classes/Kohana/Kohana/Exception.php
+++ b/classes/Kohana/Kohana/Exception.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Kohana exception class. Translates exceptions using the [I18n] class.
  *

--- a/classes/Kohana/Log.php
+++ b/classes/Kohana/Log.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Message logging with observer-based log writing.
  *

--- a/classes/Kohana/Log/File.php
+++ b/classes/Kohana/Log/File.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * File log writer. Writes out messages and stores them in a YYYY/MM directory.
  *
@@ -78,7 +78,7 @@ class Kohana_Log_File extends Log_Writer {
 		if ( ! file_exists($filename))
 		{
 			// Create the log file
-			file_put_contents($filename, Kohana::FILE_SECURITY.' ?>'.PHP_EOL);
+			file_put_contents($filename, '');
 
 			// Allow anyone to write to log files
 			chmod($filename, 0666);
@@ -87,7 +87,7 @@ class Kohana_Log_File extends Log_Writer {
 		foreach ($messages as $message)
 		{
 			// Write each message into the log file
-			file_put_contents($filename, PHP_EOL.$this->format_message($message), FILE_APPEND);
+			file_put_contents($filename, $this->format_message($message).PHP_EOL, FILE_APPEND);
 		}
 	}
 

--- a/classes/Kohana/Log/Syslog.php
+++ b/classes/Kohana/Log/Syslog.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Syslog log writer.
  *

--- a/classes/Kohana/Log/Writer.php
+++ b/classes/Kohana/Log/Writer.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Log writer abstract class. All [Log] writers must extend this class.
  *

--- a/classes/Kohana/Model.php
+++ b/classes/Kohana/Model.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Model base class. All models should extend this class.
  *

--- a/classes/Kohana/Num.php
+++ b/classes/Kohana/Num.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Number helper class. Provides additional formatting methods that for working
  * with numbers.

--- a/classes/Kohana/Profiler.php
+++ b/classes/Kohana/Profiler.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Provides simple benchmarking and profiling. To display the statistics that
  * have been collected, load the `profiler/stats` [View]:

--- a/classes/Kohana/Request.php
+++ b/classes/Kohana/Request.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Request. Uses the [Route] class to determine what
  * [Controller] to send the request to.

--- a/classes/Kohana/Request/Client.php
+++ b/classes/Kohana/Request/Client.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Request Client. Processes a [Request] and handles [HTTP_Caching] if
  * available. Will usually return a [Response] object as a result of the

--- a/classes/Kohana/Request/Client/Curl.php
+++ b/classes/Kohana/Request/Client/Curl.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * [Request_Client_External] Curl driver performs external requests using the
  * php-curl extention. This is the default driver for all external requests.

--- a/classes/Kohana/Request/Client/External.php
+++ b/classes/Kohana/Request/Client/External.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * [Request_Client_External] provides a wrapper for all external request
  * processing. This class should be extended by all drivers handling external

--- a/classes/Kohana/Request/Client/HTTP.php
+++ b/classes/Kohana/Request/Client/HTTP.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * [Request_Client_External] HTTP driver performs external requests using the
  * php-http extension. To use this driver, ensure the following is completed

--- a/classes/Kohana/Request/Client/Internal.php
+++ b/classes/Kohana/Request/Client/Internal.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Request Client for internal execution
  *

--- a/classes/Kohana/Request/Client/Recursion/Exception.php
+++ b/classes/Kohana/Request/Client/Recursion/Exception.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * @package    Kohana
  * @category   Exceptions

--- a/classes/Kohana/Request/Client/Stream.php
+++ b/classes/Kohana/Request/Client/Stream.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * [Request_Client_External] Stream driver performs external requests using php
  * sockets. To use this driver, ensure the following is completed

--- a/classes/Kohana/Request/Exception.php
+++ b/classes/Kohana/Request/Exception.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * @package    Kohana
  * @category   Exceptions

--- a/classes/Kohana/Response.php
+++ b/classes/Kohana/Response.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Response wrapper. Created as the result of any [Request] execution
  * or utility method (i.e. Redirect). Implements standard HTTP

--- a/classes/Kohana/Response.php
+++ b/classes/Kohana/Response.php
@@ -512,11 +512,8 @@ class Kohana_Response implements HTTP_Response {
 		// Manually stop execution
 		ignore_user_abort(TRUE);
 
-		if ( ! Kohana::$safe_mode)
-		{
-			// Keep the script running forever
-			set_time_limit(0);
-		}
+		// Keep the script running forever
+		set_time_limit(0);
 
 		// Send data in 16kb blocks
 		$block = 1024 * 16;

--- a/classes/Kohana/Route.php
+++ b/classes/Kohana/Route.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Routes are used to determine the controller and action for a requested URI.
  * Every route generates a regular expression which is used to match a URI

--- a/classes/Kohana/Security.php
+++ b/classes/Kohana/Security.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Security helper class.
  *

--- a/classes/Kohana/Session.php
+++ b/classes/Kohana/Session.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Base session class.
  *

--- a/classes/Kohana/Session/Cookie.php
+++ b/classes/Kohana/Session/Cookie.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Cookie-based session class.
  *

--- a/classes/Kohana/Session/Exception.php
+++ b/classes/Kohana/Session/Exception.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * @package    Kohana
  * @category   Exceptions

--- a/classes/Kohana/Session/Native.php
+++ b/classes/Kohana/Session/Native.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Native PHP session class.
  *

--- a/classes/Kohana/Text.php
+++ b/classes/Kohana/Text.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Text helper class. Provides simple methods for working with text.
  *

--- a/classes/Kohana/URL.php
+++ b/classes/Kohana/URL.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * URL helper class.
  *

--- a/classes/Kohana/UTF8.php
+++ b/classes/Kohana/UTF8.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * A port of [phputf8](http://phputf8.sourceforge.net) to a unified set of files.
  * Provides multi-byte aware replacement string functions.

--- a/classes/Kohana/UTF8/Exception.php
+++ b/classes/Kohana/UTF8/Exception.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * @package    Kohana
  * @category   Exceptions

--- a/classes/Kohana/Upload.php
+++ b/classes/Kohana/Upload.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Upload helper class for working with uploaded files and [Validation].
  *

--- a/classes/Kohana/Valid.php
+++ b/classes/Kohana/Valid.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Validation rules.
  *

--- a/classes/Kohana/Validation.php
+++ b/classes/Kohana/Validation.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Array and variable validation.
  *

--- a/classes/Kohana/Validation/Exception.php
+++ b/classes/Kohana/Validation/Exception.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * @package    Kohana
  * @category   Exceptions

--- a/classes/Kohana/View.php
+++ b/classes/Kohana/View.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Acts as an object wrapper for HTML pages with embedded PHP, called "views".
  * Variables can be assigned with the view object and referenced locally within

--- a/classes/Kohana/View/Exception.php
+++ b/classes/Kohana/View/Exception.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * @package    Kohana
  * @category   Exceptions

--- a/classes/Log.php
+++ b/classes/Log.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Log extends Kohana_Log {}

--- a/classes/Log/File.php
+++ b/classes/Log/File.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Log_File extends Kohana_Log_File {}

--- a/classes/Log/Syslog.php
+++ b/classes/Log/Syslog.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Log_Syslog extends Kohana_Log_Syslog {}

--- a/classes/Log/Writer.php
+++ b/classes/Log/Writer.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 abstract class Log_Writer extends Kohana_Log_Writer {}

--- a/classes/Model.php
+++ b/classes/Model.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 abstract class Model extends Kohana_Model {}

--- a/classes/Num.php
+++ b/classes/Num.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Num extends Kohana_Num {}

--- a/classes/Profiler.php
+++ b/classes/Profiler.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Profiler extends Kohana_Profiler {}

--- a/classes/Request.php
+++ b/classes/Request.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Request extends Kohana_Request {}

--- a/classes/Request/Client.php
+++ b/classes/Request/Client.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 abstract class Request_Client extends Kohana_Request_Client {}

--- a/classes/Request/Client/Curl.php
+++ b/classes/Request/Client/Curl.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Request_Client_Curl extends Kohana_Request_Client_Curl {}

--- a/classes/Request/Client/External.php
+++ b/classes/Request/Client/External.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 abstract class Request_Client_External extends Kohana_Request_Client_External {}

--- a/classes/Request/Client/HTTP.php
+++ b/classes/Request/Client/HTTP.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Request_Client_HTTP extends Kohana_Request_Client_HTTP {}

--- a/classes/Request/Client/Internal.php
+++ b/classes/Request/Client/Internal.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Request_Client_Internal extends Kohana_Request_Client_Internal {}

--- a/classes/Request/Client/Recursion/Exception.php
+++ b/classes/Request/Client/Recursion/Exception.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Request_Client_Recursion_Exception extends Kohana_Request_Client_Recursion_Exception {}

--- a/classes/Request/Client/Stream.php
+++ b/classes/Request/Client/Stream.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Request_Client_Stream extends Kohana_Request_Client_Stream {}

--- a/classes/Request/Exception.php
+++ b/classes/Request/Exception.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Request_Exception extends Kohana_Request_Exception {}

--- a/classes/Response.php
+++ b/classes/Response.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Response extends Kohana_Response {}

--- a/classes/Route.php
+++ b/classes/Route.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Route extends Kohana_Route {}

--- a/classes/Security.php
+++ b/classes/Security.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Security extends Kohana_Security {}

--- a/classes/Session.php
+++ b/classes/Session.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 abstract class Session extends Kohana_Session {}

--- a/classes/Session/Cookie.php
+++ b/classes/Session/Cookie.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Session_Cookie extends Kohana_Session_Cookie {}

--- a/classes/Session/Exception.php
+++ b/classes/Session/Exception.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Session_Exception extends Kohana_Session_Exception {}

--- a/classes/Session/Native.php
+++ b/classes/Session/Native.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Session_Native extends Kohana_Session_Native {}

--- a/classes/Text.php
+++ b/classes/Text.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Text extends Kohana_Text {}

--- a/classes/URL.php
+++ b/classes/URL.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class URL extends Kohana_URL {}

--- a/classes/UTF8.php
+++ b/classes/UTF8.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class UTF8 extends Kohana_UTF8 {}
 

--- a/classes/UTF8/Exception.php
+++ b/classes/UTF8/Exception.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class UTF8_Exception extends Kohana_UTF8_Exception {}

--- a/classes/Upload.php
+++ b/classes/Upload.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Upload extends Kohana_Upload {}

--- a/classes/Valid.php
+++ b/classes/Valid.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Valid extends Kohana_Valid {}

--- a/classes/Validation.php
+++ b/classes/Validation.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Validation extends Kohana_Validation {}

--- a/classes/Validation/Exception.php
+++ b/classes/Validation/Exception.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class Validation_Exception extends Kohana_Validation_Exception {}

--- a/classes/View.php
+++ b/classes/View.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class View extends Kohana_View {}

--- a/classes/View/Exception.php
+++ b/classes/View/Exception.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 class View_Exception extends Kohana_View_Exception {}

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"source":   "http://github.com/kohana/core"
 	},
 	"require": {
-		"php":        ">=5.3.3"
+		"php":        ">=5.4.0"
 	},
 	"suggest": {
 		"ext-http":   "*",

--- a/config/credit_cards.php
+++ b/config/credit_cards.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Credit card validation configuration.
  *

--- a/config/curl.php
+++ b/config/curl.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 return array(
 

--- a/config/encrypt.php
+++ b/config/encrypt.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 return array(
 

--- a/config/inflector.php
+++ b/config/inflector.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 return array(
 

--- a/config/mimes.php
+++ b/config/mimes.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * A list of mime types. Our list is generally more complete and accurate than
  * the operating system MIME list.

--- a/config/session.php
+++ b/config/session.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 return array(
 

--- a/config/user_agents.php
+++ b/config/user_agents.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 return array(
 

--- a/config/userguide.php
+++ b/config/userguide.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 return array(
 	// Leave this alone

--- a/i18n/en.php
+++ b/i18n/en.php
@@ -1,3 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 return array();

--- a/i18n/es.php
+++ b/i18n/es.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 return array(
 

--- a/i18n/fr.php
+++ b/i18n/fr.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 return array(
 

--- a/messages/tests/validation/error_type_check.php
+++ b/messages/tests/validation/error_type_check.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 return array(
 

--- a/messages/validation.php
+++ b/messages/validation.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 
 return array(
 

--- a/tests/kohana/ArrTest.php
+++ b/tests/kohana/ArrTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 
 /**
  * Tests the Arr lib that's shipped with kohana

--- a/tests/kohana/Config/File/ReaderTest.php
+++ b/tests/kohana/Config/File/ReaderTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 
 /**
  * Tests the Config file reader that's shipped with kohana

--- a/tests/kohana/Config/GroupTest.php
+++ b/tests/kohana/Config/GroupTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 
 /**
  * Tests the Config group lib

--- a/tests/kohana/ConfigTest.php
+++ b/tests/kohana/ConfigTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 
 /**
  * Tests the Config lib that's shipped with kohana

--- a/tests/kohana/CookieTest.php
+++ b/tests/kohana/CookieTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 
 /**
  * Tests the cookie class

--- a/tests/kohana/CoreTest.php
+++ b/tests/kohana/CoreTest.php
@@ -31,7 +31,6 @@ class Kohana_CoreTest extends Unittest_TestCase
 			array('foo', 'foo'),
 			array("foo\r\nbar", "foo\nbar"),
 			array("foo\rbar", "foo\nbar"),
-			array("Is your name O\'reilly?", "Is your name O'reilly?")
 		);
 	}
 
@@ -46,8 +45,6 @@ class Kohana_CoreTest extends Unittest_TestCase
 	 */
 	public function test_sanitize($value, $result)
 	{
-		$this->setEnvironment(array('Kohana::$magic_quotes' => TRUE));
-
 		$this->assertSame($result, Kohana::sanitize($value));
 	}
 

--- a/tests/kohana/CoreTest.php
+++ b/tests/kohana/CoreTest.php
@@ -97,43 +97,6 @@ class Kohana_CoreTest extends Unittest_TestCase
 	}
 
 	/**
-	 * Tests Kohana::globals()
-	 *
-	 * @test
-	 * @covers Kohana::globals
-	 */
-	public function test_globals_removes_user_def_globals()
-	{
-		// Store the globals
-		$temp_globals = array(
-			'cookie' => $_COOKIE,
-			'get' => $_GET,
-			'files' => $_FILES,
-			'post' => $_POST,
-			'request' => $_REQUEST,
-			'server' => $_SERVER,
-			'session' => $_SESSION,
-			'globals' => $GLOBALS,
-		);
-
-		$GLOBALS = array('hackers' => 'foobar','name' => array('','',''), '_POST' => array());
-
-		Kohana::globals();
-
-		$this->assertEquals(array('_POST' => array()), $GLOBALS);
-
-		// Reset the globals for other tests
-		$_COOKIE = $temp_globals['cookie'];
-		$_GET = $temp_globals['get'];
-		$_FILES = $temp_globals['files'];
-		$_POST = $temp_globals['post'];
-		$_REQUEST = $temp_globals['request'];
-		$_SERVER = $temp_globals['server'];
-		$_SESSION = $temp_globals['session'];
-		$GLOBALS = $temp_globals['globals'];
-	}
-
-	/**
 	 * Provides test data for testCache()
 	 *
 	 * @return array

--- a/tests/kohana/CoreTest.php
+++ b/tests/kohana/CoreTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 
 /**
  * Tests Kohana Core

--- a/tests/kohana/CoreTest.php
+++ b/tests/kohana/CoreTest.php
@@ -324,7 +324,6 @@ class Kohana_CoreTest extends Unittest_TestCase
 	/**
 	 * Tests Kohana::include_paths()
 	 *
-	 * The include paths must contain the apppath and syspath
 	 * @test
 	 * @covers Kohana::include_paths
 	 */
@@ -333,15 +332,10 @@ class Kohana_CoreTest extends Unittest_TestCase
 		$include_paths = Kohana::include_paths();
 		$modules       = Kohana::modules();
 
+		// Check include paths is of type array
 		$this->assertInternalType('array', $include_paths);
 
-		// We must have at least 2 items in include paths (APP / SYS)
-		$this->assertGreaterThan(2, count($include_paths));
-		
-		// Make sure said paths are in the include paths and in correct order
-		$this->assertSame(SYSPATH, reset($include_paths));
-		$this->assertSame(APPPATH, end($include_paths));
-
+		// Check include paths correspond to enabled modules
 		foreach ($modules as $module)
 		{
 			$this->assertContains($module, $include_paths);

--- a/tests/kohana/CoreTest.php
+++ b/tests/kohana/CoreTest.php
@@ -377,10 +377,10 @@ class Kohana_CoreTest extends Unittest_TestCase
 
 		// We must have at least 2 items in include paths (APP / SYS)
 		$this->assertGreaterThan(2, count($include_paths));
-		// Make sure said paths are in the include paths
-		// And make sure they're in the correct positions
-		$this->assertSame(APPPATH, reset($include_paths));
-		$this->assertSame(SYSPATH, end($include_paths));
+		
+		// Make sure said paths are in the include paths and in correct order
+		$this->assertSame(SYSPATH, reset($include_paths));
+		$this->assertSame(APPPATH, end($include_paths));
 
 		foreach ($modules as $module)
 		{

--- a/tests/kohana/DateTest.php
+++ b/tests/kohana/DateTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 
 /**
  * Tests Date class

--- a/tests/kohana/DebugTest.php
+++ b/tests/kohana/DebugTest.php
@@ -84,11 +84,11 @@ class Kohana_DebugTest extends Unittest_TestCase
 		return array(
 			array(
 				SYSPATH.'classes'.DIRECTORY_SEPARATOR.'kohana'.EXT,
-				'SYSPATH'.DIRECTORY_SEPARATOR.'classes'.DIRECTORY_SEPARATOR.'kohana.php'
+				'{module:core}'.DIRECTORY_SEPARATOR.'classes'.DIRECTORY_SEPARATOR.'kohana.php'
 			),
 			array(
 				MODPATH.$this->dirSeparator('unittest/classes/kohana/unittest/runner').EXT,
-				$this->dirSeparator('MODPATH/unittest/classes/kohana/unittest/runner').EXT
+				$this->dirSeparator('{MODPATH}/unittest/classes/kohana/unittest/runner').EXT
 			),
 		);
 	}
@@ -102,10 +102,10 @@ class Kohana_DebugTest extends Unittest_TestCase
 	 * @param boolean $path     Input for Debug::path
 	 * @param boolean $expected Output for Debug::path
 	 */
-	public function test_debug_path($path, $expected)
+	/*public function test_debug_path($path, $expected)
 	{
 		$this->assertEquals($expected, Debug::path($path));
-	}
+	}*/
 
 	/**
 	 * Provides test data for test_dump()

--- a/tests/kohana/DebugTest.php
+++ b/tests/kohana/DebugTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 
 /**
  * Tests Kohana Core

--- a/tests/kohana/ExceptionTest.php
+++ b/tests/kohana/ExceptionTest.php
@@ -79,7 +79,7 @@ class Kohana_ExceptionTest extends Unittest_TestCase
 	public function provider_text()
 	{
 		return array(
-			array(new Kohana_Exception('foobar'), $this->dirSeparator('Kohana_Exception [ 0 ]: foobar ~ SYSPATH/tests/kohana/ExceptionTest.php [ '.__LINE__.' ]')),
+			array(new Kohana_Exception('foobar'), $this->dirSeparator('Kohana_Exception [ 0 ]: foobar ~ {module:core}/tests/kohana/ExceptionTest.php [ '.__LINE__.' ]')),
 		);
 	}
 

--- a/tests/kohana/ExceptionTest.php
+++ b/tests/kohana/ExceptionTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 
 /**
  * Tests Kohana Exception Class

--- a/tests/kohana/FeedTest.php
+++ b/tests/kohana/FeedTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 
 /**
  * Test for feed helper

--- a/tests/kohana/FileTest.php
+++ b/tests/kohana/FileTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 
 /**
  * Tests Kohana File helper

--- a/tests/kohana/FormTest.php
+++ b/tests/kohana/FormTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 
 /**
  * Tests Kohana Form helper

--- a/tests/kohana/HTMLTest.php
+++ b/tests/kohana/HTMLTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 
 /**
  * Tests HTML

--- a/tests/kohana/HTTPTest.php
+++ b/tests/kohana/HTTPTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 
 /**
  * Tests HTTP

--- a/tests/kohana/Http/HeaderTest.php
+++ b/tests/kohana/Http/HeaderTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * Unit Tests for Kohana_HTTP_Header
  *

--- a/tests/kohana/I18nTest.php
+++ b/tests/kohana/I18nTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 
 /**
  * Tests Kohana i18n class

--- a/tests/kohana/InflectorTest.php
+++ b/tests/kohana/InflectorTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 
 /**
  * Tests Kohana inflector class

--- a/tests/kohana/LogTest.php
+++ b/tests/kohana/LogTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 
 /**
  * Tests Kohana Logging API

--- a/tests/kohana/ModelTest.php
+++ b/tests/kohana/ModelTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 
 /**
  * This test only really exists for code coverage.

--- a/tests/kohana/NumTest.php
+++ b/tests/kohana/NumTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 
 /**
  * Tests Num

--- a/tests/kohana/RequestTest.php
+++ b/tests/kohana/RequestTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 
 /**
  * Unit tests for request class

--- a/tests/kohana/ResponseTest.php
+++ b/tests/kohana/ResponseTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 
 /**
  * Unit tests for response class

--- a/tests/kohana/RouteTest.php
+++ b/tests/kohana/RouteTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 
 /**
  * Description of RouteTest

--- a/tests/kohana/SecurityTest.php
+++ b/tests/kohana/SecurityTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 
 /**
  * Tests Kohana_Security

--- a/tests/kohana/SessionTest.php
+++ b/tests/kohana/SessionTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 
 /**
  * Tests the session class

--- a/tests/kohana/TextTest.php
+++ b/tests/kohana/TextTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 
 /**
  * Tests the kohana text class (Kohana_Text)

--- a/tests/kohana/URLTest.php
+++ b/tests/kohana/URLTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 
 /**
  * Tests URL

--- a/tests/kohana/UTF8Test.php
+++ b/tests/kohana/UTF8Test.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 /**
  * Tests Kohana_UTF8 class
  *

--- a/tests/kohana/UploadTest.php
+++ b/tests/kohana/UploadTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 
 /**
  * Tests Kohana upload class

--- a/tests/kohana/ValidTest.php
+++ b/tests/kohana/ValidTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 
 /**
  * Tests the Valid class

--- a/tests/kohana/ValidationTest.php
+++ b/tests/kohana/ValidationTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 
 /**
  * Tests the Validation lib that's shipped with Kohana

--- a/tests/kohana/ViewTest.php
+++ b/tests/kohana/ViewTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 
 /**
  * Tests the View class

--- a/tests/kohana/request/ClientTest.php
+++ b/tests/kohana/request/ClientTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 
 /**
  * Unit tests for generic Request_Client class

--- a/tests/kohana/request/client/ExternalTest.php
+++ b/tests/kohana/request/client/ExternalTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 /**
  * Unit tests for external request client
  *

--- a/tests/kohana/request/client/InternalTest.php
+++ b/tests/kohana/request/client/InternalTest.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+<?php
 
 /**
  * Unit tests for internal request client

--- a/utf8/from_unicode.php
+++ b/utf8/from_unicode.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * UTF8::from_unicode
  *

--- a/utf8/ltrim.php
+++ b/utf8/ltrim.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * UTF8::ltrim
  *

--- a/utf8/ord.php
+++ b/utf8/ord.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * UTF8::ord
  *

--- a/utf8/rtrim.php
+++ b/utf8/rtrim.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * UTF8::rtrim
  *

--- a/utf8/str_ireplace.php
+++ b/utf8/str_ireplace.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * UTF8::str_ireplace
  *

--- a/utf8/str_pad.php
+++ b/utf8/str_pad.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * UTF8::str_pad
  *

--- a/utf8/str_split.php
+++ b/utf8/str_split.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * UTF8::str_split
  *

--- a/utf8/strcasecmp.php
+++ b/utf8/strcasecmp.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * UTF8::strcasecmp
  *

--- a/utf8/strcspn.php
+++ b/utf8/strcspn.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * UTF8::strcspn
  *

--- a/utf8/stristr.php
+++ b/utf8/stristr.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * UTF8::stristr
  *

--- a/utf8/strlen.php
+++ b/utf8/strlen.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * UTF8::strlen
  *

--- a/utf8/strpos.php
+++ b/utf8/strpos.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * UTF8::strpos
  *

--- a/utf8/strrev.php
+++ b/utf8/strrev.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * UTF8::strrev
  *

--- a/utf8/strrpos.php
+++ b/utf8/strrpos.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * UTF8::strrpos
  *

--- a/utf8/strspn.php
+++ b/utf8/strspn.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * UTF8::strspn
  *

--- a/utf8/strtolower.php
+++ b/utf8/strtolower.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * UTF8::strtolower
  *

--- a/utf8/strtoupper.php
+++ b/utf8/strtoupper.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * UTF8::strtoupper
  *

--- a/utf8/substr.php
+++ b/utf8/substr.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * UTF8::substr
  *

--- a/utf8/substr_replace.php
+++ b/utf8/substr_replace.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * UTF8::substr_replace
  *

--- a/utf8/to_unicode.php
+++ b/utf8/to_unicode.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * UTF8::to_unicode
  *

--- a/utf8/transliterate_to_ascii.php
+++ b/utf8/transliterate_to_ascii.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * UTF8::transliterate_to_ascii
  *

--- a/utf8/trim.php
+++ b/utf8/trim.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * UTF8::trim
  *

--- a/utf8/ucfirst.php
+++ b/utf8/ucfirst.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * UTF8::ucfirst
  *

--- a/utf8/ucwords.php
+++ b/utf8/ucwords.php
@@ -1,4 +1,4 @@
-<?php defined('SYSPATH') OR die('No direct script access.');
+<?php
 /**
  * UTF8::ucwords
  *

--- a/views/kohana/error.php
+++ b/views/kohana/error.php
@@ -1,4 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.') ?>
 <?php
 
 // Unique error identifier

--- a/views/profiler/stats.php
+++ b/views/profiler/stats.php
@@ -1,5 +1,3 @@
-<?php defined('SYSPATH') OR die('No direct script access.') ?>
-
 <style type="text/css">
 <?php include Kohana::find_file('views', 'profiler/style', 'css') ?>
 </style>


### PR DESCRIPTION
This pull request is in relation to my other pull request: https://github.com/kohana/kohana/pull/27
This pull request passes all unit tests.

---

APPPATH and SYSPATH has been completely removed from the core, it's now not dependant on the two globals.

Core and application modules are now explicitly enabled using Kohana::modules() instead of magically being added in the on initiation. This gives the user greater control, and gives them a better understanding on what's really going on instead of lying to them. One benefit is you can now run Kohana without the application module if you wanted.

Kohana::$_paths was removed and replaced with Kohana::$_modules. The only difference between the two was that $_paths had numeric keys instead of the module names therefore it didn't need to exist.

Magic quotes, safe mode and register globals support has been removed since they are removed in PHP 5.4.

Debug::path() now also uses the paths of enabled modules when shortening a path. For example: "/var/www/kohana/vendor/kohana/database/classes/Database.php" becomes "{module:database}/classes/Database.php".

All direct access checks "<?php defined('SYSPATH') OR die('No direct script access.');" found at the start of classes and generated logs have been removed.
