### PR TITLE
Allowing Config to be extended and set before Kohana::init

### DIFF
--- a/classes/Kohana/Core.php
+++ b/classes/Kohana/Core.php
@@ -307,7 +307,7 @@ class Kohana_Core {
 		}
 
 		// Load the config if one doesn't already exist
-		if ( ! Kohana::$config instanceof Config)
+		if ( ! Kohana::$config instanceof Kohana_Config)
 		{
 			Kohana::$config = new Config;
 		}


### PR DESCRIPTION
`Kohana::$config` is allowed to be set before `Kohana::init()`, but it checks if it's a `Config` instance. I've changed the check to `Kohana_Config` to eliminate the need to extend `Config` and instead extend `Kohana_Config` directly.

Makes sense?
