### PR TITLE
Add UTF-8 support for Text::ucfirst

### DIFF
--- a/classes/Kohana/Text.php
+++ b/classes/Kohana/Text.php
@@ -238,14 +238,24 @@ class Kohana_Text {
 	 *
 	 *      $str = Text::ucfirst('content-type'); // returns "Content-Type"
 	 *
-	 * @param   string  $string     string to transform
-	 * @param   string  $delimiter  delimiter to use
-	 * @return  string
+	 * @param string $string string to transform
+	 * @param string $delimiter delimiter to use
+	 * @return string
+	 * @uses UTF8::substr
+	 * @uses UTF8::strtoupper
+	 * @uses UTF8::strlen
 	 */
 	public static function ucfirst($string, $delimiter = '-')
 	{
+		// ucfirst closure with UTF-8 support
+		$utf8_ucfirst = function($word)
+		{
+			$first_char = UTF8::substr($word, 0, 1);
+			$remaining = UTF8::substr($word, 1, UTF8::strlen($word));
+			return UTF8::strtoupper($first_char) . UTF8::strtolower($remaining);
+		};
 		// Put the keys back the Case-Convention expected
-		return implode($delimiter, array_map('ucfirst', explode($delimiter, $string)));
+		return implode($delimiter, array_map($utf8_ucfirst, explode($delimiter, $string)));
 	}
 
 	/**

--- a/tests/kohana/TextTest.php
+++ b/tests/kohana/TextTest.php
@@ -197,6 +197,30 @@ class Kohana_TextTest extends Unittest_TestCase
 	}
 
 	/**
+	 * Provides test data for test_ucfirst
+	 *
+	 * @return array Test data
+	 */
+	public function provider_ucfirst()
+	{
+		return array(
+			array('Content-Type', 'content-type', '-'),
+			array('Բարեւ|Ձեզ', 'բարեւ|ձեզ', '|'),
+		);
+	}
+	
+	/**
+	 * Covers Text::ucfirst()
+	 *
+	 * @test
+	 * @dataProvider provider_ucfirst
+	 */
+	public function test_ucfirst($expected, $string, $delimiter)
+	{
+		$this->assertSame($expected, Text::ucfirst($string, $delimiter));
+	}
+
+	/**
 	 * Provides test data for test_reducde_slashes()
 	 *
 	 * @returns array Array of test data


### PR DESCRIPTION
By using UTF8::substr, UTF8::strtoupper, UTF8::strlen

Thanks to @Come2Daddy PR #521
