### PR TITLE
Bugfix (3.4): Text::censor

### DIFF
--- a/classes/Kohana/Text.php
+++ b/classes/Kohana/Text.php
@@ -295,8 +295,9 @@ class Kohana_Text {
 
 		if (UTF8::strlen($replacement) == 1)
 		{
-			$regex .= 'e';
-			return preg_replace($regex, 'str_repeat($replacement, UTF8::strlen(\'$1\'))', $str);
+			return preg_replace_callback($regex, function($matches) use ($replacement) {
+				return str_repeat($replacement, UTF8::strlen($matches[1]));
+			}, $str);
 		}
 
 		return preg_replace($regex, $replacement, $str);


### PR DESCRIPTION
Since php 5.5.0 /e modifier for `preg_replace` is deprecated. So I've replaced `preg_replace` with `preg_replace_callback`. Now it passes `Text::censor` tests on 5.5.
