### PR TITLE
support for PECL HTTP extension v2

### DIFF
--- a/classes/Kohana/HTTP.php
+++ b/classes/Kohana/HTTP.php
@@ -95,7 +95,10 @@ abstract class Kohana_HTTP {
 		if (extension_loaded('http'))
 		{
 			// Use the fast method to parse header string
-			return new HTTP_Header(http_parse_headers($header_string));
+			$headers = version_compare(phpversion('http'), '2.0.0', '>=') ?
+				\http\Header::parse($header_string) :
+				http_parse_headers($header_string);
+			return new HTTP_Header($headers);
 		}
 
 		// Otherwise we use the slower PHP parsing
@@ -160,7 +163,10 @@ abstract class Kohana_HTTP {
 		elseif (extension_loaded('http'))
 		{
 			// Return the much faster method
-			return new HTTP_Header(http_get_request_headers());
+			$headers = version_compare(phpversion('http'), '2.0.0', '>=') ?
+				\http\Env::getRequestHeader() :
+				http_get_request_headers();
+			return new HTTP_Header($headers);
 		}
 
 		// Setup the output

--- a/classes/Kohana/Response.php
+++ b/classes/Kohana/Response.php
@@ -604,7 +604,10 @@ class Kohana_Response implements HTTP_Response {
 		{
 			if (extension_loaded('http'))
 			{
-				$this->_header['set-cookie'] = http_build_cookie($this->_cookies);
+				$cookies = version_compare(phpversion('http'), '2.0.0', '>=') ?
+					(string) new \http\Cookie($this->_cookies) :
+					http_build_cookie($this->_cookies);
+				$this->_header['set-cookie'] = $cookies;
 			}
 			else
 			{


### PR DESCRIPTION
PECL HTTP extension v2 introduced a new namespaced API that is not compatible with v1 API
