### PR TITLE
Don't set empty body on external curl requests [Fixes R4791]

### DIFF
--- a/classes/Kohana/Request/Client/Curl.php
+++ b/classes/Kohana/Request/Client/Curl.php
@@ -34,7 +34,10 @@ class Kohana_Request_Client_Curl extends Request_Client_External {
 		// if using a request other than POST. PUT does support this method
 		// and DOES NOT require writing data to disk before putting it, if
 		// reading the PHP docs you may have got that impression. SdF
-		$options[CURLOPT_POSTFIELDS] = $request->body();
+		// This will also add a Content-Type: application/x-www-form-urlencoded header unless you override it
+		if ($body = $request->body()) {
+			$options[CURLOPT_POSTFIELDS] = $body;
+		}
 
 		// Process headers
 		if ($headers = $request->headers())


### PR DESCRIPTION
Originally opened by @acoulton in [R4791](http://dev.kohanaframework.org/issues/4791) and based on #403 

> When the CURLOPT_POSTFIELDS option is present, curl adds a
> default Content-Type header which can be changed but not
> removed, causing authentication problems with signed requests.
> The option should only be set if a request body is being sent.

Ref #547. Please review and merge :)

Thanks!
