### PR TITLE
R3931 - Register exit(1) as a shutdown function, to allow Kohana shutdown properly

### DIFF
--- a/classes/Kohana/Kohana/Exception.php
+++ b/classes/Kohana/Kohana/Exception.php
@@ -88,13 +88,8 @@ class Kohana_Kohana_Exception extends Exception {
 		// Send the response to the browser
 		echo $response->send_headers()->body();
 
-		// Shutdown closure
-		$shutdown_exit1 = function() {
-			exit(1);
-		};
-
-		// Register the closure
-		register_shutdown_function($shutdown_exit1);
+		// Register shutdown function exit(1)
+		register_shutdown_function('exit', 1);
 
 		// Return
 		return TRUE;

--- a/classes/Kohana/Kohana/Exception.php
+++ b/classes/Kohana/Kohana/Exception.php
@@ -88,7 +88,13 @@ class Kohana_Kohana_Exception extends Exception {
 		// Send the response to the browser
 		echo $response->send_headers()->body();
 
-		exit(1);
+		// Shutdown closure
+		$shutdown_exit1 = function() {
+			exit(1);
+		};
+
+		// Register the closure
+		register_shutdown_function($shutdown_exit1);
 	}
 
 	/**

--- a/classes/Kohana/Kohana/Exception.php
+++ b/classes/Kohana/Kohana/Exception.php
@@ -95,6 +95,9 @@ class Kohana_Kohana_Exception extends Exception {
 
 		// Register the closure
 		register_shutdown_function($shutdown_exit1);
+
+		// Return
+		return TRUE;
 	}
 
 	/**


### PR DESCRIPTION
Originally submitted by @zombor in [R3931](http://dev.kohanaframework.org/issues/3931) that `Kohana_Exception::handler` should `exit(1)`.

Also related to [R4794](http://dev.kohanaframework.org/issues/4794) and to its duplicate [R4275](http://dev.kohanaframework.org/issues/4275) in version 3.2, however these are not affected in version 3.3 because of the availability and use of `Kohana_Exception::_handler` (with underscore).

Through a shutdown function, we will postpone the `exit(1)` after Kohana shutdowns properly, i.e. after `Kohana::shutdown_handler`.

Ref #547. Please review and merge. Thanks!
