### PR TITLE
Use a dummy controller in RequestTest::test_param

### DIFF
--- a/tests/kohana/RequestTest.php
+++ b/tests/kohana/RequestTest.php
@@ -130,8 +130,10 @@ class Kohana_RequestTest extends Unittest_TestCase
 
 		// We need to execute the request before it has matched a route
 		$response = $request->execute();
+		$controller = new Controller_Kohana_RequestTest_Dummy($request, $response);
 
 		$this->assertSame(200, $response->status());
+		$this->assertSame($controller->get_expected_response(), $response->body());
 		$this->assertArrayHasKey('id', $request->param());
 		$this->assertArrayNotHasKey('foo', $request->param());
 		$this->assertEquals($request->uri(), $uri);
@@ -152,8 +154,10 @@ class Kohana_RequestTest extends Unittest_TestCase
 
 		// We need to execute the request before it has matched a route
 		$response = $request->execute();
+		$controller = new Controller_Kohana_RequestTest_Dummy($request, $response);
 
 		$this->assertSame(200, $response->status());
+		$this->assertSame($controller->get_expected_response(), $response->body());
 		$this->assertSame('kohana_requesttest_dummy', $request->param('uri'));
 	}
 
@@ -724,7 +728,7 @@ class Kohana_RequestTest extends Unittest_TestCase
 
 } // End Kohana_RequestTest
 
-class Controller_Kohana_RequestdTest_Dummy extends Controller
+class Controller_Kohana_RequestTest_Dummy extends Controller
 {
 	// hard coded dummy response
 	protected $dummy_response = "this is a dummy response";
@@ -734,7 +738,7 @@ class Controller_Kohana_RequestdTest_Dummy extends Controller
 		$this->response->body($this->dummy_response);
 	}
 
-	public function get_dummy_response()
+	public function get_expected_response()
 	{
 		return $this->dummy_response;
 	}

--- a/tests/kohana/RequestTest.php
+++ b/tests/kohana/RequestTest.php
@@ -125,15 +125,11 @@ class Kohana_RequestTest extends Unittest_TestCase
 	{
 		$route = new Route('(<controller>(/<action>(/<id>)))');
 
-		$uri = 'foo/bar/id';
+		$uri = 'kohana_requesttest_dummy/foobar/some_id';
 		$request = Request::factory($uri, NULL, TRUE, array($route));
 
 		// We need to execute the request before it has matched a route
-		try
-		{
-			$request->execute();
-		}
-		catch (Exception $e) {}
+		$request->execute();
 
 		$this->assertArrayHasKey('id', $request->param());
 		$this->assertArrayNotHasKey('foo', $request->param());
@@ -150,17 +146,13 @@ class Kohana_RequestTest extends Unittest_TestCase
 		$this->assertArrayNotHasKey('route', $params);
 
 		$route = new Route('(<uri>)', array('uri' => '.+'));
-		$route->defaults(array('controller' => 'foobar', 'action' => 'index'));
-		$request = Request::factory('foobar', NULL, TRUE, array($route));
+		$route->defaults(array('controller' => 'kohana_requesttest_dummy', 'action' => 'foobar'));
+		$request = Request::factory('kohana_requesttest_dummy', NULL, TRUE, array($route));
 
 		// We need to execute the request before it has matched a route
-		try
-		{
-			$request->execute();
-		}
-		catch (Exception $e) {}
+		$request->execute();
 
-		$this->assertSame('foobar', $request->param('uri'));
+		$this->assertSame('kohana_requesttest_dummy', $request->param('uri'));
 	}
 
 	/**
@@ -730,9 +722,9 @@ class Kohana_RequestTest extends Unittest_TestCase
 
 } // End Kohana_RequestTest
 
-class Controller_Kohana_RequestTest_Dummy extends Controller
+class Controller_Kohana_RequestdTest_Dummy extends Controller
 {
-	public function action_index()
+	public function action_foobar()
 	{
 	
 	}

--- a/tests/kohana/RequestTest.php
+++ b/tests/kohana/RequestTest.php
@@ -129,8 +129,9 @@ class Kohana_RequestTest extends Unittest_TestCase
 		$request = Request::factory($uri, NULL, TRUE, array($route));
 
 		// We need to execute the request before it has matched a route
-		$request->execute();
+		$response = $request->execute();
 
+		$this->assertSame(200, $response->status());
 		$this->assertArrayHasKey('id', $request->param());
 		$this->assertArrayNotHasKey('foo', $request->param());
 		$this->assertEquals($request->uri(), $uri);
@@ -150,8 +151,9 @@ class Kohana_RequestTest extends Unittest_TestCase
 		$request = Request::factory('kohana_requesttest_dummy', NULL, TRUE, array($route));
 
 		// We need to execute the request before it has matched a route
-		$request->execute();
+		$response = $request->execute();
 
+		$this->assertSame(200, $response->status());
 		$this->assertSame('kohana_requesttest_dummy', $request->param('uri'));
 	}
 
@@ -724,8 +726,17 @@ class Kohana_RequestTest extends Unittest_TestCase
 
 class Controller_Kohana_RequestdTest_Dummy extends Controller
 {
+	// hard coded dummy response
+	protected $dummy_response = "this is a dummy response";
+
 	public function action_foobar()
 	{
-	
+		$this->response->body($this->dummy_response);
 	}
+
+	public function get_dummy_response()
+	{
+		return $this->dummy_response;
+	}
+
 } // End Kohana_RequestTest


### PR DESCRIPTION
A cleaner way to test parameters passed by `Route` to `Request`:
Use a dummy controller instead of the empty `try...catch` that
was trying to silence "controller not found" 404 exceptions.
