### PR TITLE
Set and reset mb_substitute_character for mb_convert_encoding

### DIFF
--- a/classes/Kohana/UTF8.php
+++ b/classes/Kohana/UTF8.php
@@ -85,13 +85,17 @@ abstract class Kohana_UTF8 {
 
 			if ( ! UTF8::is_ascii($var) AND UTF8::$server_utf8)
 			{
-				// Disable notices
-				$error_reporting = error_reporting(~E_NOTICE);
+				// Temporarily save the mb_substitute_character() value into a variable
+				$mb_substitute_character = mb_substitute_character();
 
+				// Disable substituting illegal characters with the default '?' character
+				mb_substitute_character('none');
+
+				// convert encoding, this is expensive, used when $var is not ASCII
 				$var = mb_convert_encoding($var, $charset, $charset);
 
-				// Turn notices back on
-				error_reporting($error_reporting);
+				// Reset mb_substitute_character() value back to the original setting
+				mb_substitute_character($mb_substitute_character);
 			}
 		}
 


### PR DESCRIPTION
This was accepted as part of 3.2 bugfix here #444 

I am not sure if we want to do the same for 3.3. This makes the `mb_substitute_character('none');` line in `bootstrap.php` redundant as it sets and resets back the original value within the function, when needed. So, I will make another PR for `kohana/kohana` on 3.4/develop and remove that line from `bootstrap.php`.

Regarding Kohana 3.3, I am not sure if we consider the settings of `bootstrap.php` file as something we could not change on minor releases. Probably removing `mb_substitute_character('none');` line from `bootstrap.php` might break some code relying on `mb_` functions elsewhere in the application. So let me know if you think this should be in Kohana 3.3 or not.

Not very elegant solution, but at least better than disabling and enabling the error reporting that we had prior to v. 3.2.3.

Thanks for reviewing :)
