### PR TITLE
Configure isolated travis build for kohana/core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *~
 *.swp
+/composer.lock
+/vendor
+/koharness_bootstrap.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: php
+
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+  - hhvm
+
+before_script:
+  - composer install --prefer-dist
+  - vendor/bin/koharness
+
+script:
+  - cd /tmp/koharness && ./vendor/bin/phpunit --bootstrap=modules/unittest/bootstrap.php modules/unittest/tests.php
+
+notifications:
+  irc:
+    channels:
+      - "irc.freenode.org#kohana"
+    template:
+      - "%{repository}/%{branch} (%{commit}) - %{author}: %{message}"
+      - "Build details: %{build_url}"
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,4 @@ script:
   - cd /tmp/koharness && ./vendor/bin/phpunit --bootstrap=modules/unittest/bootstrap.php modules/unittest/tests.php
 
 notifications:
-  irc:
-    channels:
-      - "irc.freenode.org#kohana"
-    template:
-      - "%{repository}/%{branch} (%{commit}) - %{author}: %{message}"
-      - "Build details: %{build_url}"
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
   - hhvm
 
 before_script:
-  - composer install --prefer-dist
+  - COMPOSER_ROOT_VERSION=3.3.x-dev composer install --prefer-dist
   - vendor/bin/koharness
 
 script:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Kohana PHP Framework - core
+
+This is the core package for the [Kohana](http://kohanaframework.org/) object oriented HMVC framework built using PHP5.
+It aims to be swift, secure, and small.
+
+Released under a [BSD license](http://kohanaframework.org/license), Kohana can be used legally for any open source,
+commercial, or personal project.
+
+## Documentation and installation
+
+See the [sample application repository](https://github.com/kohana/kohana) for full readme and contributing information.
+You will usually add `kohana/core` as a dependency in your own project's composer.json to install and work with this
+pacakge.
+
+## Installation for development
+
+To work on this package, you'll want to install it with composer to get the required dependencies. Note that there are
+currently circular dependencies between this module and kohana/unittest. These may cause you problems if you are working
+on a feature branch, because composer may not be able to figure out which version of kohana core you have.
+
+To work around this, run composer like: `COMPOSER_ROOT_VERSION=3.3.x-dev composer install`. This tells composer that the
+current checkout is a 3.3.* development version. Obviously change the argument if your branch is based on a different
+version.
+
+After installing the dependencies, you'll need a skeleton Kohana application before you can run the unit tests etc. The
+simplest way to do this is to use kohana/koharness to build a bare project in `/tmp/koharness`.
+
+If in doubt, check the install and test steps in the [.travis.yml](.travis.yml) file.

--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,19 @@
 	"require": {
 		"php":        ">=5.3.3"
 	},
+	"require-dev": {
+		"kohana/unittest":     "3.3.*@dev",
+		"kohana/koharness":    "*@dev"
+	},
 	"suggest": {
 		"ext-http":   "*",
 		"ext-curl":   "*",
 		"ext-mcrypt": "*"
 	},
 	"extra": {
+		"installer-paths": {
+			"vendor/{$vendor}/{$name}": ["type:kohana-module"]
+		},
 		"branch-alias": {
 			"dev-3.3/develop":  "3.3.x-dev",
 			"dev-3.4/develop":  "3.4.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,5 @@
 {
+    "_readme":     "NOTE: see readme for COMPOSER_ROOT_VERSION instructions if you have dependency issues",
 	"name":        "kohana/core",
 	"description": "Core system classes for the Kohana application framework",
 	"homepage":    "http://kohanaframework.org",

--- a/koharness.php
+++ b/koharness.php
@@ -1,0 +1,8 @@
+<?php
+// Configuration for koharness - builds a standalone skeleton Kohana app for running unit tests
+return array(
+	'modules' => array(
+		'unittest' => __DIR__ . '/vendor/kohana/unittest'
+	),
+	'syspath' => __DIR__,
+);

--- a/tests/kohana/CoreTest.php
+++ b/tests/kohana/CoreTest.php
@@ -296,7 +296,7 @@ class Kohana_CoreTest extends Unittest_TestCase
 	{
 		return array(
 			array(array(), array()),
-			array(array('unittest' => MODPATH.'unittest'), array('unittest' => $this->dirSeparator(MODPATH.'unittest/'))),
+			array(array('module' => __DIR__), array('module' => $this->dirSeparator(__DIR__.'/'))),
 		);
 	}
 


### PR DESCRIPTION
This is the first of the changes to add separate CI support for each module in isolation as discussed in kohana/kohana#50.

Once this is done and working across all the 3.3 modules, I'll merge up to 3.4 and make any required changes for that.

@shadowhand, @zombor or @Zeelot I think only you (as admins) can activate the travis hooks? Could you do that now and then I'll force a push to get the build running? I think you could activate for all the core modules now, obviously all the others will fail for the minute as they don't have travis configuration but I should get to them pretty quickly.
