### PR TITLE
// script urls supported in HTML::script

### DIFF
--- a/classes/Kohana/HTML.php
+++ b/classes/Kohana/HTML.php
@@ -206,7 +206,7 @@ class Kohana_HTML {
 	 */
 	public static function style($file, array $attributes = NULL, $protocol = NULL, $index = FALSE)
 	{
-		if (strpos($file, '://') === FALSE)
+		if (strpos($file, '://') === FALSE AND strpos($file, '//') !== 0)
 		{
 			// Add the base URL
 			$file = URL::site($file, $protocol, $index);
@@ -239,7 +239,7 @@ class Kohana_HTML {
 	 */
 	public static function script($file, array $attributes = NULL, $protocol = NULL, $index = FALSE)
 	{
-		if (strpos($file, '://') === FALSE && strpos($file, '//') !== 0)
+		if (strpos($file, '://') === FALSE AND strpos($file, '//') !== 0)
 		{
 			// Add the base URL
 			$file = URL::site($file, $protocol, $index);

--- a/classes/Kohana/HTML.php
+++ b/classes/Kohana/HTML.php
@@ -239,7 +239,7 @@ class Kohana_HTML {
 	 */
 	public static function script($file, array $attributes = NULL, $protocol = NULL, $index = FALSE)
 	{
-		if (strpos($file, '://') === FALSE)
+		if (strpos($file, '://') === FALSE && strpos($file, '//') !== 0)
 		{
 			// Add the base URL
 			$file = URL::site($file, $protocol, $index);


### PR DESCRIPTION
support script URLs that that do not implicitly specify the protocol, i.e. starting with //. Ref: https://github.com/kohana/kohana/issues/40
