### PR TITLE
RequestClientInternalTest: Request mock needs mocking of `method` method

### DIFF
--- a/tests/kohana/request/client/InternalTest.php
+++ b/tests/kohana/request/client/InternalTest.php
@@ -59,6 +59,11 @@ class Kohana_Request_Client_InternalTest extends Unittest_TestCase
 			->method('response')
 			->will($this->returnValue($this->getMock('Response')));
 
+		// mock `method` method to avoid fatals in newer versions of PHPUnit
+		$request->expects($this->any())
+			->method('method')
+			->withAnyParameters();
+
 		$internal_client = new Request_Client_Internal;
 
 		$response = $internal_client->execute($request);


### PR DESCRIPTION
In order to avoid errors in newer versions of PHPUnit,
a mock of the Request class should mock its `method` method.
This is to avoid fatals such as:

```
Fatal error: Declaration of Mock_Request_cb18252f::method()
must be compatible with that of Kohana_HTTP_Request::method() in
phpunit/phpunit-mock-objects/src/Framework/MockObject/Generator.php(335)
eval()'d code on line 1
```

Related to #611 
