### PR TITLE
Cast get_magic_quotes_gpc() result to bool

### DIFF
--- a/classes/Kohana/Core.php
+++ b/classes/Kohana/Core.php
@@ -322,7 +322,7 @@ class Kohana_Core {
 		}
 
 		// Determine if the extremely evil magic quotes are enabled
-		Kohana::$magic_quotes = get_magic_quotes_gpc();
+		Kohana::$magic_quotes = (bool) get_magic_quotes_gpc();
 
 		// Sanitize all request variables
 		$_GET    = Kohana::sanitize($_GET);


### PR DESCRIPTION
`Kohana::$magic_quotes` needs to be a boolean
for proper GPC sanitization

Should fix issue #601, Thanks @amberlex78.
