### PR TITLE
Fixed method type from xdebug_get_function_stack()

### DIFF
--- a/classes/Kohana/Kohana/Exception.php
+++ b/classes/Kohana/Kohana/Exception.php
@@ -216,6 +216,14 @@ class Kohana_Kohana_Exception extends Exception {
 						{
 							$frame['type'] = '??';
 						}
+						elseif ($frame['type'] == 'static')
+						{
+							$frame['type'] = '::';
+						}
+						elseif ($frame['type'] == 'dynamic')
+						{
+							$frame['type'] = '->';
+						}
 
 						// XDebug also has a different name for the parameters array
 						if (isset($frame['params']) AND ! isset($frame['args']))


### PR DESCRIPTION
Without this patch I, for example, see `Kohana_Corestaticerror_handler(arguments)` instead of `Kohana_Core::error_handler(arguments)` in the kohana error view.
