### PR TITLE
don't empty the error message with special encode

### DIFF
--- a/views/kohana/error.php
+++ b/views/kohana/error.php
@@ -49,7 +49,7 @@ function koggle(elem)
 }
 </script>
 <div id="kohana_error">
-	<h1><span class="type"><?php echo $class ?> [ <?php echo $code ?> ]:</span> <span class="message"><?php echo htmlspecialchars( (string) $message, ENT_QUOTES, Kohana::$charset, TRUE); ?></span></h1>
+	<h1><span class="type"><?php echo $class ?> [ <?php echo $code ?> ]:</span> <span class="message"><?php echo htmlspecialchars( (string) $message, ENT_QUOTES | ENT_IGNORE, Kohana::$charset, TRUE); ?></span></h1>
 	<div id="<?php echo $error_id ?>" class="content">
 		<p><span class="file"><?php echo Debug::path($file) ?> [ <?php echo $line ?> ]</span></p>
 		<?php echo Debug::source($file, $line) ?>


### PR DESCRIPTION
refer from the manual: [htmlspecialchars](http://cn2.php.net/htmlspecialchars#refsect1-function.htmlspecialchars-returnvalues)

> If the input string contains an invalid code unit sequence within the given encoding an empty string will be returned
