### PR TITLE
Update Cookie.php :: fix error on quotes

### DIFF
--- a/classes/Kohana/Cookie.php
+++ b/classes/Kohana/Cookie.php
@@ -74,6 +74,7 @@ class Kohana_Cookie {
 			if (Security::slow_equals(Cookie::salt($key, $value), $hash))
 			{
 				// Cookie signature is valid
+				$value = str_replace('\\', '', $value); //deleting slashes (json, etc)
 				return $value;
 			}
 
@@ -117,7 +118,7 @@ class Kohana_Cookie {
 		}
 
 		// Add the salt to the cookie value
-		$value = Cookie::salt($name, $value).'~'.$value;
+		$value = Cookie::salt($name, addslashes($value)).'~'.$value; //add slashes(json support, etc)
 
 		return static::_setcookie($name, $value, $lifetime, Cookie::$path, Cookie::$domain, Cookie::$secure, Cookie::$httponly);
 	}


### PR DESCRIPTION
``` php
$array['test']['0'] = 'value2';
$array['test']['1'] = 'value2';
Cookie::set('test', json_encode($array));
```

after reload

``` php
Cookie::get('test', NULL); //NULL
```

== or ==

``` php
Cookie::set('test', 'Data with "quotes"');
```

after reload 

``` php
Cookie::get('test', NULL); //NULL
```

Just try write this date on cookie. The data will be recorded in set(), but removed when reading Cookie::get() after the Security::slow_equals() - hashes does not match

//HARDCODE MODE OFF
