### PR TITLE
3.4/bugfix/use i18n translate

### DIFF
--- a/classes/Kohana/I18n.php
+++ b/classes/Kohana/I18n.php
@@ -6,6 +6,8 @@
  * Typically this class would never be used directly, but used via the __()
  * function, which loads the message and replaces parameters:
  *
+ * the __() function is declared in the Kohana official bootstrap
+ *
  *     // Display a translated message
  *     echo __('Hello, world');
  *

--- a/classes/Kohana/Kohana/Exception.php
+++ b/classes/Kohana/Kohana/Exception.php
@@ -50,7 +50,7 @@ class Kohana_Kohana_Exception extends Exception {
 	public function __construct($message = "", array $variables = NULL, $code = 0, Exception $previous = NULL)
 	{
 		// Set the message
-		$message = __($message, $variables);
+		$message = I18n::translate($message, $variables);
 
 		// Pass the message and integer code to the parent
 		parent::__construct($message, (int) $code, $previous);

--- a/classes/Kohana/Validation.php
+++ b/classes/Kohana/Validation.php
@@ -499,12 +499,12 @@ class Kohana_Validation implements ArrayAccess {
 				if (is_string($translate))
 				{
 					// Translate the label using the specified language
-					$label = __($label, NULL, $translate);
+					$label = I18n::translate($label, NULL, $translate);
 				}
 				else
 				{
 					// Translate the label
-					$label = __($label);
+					$label = I18n::translate($label);
 				}
 			}
 
@@ -546,12 +546,12 @@ class Kohana_Validation implements ArrayAccess {
 							if (is_string($translate))
 							{
 								// Translate the value using the specified language
-								$value = __($value, NULL, $translate);
+								$value = I18n::translate($value, NULL, $translate);
 							}
 							else
 							{
 								// Translate the value
-								$value = __($value);
+								$value = I18n::translate($value);
 							}
 						}
 					}
@@ -588,12 +588,12 @@ class Kohana_Validation implements ArrayAccess {
 				if (is_string($translate))
 				{
 					// Translate the message using specified language
-					$message = __($message, $values, $translate);
+					$message = I18n::translate($message, $values, $translate);
 				}
 				else
 				{
 					// Translate the message using the default language
-					$message = __($message, $values);
+					$message = I18n::translate($message, $values);
 				}
 			}
 			else

--- a/guide/kohana/files.md
+++ b/guide/kohana/files.md
@@ -38,7 +38,7 @@ config/
 :  Configuration files return an associative array of options that can be loaded using [Kohana::$config]. Config files are merged rather than overwritten by the cascade. See [config files](files/config) for more information.
 
 i18n/
-:  Translation files return an associative array of strings. Translation is done using the `__()` method. To translate "Hello, world!" into Spanish, you would call `__('Hello, world!')` with [I18n::$lang] set to "es-es". I18n files are merged rather than overwritten by the cascade. See [I18n files](files/i18n) for more information.
+:  Translation files return an associative array of strings. Translation is done using the `__()` method. Note that the `__()` function is declared in the official Kohana bootstrap. You need to keep that declaration, otherwise you should use the `I18n::translate` method. To translate "Hello, world!" into Spanish, you would call `__('Hello, world!')` with [I18n::$lang] set to "es-es". I18n files are merged rather than overwritten by the cascade. See [I18n files](files/i18n) for more information.
 
 messages/
 :  Message files return an associative array of strings that can be loaded using [Kohana::message]. Messages and i18n files differ in that messages are not translated, but always written in the default language and referred to by a single key. Message files are merged rather than overwritten by the cascade. See [message files](files/messages) for more information.

--- a/guide/kohana/files/i18n.md
+++ b/guide/kohana/files/i18n.md
@@ -2,9 +2,11 @@
 
 Kohana has a fairly simple and easy to use i18n system. It is slightly modeled after gettext, but is not as featureful. If you need the features of gettext, please use that :)
 
-## __()
+## __() or I18n::translate
 
-Kohana has a __() function to do your translations for you. This function is only meant for small sections of text, not entire paragraphs or pages of translated text.
+Kohana has a `__()` function to do your translations for you. It is declared in `bootstrap.php` as a short alias for `I18n::translate`. If you do not have it in your `bootstrap.php`, you must use the `I18n::translate` method instead.
+
+This function is only meant for small sections of text, not entire paragraphs or pages of translated text.
 
 To echo a translated string:
 
@@ -50,18 +52,4 @@ Your i18n key in your translation file will need to be defined as:
 
 ## Defining your own __() function
 
-You can define your own __() function by simply defining your own i18n class:
-
-	<?php
-	
-	class I18n extends Kohana_I18n
-	{
-		// Intentionally empty
-	}
-	
-	function __($string, array $values = NULL, $lang = 'en-us')
-	{
-		// Your functionality here
-	}
-
-This will cause the built-in __() function to be ignored.
+You can define your own __() function by simply changing its definition in `bootstrap.php`.

--- a/guide/kohana/files/messages.md
+++ b/guide/kohana/files/messages.md
@@ -32,5 +32,5 @@ This will look in the `messages/forms/contact.php` for the `[foobar][bar]` key:
 
 ## Notes
 
- * Don't use __() in your messages files, as these files can be cached and will not work properly.
+ * Don't use `__()` or `I18n::translate` in your messages files, as these files can be cached and will not work properly.
  * Messages are merged by the cascading file system, not overwritten like classes and views.

--- a/views/kohana/error.php
+++ b/views/kohana/error.php
@@ -61,11 +61,11 @@ function koggle(elem)
 						<?php if ($step['file']): $source_id = $error_id.'source'.$i; ?>
 							<a href="#<?php echo $source_id ?>" onclick="return koggle('<?php echo $source_id ?>')"><?php echo Debug::path($step['file']) ?> [ <?php echo $step['line'] ?> ]</a>
 						<?php else: ?>
-							{<?php echo __('PHP internal call') ?>}
+							{<?php echo I18n::translate('PHP internal call') ?>}
 						<?php endif ?>
 					</span>
 					&raquo;
-					<?php echo $step['function'] ?>(<?php if ($step['args']): $args_id = $error_id.'args'.$i; ?><a href="#<?php echo $args_id ?>" onclick="return koggle('<?php echo $args_id ?>')"><?php echo __('arguments') ?></a><?php endif ?>)
+					<?php echo $step['function'] ?>(<?php if ($step['args']): $args_id = $error_id.'args'.$i; ?><a href="#<?php echo $args_id ?>" onclick="return koggle('<?php echo $args_id ?>')"><?php echo I18n::translate('arguments') ?></a><?php endif ?>)
 				</p>
 				<?php if (isset($args_id)): ?>
 				<div id="<?php echo $args_id ?>" class="collapsed">
@@ -87,10 +87,10 @@ function koggle(elem)
 		<?php endforeach ?>
 		</ol>
 	</div>
-	<h2><a href="#<?php echo $env_id = $error_id.'environment' ?>" onclick="return koggle('<?php echo $env_id ?>')"><?php echo __('Environment') ?></a></h2>
+	<h2><a href="#<?php echo $env_id = $error_id.'environment' ?>" onclick="return koggle('<?php echo $env_id ?>')"><?php echo I18n::translate('Environment') ?></a></h2>
 	<div id="<?php echo $env_id ?>" class="content collapsed">
 		<?php $included = get_included_files() ?>
-		<h3><a href="#<?php echo $env_id = $error_id.'environment_included' ?>" onclick="return koggle('<?php echo $env_id ?>')"><?php echo __('Included files') ?></a> (<?php echo count($included) ?>)</h3>
+		<h3><a href="#<?php echo $env_id = $error_id.'environment_included' ?>" onclick="return koggle('<?php echo $env_id ?>')"><?php echo I18n::translate('Included files') ?></a> (<?php echo count($included) ?>)</h3>
 		<div id="<?php echo $env_id ?>" class="collapsed">
 			<table cellspacing="0">
 				<?php foreach ($included as $file): ?>
@@ -101,7 +101,7 @@ function koggle(elem)
 			</table>
 		</div>
 		<?php $included = get_loaded_extensions() ?>
-		<h3><a href="#<?php echo $env_id = $error_id.'environment_loaded' ?>" onclick="return koggle('<?php echo $env_id ?>')"><?php echo __('Loaded extensions') ?></a> (<?php echo count($included) ?>)</h3>
+		<h3><a href="#<?php echo $env_id = $error_id.'environment_loaded' ?>" onclick="return koggle('<?php echo $env_id ?>')"><?php echo I18n::translate('Loaded extensions') ?></a> (<?php echo count($included) ?>)</h3>
 		<div id="<?php echo $env_id ?>" class="collapsed">
 			<table cellspacing="0">
 				<?php foreach ($included as $file): ?>

--- a/views/profiler/stats.php
+++ b/views/profiler/stats.php
@@ -14,16 +14,16 @@ $application_cols = array('min', 'max', 'average', 'current');
 	<?php foreach (Profiler::groups() as $group => $benchmarks): ?>
 	<table class="profiler">
 		<tr class="group">
-			<th class="name" rowspan="2"><?php echo __(ucfirst($group)) ?></th>
+			<th class="name" rowspan="2"><?php echo I18n::translate(ucfirst($group)) ?></th>
 			<td class="time" colspan="4"><?php echo number_format($group_stats[$group]['total']['time'], 6) ?> <abbr title="seconds">s</abbr></td>
 		</tr>
 		<tr class="group">
 			<td class="memory" colspan="4"><?php echo number_format($group_stats[$group]['total']['memory'] / 1024, 4) ?> <abbr title="kilobyte">kB</abbr></td>
 		</tr>
 		<tr class="headers">
-			<th class="name"><?php echo __('Benchmark') ?></th>
+			<th class="name"><?php echo I18n::translate('Benchmark') ?></th>
 			<?php foreach ($group_cols as $key): ?>
-			<th class="<?php echo $key ?>"><?php echo __(ucfirst($key)) ?></th>
+			<th class="<?php echo $key ?>"><?php echo I18n::translate(ucfirst($key)) ?></th>
 			<?php endforeach ?>
 		</tr>
 		<?php foreach ($benchmarks as $name => $tokens): ?>
@@ -60,7 +60,7 @@ $application_cols = array('min', 'max', 'average', 'current');
 	<table class="profiler">
 		<?php $stats = Profiler::application() ?>
 		<tr class="final mark time">
-			<th class="name" rowspan="2" scope="rowgroup"><?php echo __('Application Execution').' ('.$stats['count'].')' ?></th>
+			<th class="name" rowspan="2" scope="rowgroup"><?php echo I18n::translate('Application Execution').' ('.$stats['count'].')' ?></th>
 			<?php foreach ($application_cols as $key): ?>
 			<td class="<?php echo $key ?>"><?php echo number_format($stats[$key]['time'], 6) ?> <abbr title="seconds">s</abbr></td>
 			<?php endforeach ?>


### PR DESCRIPTION
I think `kohana/core` should be a self sufficient module, not relying on `__()` function which is defined outside the module, in `bootstrap.php`.

I replaced occurrences of `__()` with `I18n::translate`. Also made some doc adjustments.

Kohana userland can still use `__()` if they leave the declaration in bootstrap. Otherwise they should use `I18n::translate` instead.

Please review thoroughly.
