### PR TITLE
Added encoding support to ucfirst method

### DIFF
--- a/classes/Kohana/Arr.php
+++ b/classes/Kohana/Arr.php
@@ -282,7 +282,7 @@ abstract class Kohana_Arr {
 	 */
 	public static function get($array, $key, $default = NULL)
 	{
-		return isset($array[$key]) ? $array[$key] : $default;
+		return array_key_exists($key, $array) ? $array[$key] : $default;
 	}
 
 	/**

--- a/classes/Kohana/Text.php
+++ b/classes/Kohana/Text.php
@@ -251,10 +251,10 @@ class Kohana_Text {
 		// Put the keys back the Case-Convention expected
 		return implode($delimiter,
 			array_map(
-				create_function(
-					'$word, $encoding',
-					'return mb_strtoupper(mb_substr($word, 0, 1, $encoding), $encoding) . mb_strtolower(mb_substr($word, 1, mb_strlen($word), $encoding), $encoding);'
-					),
+				function($word, $encoding)
+				{
+				  return mb_strtoupper(mb_substr($word, 0, 1, $encoding), $encoding) . mb_strtolower(mb_substr($word, 1, mb_strlen($word), $encoding), $encoding);
+				},
 			$array,
 			array_fill(0, count($array), $encoding)
 			)

--- a/classes/Kohana/Text.php
+++ b/classes/Kohana/Text.php
@@ -243,7 +243,7 @@ class Kohana_Text {
 	* @param   string  $encoding   character encoding
 	* @return  string 
 	*/
-	static function ucfirst($string, $delimiter = '-', $encoding = 'UTF-8')
+	public static function ucfirst($string, $delimiter = '-', $encoding = 'UTF-8')
 	{
 		// Explode string
 		$array = explode($delimiter, $string);

--- a/classes/Kohana/Text.php
+++ b/classes/Kohana/Text.php
@@ -233,20 +233,27 @@ class Kohana_Text {
 	}
 
 	/**
-	 * Uppercase words that are not separated by spaces, using a custom
-	 * delimiter or the default.
-	 *
-	 *      $str = Text::ucfirst('content-type'); // returns "Content-Type"
-	 *
-	 * @param   string  $string     string to transform
-	 * @param   string  $delimiter  delimiter to use
-	 * @return  string
-	 */
-	public static function ucfirst($string, $delimiter = '-')
-	{
-		// Put the keys back the Case-Convention expected
-		return implode($delimiter, array_map('ucfirst', explode($delimiter, $string)));
-	}
+   * Uppercase words that are not separated by spaces, using a custom
+   * delimiter or the default.
+   *
+   *      $str = Text::ucfirst('content-type'); // returns "Content-Type"
+   *
+   * @param   string  $string     string to transform
+   * @param   string  $delimiter  delimiter to use
+   * @param   string  $encoding   character encoding
+   * @return  string
+   */
+  static function ucfirst($string, $delimiter = '-', $encoding = 'UTF-8')
+  {
+    // Put the keys back the Case-Convention expected
+    $array = explode($delimiter, $string);
+    return implode($delimiter,
+      array_map(create_function('$word, $encoding',
+      'return mb_strtoupper(mb_substr($word, 0, 1, $encoding), $encoding) . mb_strtolower(mb_substr($word, 1, mb_strlen($word), $encoding), $encoding);'),
+      $array, array_fill(0, count($array), $encoding)
+      )
+    );
+  }
 
 	/**
 	 * Reduces multiple slashes in a string to single slashes.

--- a/classes/Kohana/Text.php
+++ b/classes/Kohana/Text.php
@@ -241,7 +241,7 @@ class Kohana_Text {
    * @param   string  $string     string to transform
    * @param   string  $delimiter  delimiter to use
    * @param   string  $encoding   character encoding
-   * @return  string
+   * @return  string 
    */
   static function ucfirst($string, $delimiter = '-', $encoding = 'UTF-8')
   {

--- a/classes/Kohana/Text.php
+++ b/classes/Kohana/Text.php
@@ -240,10 +240,8 @@ class Kohana_Text {
 	*
 	* @param   string  $string     string to transform
 	* @param   string  $delimiter  delimiter to use
-	* @return  string 
-	* @uses    UTF8::substr
-	* @uses    UTF8::strtoupper
-	* @uses    UTF8::strlen
+	* @uses    UTF8::ucfirst
+	* @return  string
 	*/
 	public static function ucfirst($string, $delimiter = '-')
 	{

--- a/classes/Kohana/Text.php
+++ b/classes/Kohana/Text.php
@@ -248,15 +248,7 @@ class Kohana_Text {
 	public static function ucfirst($string, $delimiter = '-')
 	{
 		// Put the keys back the Case-Convention expected
-		return implode($delimiter,
-			array_map(
-				function($word)
-				{
-				  return UTF8::strtoupper(UTF8::substr($word, 0, 1)) . UTF8::strtolower(UTF8::substr($word, 1, UTF8::strlen($word)));
-				},
-			explode($delimiter, $string)
-			)
-		);
+		return implode($delimiter, array_map('UTF8::ucfirst', explode($delimiter, $string)));
 	}
 
 	/**

--- a/classes/Kohana/Text.php
+++ b/classes/Kohana/Text.php
@@ -233,8 +233,8 @@ class Kohana_Text {
 	}
 
 	/**
-  * Uppercase words that are not separated by spaces, using a custom
-  * delimiter or the default.
+	* Uppercase words that are not separated by spaces, using a custom
+	* delimiter or the default.
 	*
 	*      $str = Text::ucfirst('content-type'); // returns "Content-Type"
 	*

--- a/classes/Kohana/Text.php
+++ b/classes/Kohana/Text.php
@@ -233,8 +233,8 @@ class Kohana_Text {
 	}
 
 	/**
-   	* Uppercase words that are not separated by spaces, using a custom
-   	* delimiter or the default.
+  * Uppercase words that are not separated by spaces, using a custom
+  * delimiter or the default.
 	*
 	*      $str = Text::ucfirst('content-type'); // returns "Content-Type"
 	*

--- a/classes/Kohana/Text.php
+++ b/classes/Kohana/Text.php
@@ -233,27 +233,33 @@ class Kohana_Text {
 	}
 
 	/**
-   * Uppercase words that are not separated by spaces, using a custom
-   * delimiter or the default.
-   *
-   *      $str = Text::ucfirst('content-type'); // returns "Content-Type"
-   *
-   * @param   string  $string     string to transform
-   * @param   string  $delimiter  delimiter to use
-   * @param   string  $encoding   character encoding
-   * @return  string 
-   */
-  static function ucfirst($string, $delimiter = '-', $encoding = 'UTF-8')
-  {
-    // Put the keys back the Case-Convention expected
-    $array = explode($delimiter, $string);
-    return implode($delimiter,
-      array_map(create_function('$word, $encoding',
-      'return mb_strtoupper(mb_substr($word, 0, 1, $encoding), $encoding) . mb_strtolower(mb_substr($word, 1, mb_strlen($word), $encoding), $encoding);'),
-      $array, array_fill(0, count($array), $encoding)
-      )
-    );
-  }
+   	* Uppercase words that are not separated by spaces, using a custom
+   	* delimiter or the default.
+	*
+	*      $str = Text::ucfirst('content-type'); // returns "Content-Type"
+	*
+	* @param   string  $string     string to transform
+	* @param   string  $delimiter  delimiter to use
+	* @param   string  $encoding   character encoding
+	* @return  string 
+	*/
+	static function ucfirst($string, $delimiter = '-', $encoding = 'UTF-8')
+	{
+		// Explode string
+		$array = explode($delimiter, $string);
+		
+		// Put the keys back the Case-Convention expected
+		return implode($delimiter,
+			array_map(
+				create_function(
+					'$word, $encoding',
+					'return mb_strtoupper(mb_substr($word, 0, 1, $encoding), $encoding) . mb_strtolower(mb_substr($word, 1, mb_strlen($word), $encoding), $encoding);'
+					),
+			$array,
+			array_fill(0, count($array), $encoding)
+			)
+		);
+	}
 
 	/**
 	 * Reduces multiple slashes in a string to single slashes.

--- a/classes/Kohana/Text.php
+++ b/classes/Kohana/Text.php
@@ -240,23 +240,21 @@ class Kohana_Text {
 	*
 	* @param   string  $string     string to transform
 	* @param   string  $delimiter  delimiter to use
-	* @param   string  $encoding   character encoding
 	* @return  string 
+	* @uses    UTF8::substr
+	* @uses    UTF8::strtoupper
+	* @uses    UTF8::strlen
 	*/
-	public static function ucfirst($string, $delimiter = '-', $encoding = 'UTF-8')
+	public static function ucfirst($string, $delimiter = '-')
 	{
-		// Explode string
-		$array = explode($delimiter, $string);
-		
 		// Put the keys back the Case-Convention expected
 		return implode($delimiter,
 			array_map(
-				function($word, $encoding)
+				function($word)
 				{
-				  return mb_strtoupper(mb_substr($word, 0, 1, $encoding), $encoding) . mb_strtolower(mb_substr($word, 1, mb_strlen($word), $encoding), $encoding);
+				  return UTF8::strtoupper(UTF8::substr($word, 0, 1)) . UTF8::strtolower(UTF8::substr($word, 1, UTF8::strlen($word)));
 				},
-			$array,
-			array_fill(0, count($array), $encoding)
+			explode($delimiter, $string)
 			)
 		);
 	}


### PR DESCRIPTION
Uses mb_strtoupper and mb_substr to achieve Upper Case on first charater of each word along with encoding, following Text::ucfirst() behavior. Default encoding is UTF-8.

Exemple : Text::ucfirst('вы-рок', '-', 'UTF-8'); => 'Вы-Рок'
