### PR TITLE
R4820 incorrect mention of the missing method Request::instance

### DIFF
--- a/classes/Kohana/Form.php
+++ b/classes/Kohana/Form.php
@@ -28,7 +28,7 @@ class Kohana_Form {
 	 * @param   mixed   $action     form action, defaults to the current request URI, or [Request] class to use
 	 * @param   array   $attributes html attributes
 	 * @return  string
-	 * @uses    Request::instance
+	 * @uses    Request
 	 * @uses    URL::site
 	 * @uses    HTML::attributes
 	 */

--- a/classes/Kohana/Request.php
+++ b/classes/Kohana/Request.php
@@ -38,7 +38,7 @@ class Kohana_Request implements HTTP_Request {
 
 	/**
 	 * Creates a new request object for the given URI. New requests should be
-	 * created using the [Request::instance] or [Request::factory] methods.
+	 * Created using the [Request::factory] method.
 	 *
 	 *     $request = Request::factory($uri);
 	 *
@@ -631,7 +631,7 @@ class Kohana_Request implements HTTP_Request {
 
 	/**
 	 * Creates a new request object for the given URI. New requests should be
-	 * created using the [Request::instance] or [Request::factory] methods.
+	 * Created using the [Request::factory] method.
 	 *
 	 *     $request = new Request($uri);
 	 *

--- a/guide/kohana/flow.md
+++ b/guide/kohana/flow.md
@@ -16,7 +16,7 @@ Every application follows the same flow:
 		* Includes each module's `init.php` file, if it exists. 
 	    * The `init.php` file can perform additional environment setup, including adding routes.
 	10. [Route::set] is called multiple times to define the [application routes](routing).
-	11. [Request::instance] is called to start processing the request.
+	11. [Request::factory] is called to start processing the request.
 		1. Checks each route that has been set until a match is found.
 		2. Creates the controller instance and passes the request to it.
 		3. Calls the [Controller::before] method.

--- a/guide/kohana/mvc/controllers.md
+++ b/guide/kohana/mvc/controllers.md
@@ -55,7 +55,7 @@ You can also have a controller extend another controller to share common things,
 
 Every controller has the `$this->request` property which is the [Request] object that called the controller.  You can use this to get information about the current request, as well as set the response body via `$this->response->body($ouput)`.
 
-Here is a partial list of the properties and methods available to `$this->request`.  These can also be accessed via `Request::instance()`, but `$this->request` is provided as a shortcut.  See the [Request] class for more information on any of these. 
+Here is a partial list of the properties and methods available to `$this->request`. See the [Request] class for more information on any of these.
 
 Property/method | What it does
 --- | ---


### PR DESCRIPTION
Originally submitted by @Asenar in [R4820](http://dev.kohanaframework.org/issues/4820) and based on his PR #455

> Various place in guide and php comments were mentionning
> Request::instance() to be used. I replaced it either by
> Request::factory() or something more appropriate.

the file `guide/kohana/routing.md` in `3.3/develop` did not have the bottom part to fix.

Related to #547. Please review and merge.
