### PR TITLE
Explicitly enable application and core modules

### DIFF
--- a/classes/Kohana/Core.php
+++ b/classes/Kohana/Core.php
@@ -134,7 +134,7 @@ class Kohana_Core {
 	/**
 	 * @var  array   Currently active modules
 	 */
-	protected static $_modules = ['application' => APPPATH, 'core' => SYSPATH];
+	protected static $_modules = [];
 
 	/**
 	 * @var  array   File path cache, used when caching is true in [Kohana::init]
@@ -365,7 +365,7 @@ class Kohana_Core {
 			Kohana::$log = Kohana::$config = NULL;
 
 			// Reset internal storage
-			Kohana::$_modules = ['application' => APPPATH, 'core' => SYSPATH];
+			Kohana::$_modules = [];
 			Kohana::$_files = [];
 
 			// Reset file cache status
@@ -574,9 +574,6 @@ class Kohana_Core {
 				));
 			}
 		}
-
-		// Prepend application module and append core module
-		$modules = array_merge(['application' => APPPATH], $modules, ['core' => SYSPATH]);
 
 		// Set the current module list
 		Kohana::$_modules = $modules;

--- a/classes/Kohana/Core.php
+++ b/classes/Kohana/Core.php
@@ -134,12 +134,7 @@ class Kohana_Core {
 	/**
 	 * @var  array   Currently active modules
 	 */
-	protected static $_modules = array();
-
-	/**
-	 * @var  array   Include paths that are used to find files
-	 */
-	protected static $_paths = array(APPPATH, SYSPATH);
+	protected static $_modules = ['application' => APPPATH, 'core' => SYSPATH];
 
 	/**
 	 * @var  array   File path cache, used when caching is true in [Kohana::init]
@@ -370,8 +365,8 @@ class Kohana_Core {
 			Kohana::$log = Kohana::$config = NULL;
 
 			// Reset internal storage
-			Kohana::$_modules = Kohana::$_files = array();
-			Kohana::$_paths   = array(APPPATH, SYSPATH);
+			Kohana::$_modules = ['application' => APPPATH, 'core' => SYSPATH];
+			Kohana::$_files = [];
 
 			// Reset file cache status
 			Kohana::$_files_changed = FALSE;
@@ -563,15 +558,12 @@ class Kohana_Core {
 			return Kohana::$_modules;
 		}
 
-		// Start a new list of include paths, APPPATH first
-		$paths = array(APPPATH);
-
 		foreach ($modules as $name => $path)
 		{
 			if (is_dir($path))
 			{
 				// Add the module to include paths
-				$paths[] = $modules[$name] = realpath($path).DIRECTORY_SEPARATOR;
+				$modules[$name] = realpath($path).DIRECTORY_SEPARATOR;
 			}
 			else
 			{
@@ -583,11 +575,8 @@ class Kohana_Core {
 			}
 		}
 
-		// Finish the include paths by adding SYSPATH
-		$paths[] = SYSPATH;
-
-		// Set the new include paths
-		Kohana::$_paths = $paths;
+		// Prepend application module and append core module
+		$modules = array_merge(['application' => APPPATH], $modules, ['core' => SYSPATH]);
 
 		// Set the current module list
 		Kohana::$_modules = $modules;
@@ -604,17 +593,6 @@ class Kohana_Core {
 		}
 
 		return Kohana::$_modules;
-	}
-
-	/**
-	 * Returns the the currently active include paths, including the
-	 * application, system, and each module's path.
-	 *
-	 * @return  array
-	 */
-	public static function include_paths()
-	{
-		return Kohana::$_paths;
 	}
 
 	/**
@@ -682,7 +660,7 @@ class Kohana_Core {
 		if ($array OR $dir === 'config' OR $dir === 'i18n' OR $dir === 'messages')
 		{
 			// Include paths must be searched in reverse
-			$paths = array_reverse(Kohana::$_paths);
+			$paths = array_reverse(Kohana::$_modules);
 
 			// Array of files that have been found
 			$found = array();
@@ -701,7 +679,7 @@ class Kohana_Core {
 			// The file has not been found yet
 			$found = FALSE;
 
-			foreach (Kohana::$_paths as $dir)
+			foreach (Kohana::$_modules as $dir)
 			{
 				if (is_file($dir.$path))
 				{
@@ -755,7 +733,7 @@ class Kohana_Core {
 		if ($paths === NULL)
 		{
 			// Use the default paths
-			$paths = Kohana::$_paths;
+			$paths = Kohana::$_modules;
 		}
 
 		// Create an array for the files

--- a/tests/kohana/CoreTest.php
+++ b/tests/kohana/CoreTest.php
@@ -360,32 +360,5 @@ class Kohana_CoreTest extends Unittest_TestCase
 
 		$this->assertArrayHasKey('unittest', $modules);
 	}
-
-	/**
-	 * Tests Kohana::include_paths()
-	 *
-	 * The include paths must contain the apppath and syspath
-	 * @test
-	 * @covers Kohana::include_paths
-	 */
-	public function test_include_paths()
-	{
-		$include_paths = Kohana::include_paths();
-		$modules       = Kohana::modules();
-
-		$this->assertInternalType('array', $include_paths);
-
-		// We must have at least 2 items in include paths (APP / SYS)
-		$this->assertGreaterThan(2, count($include_paths));
-		// Make sure said paths are in the include paths
-		// And make sure they're in the correct positions
-		$this->assertSame(APPPATH, reset($include_paths));
-		$this->assertSame(SYSPATH, end($include_paths));
-
-		foreach ($modules as $module)
-		{
-			$this->assertContains($module, $include_paths);
-		}
-	}
 }
 


### PR DESCRIPTION
The application and core modules must now be explicitly set in the bootstrap.php instead of magically being added in the core behind the scenes. This gives the user total control and flexibility over modules and makes all modules optional.

Kohana::include_paths() method has been removed, the only difference between this and Kohana::modules() is that it included the application and core module paths. Now that these two modules are included in Kohana::$_modules there's no need for the method to exist, likewise with Kohana::$_paths.

In the refactor of Kohana::modules(), array_reverse() is used before setting and getting modules. This makes it so Kohana::$_modules internally stores modules in the correct order, however externally it works in the same "top to bottom" fashion. As array_reverse() is now in one place, other methods such as find_file() don't have to worry about reversing the modules array before use.
