### PR TITLE
Add UTF8 support to Text::ucfirst()

### DIFF
--- a/classes/Kohana/Text.php
+++ b/classes/Kohana/Text.php
@@ -240,12 +240,13 @@ class Kohana_Text {
 	 *
 	 * @param   string  $string     string to transform
 	 * @param   string  $delimiter  delimiter to use
+	 * @uses    UTF8::ucfirst
 	 * @return  string
 	 */
 	public static function ucfirst($string, $delimiter = '-')
 	{
 		// Put the keys back the Case-Convention expected
-		return implode($delimiter, array_map('ucfirst', explode($delimiter, $string)));
+		return implode($delimiter, array_map('UTF8::ucfirst', explode($delimiter, $string)));
 	}
 
 	/**

--- a/tests/kohana/TextTest.php
+++ b/tests/kohana/TextTest.php
@@ -197,6 +197,30 @@ class Kohana_TextTest extends Unittest_TestCase
 	}
 
 	/**
++	 * Provides test data for test_ucfirst
++	 *
++	 * @return array Test data
++	 */
++	public function provider_ucfirst()
++	{
++		return array(
++			array('Content-Type', 'content-type', '-'),
++			array('Բարեւ|Ձեզ', 'բարեւ|ձեզ', '|'),
++		);
++	}
++
++	/**
++	 * Covers Text::ucfirst()
++	 *
++	 * @test
++	 * @dataProvider provider_ucfirst
++	 */
++	public function test_ucfirst($expected, $string, $delimiter)
++	{
++		$this->assertSame($expected, Text::ucfirst($string, $delimiter));
++	}
+
+	/**
 	 * Provides test data for test_reducde_slashes()
 	 *
 	 * @returns array Array of test data


### PR DESCRIPTION
Uses UTF8::ucfirst()
