### PR TITLE
Add reference to CONTRIBUTING, reduce chances for out of sync copies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+Please refer to the CONTRIBUTING file located under the [kohana](https://github.com/kohana/kohana) repo.


### PR DESCRIPTION
Referring to the main CONTRIBUTING instead of adding copies allows
us to track one and not have to deal with the other versions running
out of sync.

Can't seem to link to the default current branch without
specifying exactly the version, so going to refer to where
it can be found instead of adding in permalink.
