### PR TITLE
Create new method Kohana::init_modules()

### DIFF
--- a/classes/Kohana/Core.php
+++ b/classes/Kohana/Core.php
@@ -499,18 +499,29 @@ class Kohana_Core {
 		// Set the current module list
 		Kohana::$_modules = $modules;
 
+		return Kohana::$_modules;
+	}
+	
+	/**
+	 * Initializes the enabled modules.
+	 * 
+	 * @return void
+	 */
+	public static function init_modules()
+	{
+		// For each enabled module
 		foreach (Kohana::$_modules as $path)
 		{
-			$init = $path.'init'.EXT;
+			// Get init file path
+			$init_path = $path.'init'.EXT;
 
-			if (is_file($init))
+			// If init file exists in module
+			if (is_file($init_path))
 			{
-				// Include the module initialization file once
-				require_once $init;
+				// Include the init file
+				require_once $init_path;
 			}
 		}
-
-		return Kohana::$_modules;
 	}
 
 	/**


### PR DESCRIPTION
This PR splits the module initialisation functionality from Kohana::modules() and places it into its own method called Kohana::init_modules().

Previous PRs to the 3.4/develop branch has forced Kohana::modules() to be called in the bootstrap before any classes are used. This causes a problem because a few things need to be done before the modules are initialised such as attaching a config object to Kohana::$config (the userguide uses this for example https://github.com/kohana/userguide/blob/3.3/master/init.php#L12).

To fix this problem, the method Kohana::init_modules() can be called after everything has been set up for init files in the bootstrap.
