### PR TITLE
feature: change kohana_find priority

### DIFF
--- a/classes/Kohana/Core.php
+++ b/classes/Kohana/Core.php
@@ -679,6 +679,12 @@ class Kohana_Core {
 			$benchmark = Profiler::start('Kohana', __FUNCTION__);
 		}
 
+		$paths = Kohana::$_paths;
+	        $paths = array_slice(Kohana::$_paths, 1, -1);
+	        $paths = array_reverse($paths);
+	        array_unshift($paths, APPPATH);
+	        $paths[] = SYSPATH;
+
 		if ($array OR $dir === 'config' OR $dir === 'i18n' OR $dir === 'messages')
 		{
 			// Include paths must be searched in reverse
@@ -701,7 +707,7 @@ class Kohana_Core {
 			// The file has not been found yet
 			$found = FALSE;
 
-			foreach (Kohana::$_paths as $dir)
+			foreach ($paths as $dir)
 			{
 				if (is_file($dir.$path))
 				{


### PR DESCRIPTION
Kohana::$_paths not correct ordered by priority and Kohana::find_file returns wrong files

Problem:

Step 1) Init modules

```
Kohana::modules(array(
...
'database' => MODPATH.'database', // PRIOR 0
'module_core' => MODPATH.'module_core', PRIOR 1
'module_app' => MODPATH.'module_app', // PRIOR 2, module_app dependense from module_core
...
));
```

P.S. module_core != SYSPATH, module_app != APPPATH

Structure of files:

```
module_core/
-----views
----------template.php
module_app/
-----views
----------template.php // extend view file of module_core/views/template.php
```

Step 2: Get view

```
Kohana::find_file('views', 'template');
```

Result:

```
module_core/views/template.php
```

But we need module_app/views/template.php

Why we get this result?

Step 3: Algoritm find view files

```
echo Kohana::$_paths;

// Result
```

APPPATH,
module_core,
module_app
SYSPATH

```

Step 4: Show order for view location (order than now using in core (K3.3.2)).
```

APPPATH, // 1 
...,
database, // 2
module_core, // 3
module_app // 4
..., 
SYSPATH // 5

```

Step 5: The order what we need for get correct view (current priority)
```

APPPATH, // 1
...,
database, // 4
module_core, // 3
module_app // 2
..., 
SYSPATH // 5

```
Am I wrong?


```
