### PR TITLE
related to R4813, removes redundant notice-disabling lines

### DIFF
--- a/classes/Kohana/UTF8.php
+++ b/classes/Kohana/UTF8.php
@@ -70,13 +70,7 @@ class Kohana_UTF8 {
 
 			if ( ! UTF8::is_ascii($var))
 			{
-				// Disable notices
-				$error_reporting = error_reporting(~E_NOTICE);
-
 				$var = mb_convert_encoding($var, $charset, $charset);
-
-				// Turn notices back on
-				error_reporting($error_reporting);
 			}
 		}
 


### PR DESCRIPTION
This is related to [R4813](http://dev.kohanaframework.org/issues/4813) and #444

It is already fixed in Kohana 3.3 by @rjd22 in #363 and kohana/kohana#12

I just removed redundant notice-disabling lines because `mb_convert_encoding`, unlike `iconv`, does not emit `E_NOTICE`.

Also related to #547. Please review and merge :) Thanks!
