### PR TITLE
Fix skipped/incomplete core tests for 3.3 series

### DIFF
--- a/classes/Kohana/Cookie.php
+++ b/classes/Kohana/Cookie.php
@@ -78,7 +78,7 @@ class Kohana_Cookie {
 			}
 
 			// The cookie signature is invalid, delete it
-			Cookie::delete($key);
+			static::delete($key);
 		}
 
 		return $default;
@@ -88,33 +88,38 @@ class Kohana_Cookie {
 	 * Sets a signed cookie. Note that all cookie values must be strings and no
 	 * automatic serialization will be performed!
 	 *
+	 * [!!] By default, Cookie::$expiration is 0 - if you skip/pass NULL for the optional
+	 *      lifetime argument your cookies will expire immediately unless you have separately
+	 *      configured Cookie::$expiration.
+	 *
+	 *
 	 *     // Set the "theme" cookie
 	 *     Cookie::set('theme', 'red');
 	 *
 	 * @param   string  $name       name of cookie
 	 * @param   string  $value      value of cookie
-	 * @param   integer $expiration lifetime in seconds
+	 * @param   integer $lifetime   lifetime in seconds
 	 * @return  boolean
 	 * @uses    Cookie::salt
 	 */
-	public static function set($name, $value, $expiration = NULL)
+	public static function set($name, $value, $lifetime = NULL)
 	{
-		if ($expiration === NULL)
+		if ($lifetime === NULL)
 		{
 			// Use the default expiration
-			$expiration = Cookie::$expiration;
+			$lifetime = Cookie::$expiration;
 		}
 
-		if ($expiration !== 0)
+		if ($lifetime !== 0)
 		{
 			// The expiration is expected to be a UNIX timestamp
-			$expiration += time();
+			$lifetime += static::_time();
 		}
 
 		// Add the salt to the cookie value
 		$value = Cookie::salt($name, $value).'~'.$value;
 
-		return setcookie($name, $value, $expiration, Cookie::$path, Cookie::$domain, Cookie::$secure, Cookie::$httponly);
+		return static::_setcookie($name, $value, $lifetime, Cookie::$path, Cookie::$domain, Cookie::$secure, Cookie::$httponly);
 	}
 
 	/**
@@ -131,7 +136,7 @@ class Kohana_Cookie {
 		unset($_COOKIE[$name]);
 
 		// Nullify the cookie and make it expire
-		return setcookie($name, NULL, -86400, Cookie::$path, Cookie::$domain, Cookie::$secure, Cookie::$httponly);
+		return static::_setcookie($name, NULL, -86400, Cookie::$path, Cookie::$domain, Cookie::$secure, Cookie::$httponly);
 	}
 
 	/**
@@ -139,8 +144,10 @@ class Kohana_Cookie {
 	 *
 	 *     $salt = Cookie::salt('theme', 'red');
 	 *
-	 * @param   string  $name   name of cookie
-	 * @param   string  $value  value of cookie
+	 * @param   string $name name of cookie
+	 * @param   string $value value of cookie
+	 *
+	 * @throws Kohana_Exception if Cookie::$salt is not configured
 	 * @return  string
 	 */
 	public static function salt($name, $value)
@@ -155,6 +162,37 @@ class Kohana_Cookie {
 		$agent = isset($_SERVER['HTTP_USER_AGENT']) ? strtolower($_SERVER['HTTP_USER_AGENT']) : 'unknown';
 
 		return sha1($agent.$name.$value.Cookie::$salt);
+	}
+
+	/**
+	 * Proxy for the native setcookie function - to allow mocking in unit tests so that they do not fail when headers
+	 * have been sent.
+	 *
+	 * @param string  $name
+	 * @param string  $value
+	 * @param integer $expire
+	 * @param string  $path
+	 * @param string  $domain
+	 * @param boolean $secure
+	 * @param boolean $httponly
+	 *
+	 * @return bool
+	 * @see setcookie
+	 */
+	protected static function _setcookie($name, $value, $expire, $path, $domain, $secure, $httponly)
+	{
+		return setcookie($name, $value, $expire, $path, $domain, $secure, $httponly);
+	}
+
+	/**
+	 * Proxy for the native time function - to allow mocking of time-related logic in unit tests
+	 *
+	 * @return int
+	 * @see    time
+	 */
+	protected static function _time()
+	{
+		return time();
 	}
 
 }

--- a/tests/kohana/CookieTest.php
+++ b/tests/kohana/CookieTest.php
@@ -11,13 +11,15 @@
  * @category   Tests
  * @author     Kohana Team
  * @author     Jeremy Bush <contractfrombelow@gmail.com>
- * @copyright  (c) 2008-2012 Kohana Team
+ * @author     Andrew Coulton <andrew@ingenerator.com>
+ * @copyright  (c) 2008-2014 Kohana Team
  * @license    http://kohanaframework.org/license
  */
 class Kohana_CookieTest extends Unittest_TestCase
 {
+	const UNIX_TIMESTAMP      = 1411040141;
+	const COOKIE_EXPIRATION   = 60;
 
-	protected $_default_salt = 'AdaoidadnA£ASDNadnaoiwdnawd';
 	/**
 	 * Sets up the environment
 	 */
@@ -26,152 +28,298 @@ class Kohana_CookieTest extends Unittest_TestCase
 	// @codingStandardsIgnoreEnd
 	{
 		parent::setUp();
+		Kohana_CookieTest_TestableCookie::$_mock_cookies_set = array();
 
-		Cookie::$salt = $this->_default_salt;
+		$this->setEnvironment(array(
+			'Cookie::$salt'   => 'some-random-salt',
+			'HTTP_USER_AGENT' => 'cli'
+		));
 	}
 
 	/**
-	 * Tears down the environment
+	 * Tests that cookies are set with the global path, domain, etc options.
+	 *
+	 * @covers Cookie::set
+	 */
+	public function test_set_creates_cookie_with_configured_cookie_options()
+	{
+		$this->setEnvironment(array(
+			'Cookie::$path'     => '/path',
+			'Cookie::$domain'   => 'my.domain',
+			'Cookie::$secure'   => TRUE,
+			'Cookie::$httponly' => FALSE,
+		));
+
+		Kohana_CookieTest_TestableCookie::set('cookie', 'value');
+
+		$this->assertSetCookieWith(array(
+			'path'       => '/path',
+			'domain'     => 'my.domain',
+			'secure'     => TRUE,
+			'httponly'   => FALSE
+		));
+	}
+
+	/**
+	 * Provider for test_set_calculates_expiry_from_lifetime
+	 *
+	 * @return array of $lifetime, $expect_expiry
+	 */
+	public function provider_set_calculates_expiry_from_lifetime()
+	{
+		return array(
+			array(NULL, self::COOKIE_EXPIRATION + self::UNIX_TIMESTAMP),
+			array(0,    0),
+			array(10,   10 + self::UNIX_TIMESTAMP),
+		);
+	}
+
+	/**
+	 * @param int $expiration
+	 * @param int $expect_expiry
+	 *
+	 * @dataProvider provider_set_calculates_expiry_from_lifetime
+	 * @covers Cookie::set
+	 */
+	public function test_set_calculates_expiry_from_lifetime($expiration, $expect_expiry)
+	{
+		$this->setEnvironment(array('Cookie::$expiration' => self::COOKIE_EXPIRATION));
+		Kohana_CookieTest_TestableCookie::set('foo', 'bar', $expiration);
+		$this->assertSetCookieWith(array('expire' => $expect_expiry));
+	}
+
+	/**
+	 * @covers Cookie::get
+	 */
+	public function test_get_returns_default_if_cookie_missing()
+	{
+		unset($_COOKIE['missing_cookie']);
+		$this->assertEquals('default', Cookie::get('missing_cookie', 'default'));
+	}
+
+	/**
+	 * @covers Cookie::get
+	 */
+	public function test_get_returns_value_if_cookie_present_and_signed()
+	{
+		Kohana_CookieTest_TestableCookie::set('cookie', 'value');
+		$cookie = Kohana_CookieTest_TestableCookie::$_mock_cookies_set[0];
+		$_COOKIE[$cookie['name']] = $cookie['value'];
+		$this->assertEquals('value', Cookie::get('cookie', 'default'));
+	}
+
+	/**
+	 * Provider for test_get_returns_default_without_deleting_if_cookie_unsigned
+	 *
+	 * @return array
+	 */
+	public function provider_get_returns_default_without_deleting_if_cookie_unsigned()
+	{
+		return array(
+			array('unsalted'),
+			array('un~salted'),
+		);
+	}
+
+	/**
+	 * Verifies that unsigned cookies are not available to the kohana application, but are not affected for other
+	 * consumers.
+	 *
+	 * @param string $unsigned_value
+	 *
+	 * @dataProvider provider_get_returns_default_without_deleting_if_cookie_unsigned
+	 * @covers Cookie::get
+	 */
+	public function test_get_returns_default_without_deleting_if_cookie_unsigned($unsigned_value)
+	{
+		$_COOKIE['cookie'] = $unsigned_value;
+		$this->assertEquals('default', Kohana_CookieTest_TestableCookie::get('cookie', 'default'));
+		$this->assertEquals($unsigned_value, $_COOKIE['cookie'], '$_COOKIE not affected');
+		$this->assertEmpty(Kohana_CookieTest_TestableCookie::$_mock_cookies_set, 'No cookies set or changed');
+	}
+
+	/**
+	 * If a cookie looks like a signed cookie but the signature no longer matches, it should be deleted.
+	 *
+	 * @covers Cookie::get
+	 */
+	public function test_get_returns_default_and_deletes_tampered_signed_cookie()
+	{
+		$_COOKIE['cookie'] = Cookie::salt('cookie', 'value').'~tampered';
+		$this->assertEquals('default', Kohana_CookieTest_TestableCookie::get('cookie', 'default'));
+		$this->assertDeletedCookie('cookie');
+	}
+
+	/**
+	 * @covers Cookie::delete
+	 */
+	public function test_delete_removes_cookie_from_globals_and_expires_cookie()
+	{
+		$_COOKIE['cookie'] = Cookie::salt('cookie', 'value').'~tampered';
+		$this->assertTrue(Kohana_CookieTest_TestableCookie::delete('cookie'));
+		$this->assertDeletedCookie('cookie');
+	}
+
+	/**
+	 * @covers Cookie::delete
+	 * @link    http://dev.kohanaframework.org/issues/3501
+	 * @link    http://dev.kohanaframework.org/issues/3020
+	 */
+	public function test_delete_does_not_require_configured_salt()
+	{
+		Cookie::$salt = NULL;
+		$this->assertTrue(Kohana_CookieTest_TestableCookie::delete('cookie'));
+		$this->assertDeletedCookie('cookie');
+	}
+
+	/**
+	 * @covers Cookie::salt
+	 * @expectedException Kohana_Exception
+	 */
+	public function test_salt_throws_with_no_configured_salt()
+	{
+		Cookie::$salt = NULL;
+		Cookie::salt('key', 'value');
+	}
+
+	/**
+	 * @covers Cookie::salt
+	 */
+	public function test_salt_creates_same_hash_for_same_values_and_state()
+	{
+		$name  = 'cookie';
+		$value = 'value';
+		$this->assertEquals(Cookie::salt($name, $value), Cookie::salt($name, $value));
+	}
+
+	/**
+	 * Provider for test_salt_creates_different_hash_for_different_data
+	 *
+	 * @return array
+	 */
+	public function provider_salt_creates_different_hash_for_different_data()
+	{
+		return array(
+			array(array('name' => 'foo', 'value' => 'bar', 'salt' => 'our-salt', 'user-agent' => 'Chrome'), array('name' => 'changed')),
+			array(array('name' => 'foo', 'value' => 'bar', 'salt' => 'our-salt', 'user-agent' => 'Chrome'), array('value' => 'changed')),
+			array(array('name' => 'foo', 'value' => 'bar', 'salt' => 'our-salt', 'user-agent' => 'Chrome'), array('salt' => 'changed-salt')),
+			array(array('name' => 'foo', 'value' => 'bar', 'salt' => 'our-salt', 'user-agent' => 'Chrome'), array('user-agent' => 'Firefox')),
+			array(array('name' => 'foo', 'value' => 'bar', 'salt' => 'our-salt', 'user-agent' => 'Chrome'), array('user-agent' => NULL)),
+		);
+	}
+
+	/**
+	 * @param array $first_args
+	 * @param array $changed_args
+	 *
+	 * @dataProvider provider_salt_creates_different_hash_for_different_data
+	 * @covers Cookie::salt
+	 */
+	public function test_salt_creates_different_hash_for_different_data($first_args, $changed_args)
+	{
+		$second_args = array_merge($first_args, $changed_args);
+		$hashes = array();
+		foreach (array($first_args, $second_args) as $args)
+		{
+			Cookie::$salt = $args['salt'];
+			$this->set_or_remove_http_user_agent($args['user-agent']);
+
+			$hashes[] = Cookie::salt($args['name'], $args['value']);
+		}
+
+		$this->assertNotEquals($hashes[0], $hashes[1]);
+	}
+
+	/**
+	 * Verify that a cookie was deleted from the global $_COOKIE array, and that a setcookie call was made to remove it
+	 * from the client.
+	 *
+	 * @param string $name
 	 */
 	// @codingStandardsIgnoreStart
-	public function tearDown()
+	protected function assertDeletedCookie($name)
 	// @codingStandardsIgnoreEnd
 	{
-		parent::tearDown();
-
-		Cookie::$salt = NULL;
+		$this->assertArrayNotHasKey($name, $_COOKIE);
+		// To delete the client-side cookie, Cookie::delete should send a new cookie with value NULL and expiry in the past
+		$this->assertSetCookieWith(array(
+			'name'     => $name,
+			'value'    => NULL,
+			'expire'   => -86400,
+			'path'     => Cookie::$path,
+			'domain'   => Cookie::$domain,
+			'secure'   => Cookie::$secure,
+			'httponly' => Cookie::$httponly
+		));
 	}
 
 	/**
-	 * Provides test data for test_set()
+	 * Verify that there was a single call to setcookie including the provided named arguments
 	 *
-	 * @return array
+	 * @param array $expected
 	 */
-	public function provider_set()
+	// @codingStandardsIgnoreStart
+	protected function assertSetCookieWith($expected)
+	// @codingStandardsIgnoreEnd
 	{
-		return array(
-			array('foo', 'bar', NULL, TRUE),
-			array('foo', 'bar', 10, TRUE),
-		);
+		$this->assertCount(1, Kohana_CookieTest_TestableCookie::$_mock_cookies_set);
+		$relevant_values = array_intersect_key(Kohana_CookieTest_TestableCookie::$_mock_cookies_set[0], $expected);
+		$this->assertEquals($expected, $relevant_values);
 	}
 
 	/**
-	 * Tests cookie::set()
+	 * Configure the $_SERVER[HTTP_USER_AGENT] environment variable for the test
 	 *
-	 * @test
-	 * @dataProvider provider_set
-	 * @covers cookie::set
-	 * @param mixed   $key      key to use
-	 * @param mixed   $value    value to set
-	 * @param mixed   $exp      exp to set
-	 * @param boolean $expected Output for cookie::set()
+	 * @param string $user_agent
 	 */
-	public function test_set($key, $value, $exp, $expected)
+	protected function set_or_remove_http_user_agent($user_agent)
 	{
-		if (headers_sent()) {
-			$this->markTestSkipped('Cannot test setting cookies as headers have already been sent');
-		}
-
-		$this->assertSame($expected, cookie::set($key, $value, $exp));
-	}
-
-	/**
-	 * Provides test data for test_get()
-	 *
-	 * @return array
-	 */
-	public function provider_get()
-	{
-		// setUp is called after the provider so we need to specify a
-		// salt here in order to use it in the provider
-		Cookie::$salt = $this->_default_salt;
-
-		return array(
-			array('foo', Cookie::salt('foo', 'bar').'~bar', 'bar'),
-			array('bar', Cookie::salt('foo', 'bar').'~bar', NULL),
-			array(NULL, Cookie::salt('foo', 'bar').'~bar', NULL),
-		);
-	}
-
-	/**
-	 * Tests cookie::set()
-	 *
-	 * @test
-	 * @dataProvider provider_get
-	 * @covers cookie::get
-	 * @param mixed   $key      key to use
-	 * @param mixed   $value    value to set
-	 * @param boolean $expected Output for cookie::get()
-	 */
-	public function test_get($key, $value, $expected)
-	{
-		if (headers_sent()) {
-			$this->markTestSkipped('Cannot test setting cookies as headers have already been sent');
-		}
-
-		// Force $_COOKIE
-		if ($key !== NULL)
+		if ($user_agent === NULL)
 		{
-			$_COOKIE[$key] = $value;
+			unset($_SERVER['HTTP_USER_AGENT']);
 		}
-
-		$this->assertSame($expected, cookie::get($key));
-	}
-
-	/**
-	 * Provides test data for test_delete()
-	 *
-	 * @return array
-	 */
-	public function provider_delete()
-	{
-		return array(
-			array('foo', TRUE),
-		);
-	}
-
-	/**
-	 * Tests cookie::delete()
-	 *
-	 * @test
-	 * @dataProvider provider_delete
-	 * @covers cookie::delete
-	 * @param mixed   $key      key to use
-	 * @param boolean $expected Output for cookie::delete()
-	 */
-	public function test_delete($key, $expected)
-	{
-		if (headers_sent()) {
-			$this->markTestSkipped('Cannot test setting cookies as headers have already been sent');
+		else
+		{
+			$_SERVER['HTTP_USER_AGENT'] = $user_agent;
 		}
-
-		$this->assertSame($expected, cookie::delete($key));
 	}
+}
+
+/**
+ * Class Kohana_CookieTest_TestableCookie wraps the cookie class to mock out the actual setcookie and time calls for
+ * unit testing.
+ */
+class Kohana_CookieTest_TestableCookie extends Cookie {
 
 	/**
-	 * Provides test data for test_salt()
-	 *
-	 * @return array
+	 * @var array setcookie calls that were made
 	 */
-	public function provider_salt()
+	public static $_mock_cookies_set = array();
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected static function _setcookie($name, $value, $expire, $path, $domain, $secure, $httponly)
 	{
-		return array(
-			array('foo', 'bar', 'b5773a6255d1deefc23f9f69bcc40fdc998e5802'),
+		self::$_mock_cookies_set[] = array(
+			'name'     => $name,
+			'value'    => $value,
+			'expire'   => $expire,
+			'path'     => $path,
+			'domain'   => $domain,
+			'secure'   => $secure,
+			'httponly' => $httponly
 		);
+
+		return TRUE;
 	}
 
 	/**
-	 * Tests cookie::salt()
-	 *
-	 * @test
-	 * @dataProvider provider_salt
-	 * @covers cookie::salt
-	 * @param mixed   $key      key to use
-	 * @param mixed   $value    value to salt with
-	 * @param boolean $expected Output for cookie::delete()
+	 * @return int
 	 */
-	public function test_salt($key, $value, $expected)
+	protected static function _time()
 	{
-		$this->assertSame($expected, cookie::salt($key, $value));
+		return Kohana_CookieTest::UNIX_TIMESTAMP;
 	}
+
 }

--- a/tests/kohana/CoreTest.php
+++ b/tests/kohana/CoreTest.php
@@ -18,6 +18,32 @@
  */
 class Kohana_CoreTest extends Unittest_TestCase
 {
+	protected $old_modules = array();
+
+	/**
+	 * Captures the module list as it was before this test
+	 *
+	 * @return null
+	 */
+	// @codingStandardsIgnoreStart
+	public function setUp()
+	// @codingStandardsIgnoreEnd
+	{
+		parent::setUp();
+		$this->old_modules = Kohana::modules();
+	}
+
+	/**
+	 * Restores the module list
+	 *
+	 * @return null
+	 */
+	// @codingStandardsIgnoreStart
+	public function tearDown()
+	// @codingStandardsIgnoreEnd
+	{
+		Kohana::modules($this->old_modules);
+	}
 
 	/**
 	 * Provides test data for test_sanitize()
@@ -157,35 +183,18 @@ class Kohana_CoreTest extends Unittest_TestCase
 	public function provider_message()
 	{
 		return array(
-			// $value, $result
-			array(':field must not be empty', 'validation', 'not_empty'),
-			array(
+			array('no_message_file', 'anything', 'default', 'default'),
+			array('no_message_file', NULL, 'anything', array()),
+			array('kohana_core_message_tests', 'bottom_only', 'anything', 'inherited bottom message'),
+			array('kohana_core_message_tests', 'cfs_replaced', 'anything', 'overriding cfs_replaced message'),
+			array('kohana_core_message_tests', 'top_only', 'anything', 'top only message'),
+			array('kohana_core_message_tests', 'missing', 'default', 'default'),
+			array('kohana_core_message_tests', NULL, 'anything',
 				array(
-					'alpha'         => ':field must contain only letters',
-					'alpha_dash'    => ':field must contain only numbers, letters and dashes',
-					'alpha_numeric' => ':field must contain only letters and numbers',
-					'color'         => ':field must be a color',
-					'credit_card'   => ':field must be a credit card number',
-					'date'          => ':field must be a date',
-					'decimal'       => ':field must be a decimal with :param2 places',
-					'digit'         => ':field must be a digit',
-					'email'         => ':field must be a email address',
-					'email_domain'  => ':field must contain a valid email domain',
-					'equals'        => ':field must equal :param2',
-					'exact_length'  => ':field must be exactly :param2 characters long',
-					'in_array'      => ':field must be one of the available options',
-					'ip'            => ':field must be an ip address',
-					'matches'       => ':field must be the same as :param2',
-					'min_length'    => ':field must be at least :param2 characters long',
-					'max_length'    => ':field must not exceed :param2 characters long',
-					'not_empty'     => ':field must not be empty',
-					'numeric'       => ':field must be numeric',
-					'phone'         => ':field must be a phone number',
-					'range'         => ':field must be within the range of :param2 to :param3',
-					'regex'         => ':field does not match the required format',
-					'url'           => ':field must be a url',
-				),
-				'validation', NULL,
+					'bottom_only'  => 'inherited bottom message',
+					'cfs_replaced' => 'overriding cfs_replaced message',
+					'top_only'     => 'top only message'
+				)
 			),
 		);
 	}
@@ -195,15 +204,18 @@ class Kohana_CoreTest extends Unittest_TestCase
 	 *
 	 * @test
 	 * @dataProvider provider_message
-	 * @covers Kohana::message
-	 * @param boolean $expected Output for Kohana::message
-	 * @param boolean $file     File to look in for Kohana::message
-	 * @param boolean $key      Key for Kohana::message
+	 * @covers       Kohana::message
+	 * @param string $file     to pass to Kohana::message
+	 * @param string $key      to pass to Kohana::message
+	 * @param string $default  to pass to Kohana::message
+	 * @param string $expected Output for Kohana::message
 	 */
-	public function test_message($expected, $file, $key)
+	public function test_message($file, $key, $default, $expected)
 	{
-		$this->markTestSkipped('This test is incredibly fragile and needs to be re-done');
-		$this->assertEquals($expected, Kohana::message($file, $key));
+		$test_path = realpath(dirname(__FILE__).'/../test_data/message_tests');
+		Kohana::modules(array('top' => "$test_path/top_module", 'bottom' => "$test_path/bottom_module"));
+
+		$this->assertEquals($expected, Kohana::message($file, $key, $default, $expected));
 	}
 
 	/**

--- a/tests/kohana/FeedTest.php
+++ b/tests/kohana/FeedTest.php
@@ -25,7 +25,8 @@ class Kohana_FeedTest extends Unittest_TestCase
 	{
 		return array(
 			// $source, $expected
-			array('http://dev.kohanaframework.org/projects/kohana3/activity.atom', 15),
+			array(realpath(__DIR__.'/../test_data/feeds/activity.atom'), array('Proposals (Political/Workflow) #4839 (New)', 'Proposals (Political/Workflow) #4782')),
+			array(realpath(__DIR__.'/../test_data/feeds/example.rss20'), array('Example entry')),
 		);
 	}
 
@@ -38,11 +39,15 @@ class Kohana_FeedTest extends Unittest_TestCase
 	 * @param string  $source   URL to test
 	 * @param integer $expected Count of items
 	 */
-	public function test_parse($source, $expected)
+	public function test_parse($source, $expected_titles)
 	{
-		$this->markTestSkipped('We don\'t go to the internet for tests.');
+		$titles = array();
+		foreach (Feed::parse($source) as $item)
+		{
+			$titles[] = $item['title'];
+		}
 
-		$this->assertEquals($expected, count(Feed::parse($source)));
+		$this->assertSame($expected_titles, $titles);
 	}
 
 	/**

--- a/tests/kohana/FileTest.php
+++ b/tests/kohana/FileTest.php
@@ -5,7 +5,7 @@
  *
  * @group kohana
  * @group kohana.core
- * @group kohana.core.url
+ * @group kohana.core.file
  *
  * @package    Kohana
  * @category   Tests
@@ -25,8 +25,7 @@ class Kohana_FileTest extends Unittest_TestCase
 	{
 		return array(
 			// $value, $result
-			array(Kohana::find_file('classes', 'File')),
-			array(Kohana::find_file('tests', 'test_data/github', 'png')),
+			array(Kohana::find_file('tests', 'test_data/github', 'png'), 'image/png'),
 		);
 	}
 
@@ -38,12 +37,10 @@ class Kohana_FileTest extends Unittest_TestCase
 	 * @param boolean $input  Input for File::mime
 	 * @param boolean $expected Output for File::mime
 	 */
-	public function test_mime($input)
+	public function test_mime($input, $expected)
 	{
-		$this->markTestSkipped(
-			'This test doesn\'t do anything useful!'
-		);
-		$this->assertSame(1, preg_match('/^(?:application|audio|image|message|multipart|text|video)\/[a-z.+0-9-]+$/i', File::mime($input)));
+		//@todo: File::mime coverage needs significant improvement or to be dropped for a composer package - it's a "horribly unreliable" method with very little testing
+		$this->assertSame($expected, File::mime($input));
 	}
 
 	/**

--- a/tests/kohana/ResponseTest.php
+++ b/tests/kohana/ResponseTest.php
@@ -172,27 +172,6 @@ class Kohana_ResponseTest extends Unittest_TestCase
 	}
 
 	/**
-	 * Tests that the headers are not sent by PHP in CLI mode
-	 *
-	 * @return void
-	 */
-	public function test_send_headers_cli()
-	{
-		if (headers_sent())
-		{
-			$this->markTestSkipped('Cannot test this feature as headers have already been sent!');
-		}
-
-		$content_type = 'application/json';
-		$response = new Response;
-		$response->headers('content-type', $content_type)
-			->send_headers();
-
-		$this->assertFalse(headers_sent());
-
-	}
-
-	/**
 	 * Test the content type is sent when set
 	 * 
 	 * @test

--- a/tests/kohana/SecurityTest.php
+++ b/tests/kohana/SecurityTest.php
@@ -67,17 +67,6 @@ class Kohana_SecurityTest extends Unittest_TestCase
 	 */
 	public function provider_csrf_token()
 	{
-		// Unfortunately this data provider has to use the session in order to 
-		// generate its data. If headers have already been sent then this method
-		// throws an error, even if the test is does not run.  If we return an 
-		// empty array then this also causes an error, so the only way to get 
-		// around it is to return an array of misc data and have the test skip 
-		// if headers have been sent. It's annoying this hack has to be 
-		// implemented, but the security code isn't exactly brilliantly 
-		// implemented. Ideally we'd be able to inject a session instance
-		if (headers_sent())
-			return array(array('', '', 0));
-
 		$array = array();
 		for ($i = 0; $i <= 4; $i++)
 		{
@@ -96,10 +85,7 @@ class Kohana_SecurityTest extends Unittest_TestCase
 	 */
 	public function test_csrf_token($expected, $input, $iteration)
 	{
-		if (headers_sent()) {
-			$this->markTestSkipped('Headers have already been sent, session not available');
-		}
-
+		//@todo: the Security::token tests need to be reviewed to check how much of the logic they're actually covering
 		Security::$token_name = 'token_'.$iteration;
 		$this->assertSame(TRUE, $input);
 		$this->assertSame($expected, Security::token(FALSE));

--- a/tests/kohana/SessionTest.php
+++ b/tests/kohana/SessionTest.php
@@ -95,20 +95,14 @@ class Kohana_SessionTest extends Unittest_TestCase
 	 */
 	public function test_constructor_loads_session_with_session_id()
 	{
-		$this->markTestIncomplete(
-			'Need to work out why constructor is not being called'
-		);
-
 		$config = array();
 		$session_id = 'lolums';
 
 		// Don't auto-call constructor, we need to setup the mock first
-		$session = $this->getMockForAbstractClass(
-			'Session',
-			array(),
-			'',
-			FALSE
-		);
+		$session = $this->getMockBuilder('Session')
+			->disableOriginalConstructor()
+			->setMethods(array('read'))
+			->getMockForAbstractClass();
 
 		$session
 			->expects($this->once())

--- a/tests/test_data/feeds/activity.atom
+++ b/tests/test_data/feeds/activity.atom
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Kohana v3.x: Activity</title>
+  <link href="http://dev.kohanaframework.org/projects/kohana3/activity.atom" rel="self"/>
+  <link href="http://dev.kohanaframework.org/projects/kohana3/activity" rel="alternate"/>
+  <id>http://dev.kohanaframework.org/</id>
+  <icon>http://dev.kohanaframework.org/favicon.ico?1392677580</icon>
+  <updated>2014-08-28T01:52:12Z</updated>
+  <author>
+    <name>Kohana Development</name>
+  </author>
+  <generator uri="http://www.redmine.org/">
+Redmine  </generator>
+  <entry>
+    <title>Proposals (Political/Workflow) #4839 (New)</title>
+    <link href="http://dev.kohanaframework.org/issues/4839" rel="alternate"/>
+    <id>http://dev.kohanaframework.org/issues/4839</id>
+    <updated>2014-08-28T01:52:12Z</updated>
+    <author>
+      <name>Guillaume Poirier-Morency</name>
+      <email>guillaumepoiriermorency@gmail.com</email>
+    </author>
+    <content type="html">
+&lt;p&gt;I have a prototype here &lt;a class="external" href="https://github.com/arteymix/kohana-makefile"&gt;https://github.com/arteymix/kohana-makefile&lt;/a&gt;&lt;/p&gt;
+
+
+	&lt;p&gt;The tool is very useful for settings permissions and running tests.&lt;/p&gt;
+
+
+	&lt;p&gt;I think we should consider having a good make tool in the sample application for the 3.4.*.&lt;/p&gt;    </content>
+  </entry>
+  <entry>
+    <title>Proposals (Political/Workflow) #4782</title>
+    <link href="http://dev.kohanaframework.org/issues/4782#change-17279" rel="alternate"/>
+    <id>http://dev.kohanaframework.org/issues/4782#change-17279</id>
+    <updated>2014-08-28T01:44:26Z</updated>
+    <author>
+      <name>Guillaume Poirier-Morency</name>
+      <email>guillaumepoiriermorency@gmail.com</email>
+    </author>
+    <content type="html">
+&lt;p&gt;Moving to composer is a nice idea. This will allow Kohana modules to define a wide range of dependencies.&lt;/p&gt;
+
+
+	&lt;p&gt;Although, I think that modules designed specifically for Kohana should end in modules and external libraries in application/vendor. This makes a clear dinsinction between what gets autoloaded by the CFS and what gets loaded by composer. Technically, we add "vendor-dir": "application/vendor" in "config" in composer.json.&lt;/p&gt;
+
+
+	&lt;p&gt;Then, only add a line after the modules loading in bootstrap.php&lt;/p&gt;
+
+
+&lt;pre&gt;
+// Autoloading composer packages
+require Kohana::find_file('vendor', 'autoload');
+&lt;/pre&gt;
+
+	&lt;p&gt;This is pretty much what I do right now. This doesn't break anything and allow a full access to composer.&lt;/p&gt;    </content>
+  </entry>
+</feed>

--- a/tests/test_data/feeds/example.rss20
+++ b/tests/test_data/feeds/example.rss20
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0">
+<channel>
+ <title>RSS Title</title>
+ <description>This is an example of an RSS feed</description>
+ <link>http://www.example.com/main.html</link>
+ <lastBuildDate>Mon, 06 Sep 2010 00:01:00 +0000 </lastBuildDate>
+ <pubDate>Sun, 06 Sep 2009 16:20:00 +0000</pubDate>
+ <ttl>1800</ttl>
+
+ <item>
+  <title>Example entry</title>
+  <description>Here is some text containing an interesting description.</description>
+  <link>http://www.example.com/blog/post/1</link>
+  <guid>7bd204c6-1655-4c27-aeee-53f933c5395f</guid>
+  <pubDate>Sun, 06 Sep 2009 16:20:00 +0000</pubDate>
+ </item>
+
+</channel>
+</rss>

--- a/tests/test_data/message_tests/bottom_module/messages/kohana_core_message_tests.php
+++ b/tests/test_data/message_tests/bottom_module/messages/kohana_core_message_tests.php
@@ -1,0 +1,6 @@
+<?php
+// See the Kohana_CoreTest tests for Kohana::message
+return array(
+	'bottom_only'   => 'inherited bottom message',
+	'cfs_replaced'  => 'inherited cfs_replaced message',
+);

--- a/tests/test_data/message_tests/top_module/messages/kohana_core_message_tests.php
+++ b/tests/test_data/message_tests/top_module/messages/kohana_core_message_tests.php
@@ -1,0 +1,6 @@
+<?php
+// See the Kohana_CoreTest tests for Kohana::message
+return array(
+	'top_only'      => 'top only message',
+	'cfs_replaced'  => 'overriding cfs_replaced message',
+);


### PR DESCRIPTION
This pull reinstates and improves tests that were being skipped on CI as discussed in #547, in particular:
- Internally refactoring the Cookie class so tests can run regardless of headers being sent or not
- Rewriting the Cookie tests so they actually cover the setting / signing / salting logic - the original assertions were relatively meaningless.
- Rewriting the tests for Kohana::message to cover more cases and be independent of any other modules or message files
- Rewriting the tests for Feed::parse to test parsing of local sample Atom and RSS2.0 feeds.
- Removing a long-since invalid test that Response::send_headers does not send headers in CLI (it does, and has since 3.2.0).

There are now no skipped tests on kohana/core.

NB that this PR depends on the changes in #548, once that's merged I'll rebase this.

@enov are you happy that the refactorings here are all safe to release in the 3.3 bugfix series?
