### PR TITLE
HP Fortify security patch: do not trust HTTP_HOST

### DIFF
--- a/config/url.php
+++ b/config/url.php
@@ -1,0 +1,18 @@
+<?php defined('SYSPATH') OR die('No direct script access.');
+
+return array(
+
+	'trusted_hosts' => array(
+		// Set up your hostnames here
+		//
+		// Example:
+		//
+		//        'example\.org',
+		//        '.*\.example\.org',
+		//
+		// Do not forget to escape your dots (.) as these are regex patterns.
+		// These patterns should always fully match,
+		// as they are prepended with `^` and appended with `$`
+	),
+
+);

--- a/guide/kohana/install.md
+++ b/guide/kohana/install.md
@@ -34,6 +34,18 @@ Kohana::init(array(
 ));
 ~~~
 
+ - List your trusted hosts. Open `application/config/url.php` and add regex patterns of the hosts you expect your application to be accessible from.
+
+   [!!] Do not forget to escape your dots (.) as these are regex patterns. These patterns should always fully match, as they are prepended with `^` and appended with `$`.
+~~~
+return array(
+	'trusted_hosts' => array(
+		'example\.org',
+		'.*\.example\.org',
+	),
+);
+~~~
+
  - Define a salt for the `Cookie` class.
 ~~~
 Cookie::$salt = 'some-really-long-cookie-salt-here';

--- a/guide/kohana/menu.md
+++ b/guide/kohana/menu.md
@@ -20,6 +20,7 @@
    - [Error Handling](errors)
    - [Tips & Common Mistakes](tips)
    - [Upgrading from v3.2](upgrading)
+   - [Upgrading from v3.3.3.1](upgrading-from-3-3-3-1)
 - Basic Usage
    - [Debugging](debugging)
    - [Loading Classes](autoloading)

--- a/guide/kohana/upgrading-from-3-3-3-1.md
+++ b/guide/kohana/upgrading-from-3-3-3-1.md
@@ -1,0 +1,23 @@
+# Upgrading from 3.3.3.1
+
+Minor version upgrades are usually done in a drop-in fashion. Unfortunately, however, upgrading from 3.3.3.1 to 3.3.4 needs a little configuration. This is because a [security disclosure from HP Fortify](https://github.com/kohana/kohana/issues/74), that unveiled a serious [host header attack](https://github.com/kohana/core/issues/613) vulnerability.
+
+[!!] You *might* still be able to have a drop-in upgrade, in case you have set the `base_url` in the [Kohana::init] call to an absolute URL. We advise you however that you follow the step below to make your application secure, in case some day you decide to change your `base_url` to a relative URL.
+
+## Trusted Hosts
+
+You need to setup a list of trusted hosts. Trusted hosts are hosts that you expect your application to be accessible from.
+
+Open `application/config/url.php` and add regex patterns of these hosts. An example is given hereunder:
+
+~~~
+return array(
+	'trusted_hosts' => array(
+		'example\.org',
+		'.*\.example\.org',
+	),
+);
+~~~
+
+[!!] Do not forget to escape your dots (.) as these are regex patterns. These patterns should always fully match, as they are prepended with `^` and appended with `$`.
+

--- a/tests/kohana/FeedTest.php
+++ b/tests/kohana/FeedTest.php
@@ -16,6 +16,18 @@
  */
 class Kohana_FeedTest extends Unittest_TestCase
 {
+
+	/**
+	 * Sets up the environment
+	 */
+	// @codingStandardsIgnoreStart
+	public function setUp()
+	// @codingStandardsIgnoreEnd
+	{
+		parent::setUp();
+		Kohana::$config->load('url')->set('trusted_hosts', array('localhost'));
+	}
+
 	/**
 	 * Provides test data for test_parse()
 	 *

--- a/tests/kohana/HTMLTest.php
+++ b/tests/kohana/HTMLTest.php
@@ -16,6 +16,18 @@
  */
 class Kohana_HTMLTest extends Unittest_TestCase
 {
+
+	/**
+	 * Sets up the environment
+	 */
+	// @codingStandardsIgnoreStart
+	public function setUp()
+	// @codingStandardsIgnoreEnd
+	{
+		parent::setUp();
+		Kohana::$config->load('url')->set('trusted_hosts', array('www\.kohanaframework\.org'));
+	}
+
 	/**
 	 * Defaults for this test
 	 * @var array

--- a/tests/kohana/HTTPTest.php
+++ b/tests/kohana/HTTPTest.php
@@ -16,6 +16,18 @@
 class Kohana_HTTPTest extends Unittest_TestCase {
 
 	/**
+	 * Sets up the environment
+	 */
+	// @codingStandardsIgnoreStart
+	public function setUp()
+	// @codingStandardsIgnoreEnd
+	{
+		parent::setUp();
+		Kohana::$config->load('url')->set('trusted_hosts', array('www\.example\.com'));
+	}
+
+
+	/**
 	 * Defaults for this test
 	 * @var array
 	 */

--- a/tests/kohana/RequestTest.php
+++ b/tests/kohana/RequestTest.php
@@ -23,6 +23,7 @@ class Kohana_RequestTest extends Unittest_TestCase
 	// @codingStandardsIgnoreEnd
 	{
 		parent::setUp();
+		Kohana::$config->load('url')->set('trusted_hosts', array('localhost'));
 		$this->_initial_request = Request::$initial;
 		Request::$initial = new Request('/');
 	}

--- a/tests/kohana/RouteTest.php
+++ b/tests/kohana/RouteTest.php
@@ -28,6 +28,8 @@ class Kohana_RouteTest extends Unittest_TestCase
 	{
 		parent::setUp();
 
+		Kohana::$config->load('url')->set('trusted_hosts', array('kohanaframework\.org'));
+
 		$this->cleanCacheDir();
 	}
 


### PR DESCRIPTION
A security patch: throw exception when host is untrusted or invalid
added URL::is_trusted_host to match for hosts provided by `url` config.

Parts checking for validity of the given host is shamelessly copied
from the Symfony project.

However, in contrast with the Symfony, URL::is_trusted_host forces
full pattern match similar to the Kohana Routes pattern matching.

Kindly review carefully as this is breaking.

Still needs some documentation and upgrading notices.
