### PR TITLE
Bugfix (3.4): Text::readable_list

### DIFF
--- a/classes/Kohana/Text.php
+++ b/classes/Kohana/Text.php
@@ -705,12 +705,12 @@ class Kohana_Text {
 			// Check that the word isn't an array itself.
 			if (is_array($word))
 			{
-				throw new InvalidArgumentException('The array must only have one dimension.');
+				throw new Kohana_Exception('The array must only have one dimension.');
 			}
 			// Check that the value of the word is appropriate.
 			elseif ( ! is_string($word) AND ! is_int($word) AND ! (is_object($word) AND method_exists($word, '__toString')))
 			{
-				throw new InvalidArgumentException('Array values must be either strings or integers.');
+				throw new Kohana_Exception('Array values must be either strings or integers.');
 			}
 		}
 

--- a/tests/kohana/TextTest.php
+++ b/tests/kohana/TextTest.php
@@ -649,11 +649,41 @@ class Kohana_TextTest extends Unittest_TestCase
 	public function provider_readable_list()
 	{
 		return array(
-			array('Tom, Dick and Harry',
-				array('Tom', 'Dick', 'Harry')
+			array(
+				'Tom, Dick, and Harry',
+				array('Tom', 'Dick', 'Harry'),
+				'and',
+				TRUE
 			),
-			array('1, 2 and 3',
-				array(1, 2, 3)
+			array(
+				'Tom, Dick and Harry',
+				array('Tom', 'Dick', 'Harry'),
+				'and',
+				FALSE
+			),
+			array(
+				'1, 2, and 3',
+				array(1, 2, 3),
+				'and',
+				TRUE,
+			),
+			array(
+				'1, 2 and 3',
+				array(1, 2, 3),
+				'and',
+				FALSE
+			),
+			array(
+				'Tom, Dick & Harry',
+				array('Tom', 'Dick', 'Harry'),
+				'&',
+				FALSE
+			),
+			array(
+				'1, 2, & 3',
+				array(1, 2, 3),
+				'&',
+				TRUE
 			)
 		);
 	}
@@ -686,9 +716,9 @@ class Kohana_TextTest extends Unittest_TestCase
 	 * @dataProvider  provider_readable_list
 	 * @covers        Text::readable_list
 	 */
-	public function test_readable_list($expected, $words)
+	public function test_readable_list($expected, $words, $conjunction, $serial_comma)
 	{
-		$this->assertSame($expected, Text::readable_list($words));
+		$this->assertSame($expected, Text::readable_list($words, $conjunction, $serial_comma));
 	}
 
 	/**


### PR DESCRIPTION
Fixed the data for `test_readable_list` and `test_readable_list` itself.
Also replaced `InvalidArgumentException` with `Kohana_Exception` because `Kohana_Exception` is the enter point of all Kohana exceptions. Tell me if I'm wrong.
