### PR TITLE
RouteTest: Request mock needs mocking of `method` method

### DIFF
--- a/tests/kohana/RouteTest.php
+++ b/tests/kohana/RouteTest.php
@@ -268,11 +268,7 @@ class Kohana_RouteTest extends Unittest_TestCase
 		$route = new Route($uri);
 
 		// Mock a request class with the $match uri
-		$stub = $this->getMock('Request', array('uri'), array($match));
-		$stub->expects($this->any())
-			->method('uri')
-			// Request::uri() called by Route::matches() will return $match
-			->will($this->returnValue($match));
+		$stub = $this->get_request_mock($match);
 
 		$this->assertSame(FALSE, $route->matches($stub));
 	}
@@ -308,11 +304,7 @@ class Kohana_RouteTest extends Unittest_TestCase
 		$route = new Route($uri);
 
 		// Mock a request class with the $m uri
-		$request = $this->getMock('Request', array('uri'), array($m));
-		$request->expects($this->any())
-			->method('uri')
-			// Request::uri() called by Route::matches() will return $m
-			->will($this->returnValue($m));
+		$request = $this->get_request_mock($m);
 
 		$matches = $route->matches($request);
 
@@ -381,10 +373,7 @@ class Kohana_RouteTest extends Unittest_TestCase
 		$this->assertSame($defaults, $route->defaults());
 
 		// Mock a request class
-		$request = $this->getMock('Request', array('uri'), array($default_uri));
-		$request->expects($this->any())
-			->method('uri')
-			->will($this->returnValue($default_uri));
+		$request = $this->get_request_mock($default_uri);
 
 		$matches = $route->matches($request);
 
@@ -550,28 +539,19 @@ class Kohana_RouteTest extends Unittest_TestCase
 		$route = new Route($uri);
 
 		// Mock a request class that will return empty uri
-		$request = $this->getMock('Request', array('uri'), array(''));
-		$request->expects($this->any())
-			->method('uri')
-			->will($this->returnValue(''));
+		$request = $this->get_request_mock('');
 
 		$this->assertFalse($route->matches($request));
 
 		// Mock a request class that will return route1
-		$request = $this->getMock('Request', array('uri'), array($matches_route1));
-		$request->expects($this->any())
-			->method('uri')
-			->will($this->returnValue($matches_route1));
+		$request = $this->get_request_mock($matches_route1);
 
 		$matches = $route->matches($request);
 
 		$this->assertInternalType('array', $matches);
 
 		// Mock a request class that will return route2 uri
-		$request = $this->getMock('Request', array('uri'), array($matches_route2));
-		$request->expects($this->any())
-			->method('uri')
-			->will($this->returnValue($matches_route2));
+		$request = $this->get_request_mock($matches_route2);
 
 		$matches = $route->matches($request);
 
@@ -899,10 +879,7 @@ class Kohana_RouteTest extends Unittest_TestCase
 		$route = new Route($route);
 
 		// Mock a request class
-		$request = $this->getMock('Request', array('uri'), array($uri));
-		$request->expects($this->any())
-			->method('uri')
-			->will($this->returnValue($uri));
+		$request = $this->get_request_mock($uri);
 
 		$params = $route->defaults($defaults)->filter($filter)->matches($request);
 
@@ -946,6 +923,34 @@ class Kohana_RouteTest extends Unittest_TestCase
 		$get_route_uri = Route::get($name)->uri(array($uri_key => $uri_value));
 
 		$this->assertSame($expected, $get_route_uri);
+	}
+
+	/**
+	 * Get a mock of the Request class with a mocked `uri` method
+	 *
+	 * We are also mocking `method` method as it conflicts with newer PHPUnit,
+	 * in order to avoid the fatal errors
+	 *
+	 * @param string $uri
+	 * @return type
+	 */
+	public function get_request_mock($uri)
+	{
+		// Mock a request class with the $uri uri
+		$request = $this->getMock('Request', array('uri', 'method'), array($uri));
+
+		// mock `uri` method
+		$request->expects($this->any())
+			->method('uri')
+		  	// Request::uri() called by Route::matches() in the tests will return $uri
+			->will($this->returnValue($uri));
+
+		// also mock `method` method
+		$request->expects($this->any())
+			->method('method')
+			->withAnyParameters();
+
+		return $request;
 	}
 
 }


### PR DESCRIPTION
In order to avoid errors in newer versions of PHPUnit,
a mock of the Request class should mock its `method` method.
This is to avoid fatals such as:

```
Fatal error: Declaration of Mock_Request_cb18252f::method()
must be compatible with that of Kohana_HTTP_Request::method() in
phpunit/phpunit-mock-objects/src/Framework/MockObject/Generator.php(335)
eval()'d code on line 1
```
