### PR TITLE
Xdebug returns `dynamic` and `static` instead of using `->` and `::`

### DIFF
--- a/classes/Kohana/Kohana/Exception.php
+++ b/classes/Kohana/Kohana/Exception.php
@@ -217,6 +217,16 @@ class Kohana_Kohana_Exception extends Exception {
 							$frame['type'] = '??';
 						}
 
+						// Xdebug returns the words 'dynamic' and 'static' instead of using '->' and '::' symbols
+						if ('dynamic' === $frame['type'])
+						{
+							$frame['type'] = '->';
+						}
+						elseif ('static' === $frame['type'])
+						{
+							$frame['type'] = '::';
+						}
+
 						// XDebug also has a different name for the parameters array
 						if (isset($frame['params']) AND ! isset($frame['args']))
 						{


### PR DESCRIPTION
When debugging a Kohana application through error view, things starts to be confusing as the names of the classes are concatenated to the method names with words `dynamic` and `static`. See the images:

Before:
![before](https://cloud.githubusercontent.com/assets/4045110/4355543/d09e82ca-424d-11e4-94b8-8796118dd718.png)

After:
![after](https://cloud.githubusercontent.com/assets/4045110/4355575/15bad5fc-424e-11e4-827d-5b57f2c9779d.png)

So I borrowed (back) some code from here:
https://github.com/symfony/symfony/pull/5863/files#diff-230e5606e6f592c8b8973fc758d112c8R185

As it seems to me that that code itself was borrowing some code from here:
https://github.com/kohana/core/pull/194/files#diff-6e70141994f9975e43722712df1e9611R201

Please review and merge.

Cheers!
