### PR TITLE
Load controllers with FQCN.

### DIFF
--- a/classes/Kohana/Request/Client/Internal.php
+++ b/classes/Kohana/Request/Client/Internal.php
@@ -45,6 +45,12 @@ class Kohana_Request_Client_Internal extends Request_Client {
 			$prefix .= str_replace(array('\\', '/'), '_', trim($directory, '/')).'_';
 		}
 
+		// Use the FQCN to load the Controller
+		if (substr($controller, 0, 1) === '\\')
+		{
+			$prefix = '';
+		}
+
 		if (Kohana::$profiling)
 		{
 			// Set the benchmark name

--- a/classes/Kohana/Route.php
+++ b/classes/Kohana/Route.php
@@ -351,6 +351,14 @@ class Kohana_Route {
 			return $this->_defaults;
 		}
 
+		if (isset($defaults['controller']) AND substr($defaults['controller'], 0, 1) === '\\')
+		{
+			if (isset($defaults['directory']))
+			{
+				throw new Kohana_Exception('Route directory should not be set when the controller is a FQCN.');
+			}
+		}
+
 		$this->_defaults = $defaults;
 
 		return $this;

--- a/guide/kohana/routing.md
+++ b/guide/kohana/routing.md
@@ -68,6 +68,8 @@ If a key in a route is optional (or not present in the route), you can provide a
 
 [!!] The `controller` and `action` key must always have a value, so they either need to be required in your route (not inside of parentheses) or have a default value provided.
 
+[!!] When using the `Fully Qualified Class Name` or `FQCN` for the `controller` you aren't allowed to set `directory`. The reason is that when using the `FQCN` the autoloader will look for the right location of the file.
+
 [!!] Kohana automatically converts controllers to follow the standard naming convention. For example /blog/view/123 would look for the controller Controller_Blog in classes/Controller/Blog.php and trigger the action_view() method on it.
 
 In the default route, all the keys are optional, and the controller and action are given a default.   If we called an empty url, the defaults would fill in and `Controller_Welcome::action_index()` would be called.  If we called `foobar` then only the default for action would be used, so it would call `Controller_Foobar::action_index()` and finally, if we called `foobar/baz` then neither default would be used and `Controller_Foobar::action_baz()` would be called.
@@ -79,6 +81,24 @@ You can also use defaults to set a key that isn't in the route at all.
 TODO: example of either using directory or controller where it isn't in the route, but set by defaults
 
 ### Directory
+
+### Selecting controllers by their FQCN
+
+You can also use the `Fully Qualified Class Name` to find the controller. It will enable you to store your controllers at the location of your choosing as long as the autoloader is able to find it.
+
+When using `FQCN` controllers the controllers will not use any prefixed or affixes so `\Acme\Module\Controller\Demo` will point to `class Demo {}` and `\Acme\Module\Controller\DemoController` will point to `class DemoController {}`. You will have full flexibility on how you name you classes.
+
+Because of the autoloading the `directory` default value will not work and setting it will result in a `Exception` being thrown.
+
+An example of a `FQCN` route:
+
+    /*
+     * Routes using FQCN
+     */
+    Route::set('default', 'controller-name/<action>')
+        ->defaults(array(
+            'controller' => '\Acme\Module\Controller\DemoController'
+        ));
 
 ## Route Filters
 

--- a/tests/kohana/RouteTest.php
+++ b/tests/kohana/RouteTest.php
@@ -522,6 +522,24 @@ class Kohana_RouteTest extends Unittest_TestCase
 	}
 
 	/**
+	 * When using a FQCN test if the directory is not set else throw an exception
+	 *
+	 * @test
+	 * @covers Route::defaults
+	 */
+	public function test_defaults_throws_exception_when_setting_fqcn_and_directory()
+	{
+		$this->setExpectedException('Kohana_Exception', 'Route directory should not be set when the controller is a FQCN.');
+
+		$route = new Route('(<controller>(/<action>(/<id>)))');
+		$route->defaults(array(
+			'directory'  => 'directory/path',
+			'controller' => '\FQCN\Class\Name',
+			'action'     => 'index'
+		));
+	}
+
+	/**
 	 * Provider for test_required_parameters_are_needed
 	 *
 	 * @return array


### PR DESCRIPTION
Fixes part of #571 

It's BC and works by the following syntax:

``` php
Route::set('default', 'controller-name/<action>')
    ->defaults(array(
        'controller' => '\Acme\Module\Controller\Demo'
    ));
```

The <controller> syntax won't work but I think that when using FQCN you should not use variable controller parameters.

@acoulton or @enov can you please review if this is okay?
