### PR TITLE
Temporarily disable logging for expected exceptions in tests

### DIFF
--- a/tests/kohana/request/client/InternalTest.php
+++ b/tests/kohana/request/client/InternalTest.php
@@ -17,6 +17,30 @@
  */
 class Kohana_Request_Client_InternalTest extends Unittest_TestCase
 {
+
+	protected $_log_object;
+
+	// @codingStandardsIgnoreStart
+	public function setUp()
+	// @codingStandardsIgnoreEnd
+	{
+		parent::setUp();
+
+		// temporarily save $log object
+		$this->_log_object = Kohana::$log;
+		Kohana::$log = NULL;
+	}
+
+	// @codingStandardsIgnoreStart
+	public function tearDown()
+	// @codingStandardsIgnoreEnd
+	{
+		// re-assign log object
+		Kohana::$log = $this->_log_object;
+
+		parent::tearDown();
+	}
+
 	public function provider_response_failure_status()
 	{
 		return array(


### PR DESCRIPTION
These are expected exceptions in tests.

I wonder if there is any reason to fill the logs every time we run the tests? It is also confusing seeing these entries while working.

Basically this is to disable logs to avoid entries such as:

```
2015-06-05 03:12:32 --- EMERGENCY: Kohana_Exception [ 0 ]: Cannot create
instances of abstract Controller_Template ~
SYSPATH/classes/Kohana/Request/Client/Internal.php [ 87 ] in
/classes/Kohana/Request/Client.php:114
2015-06-05 03:12:32 --- DEBUG: #0
/classes/Kohana/Request/Client.php(114):
Kohana_Request_Client_Internal->execute_request(Object(Mock_Request_af8becb4),
Object(Response))
Kohana_Request_Client->execute(Object(Mock_Request_af8becb4))
Kohana_Request_Client_InternalTest->test_response_failure_status('',
'Template', 'missing_action', 'kohana3/Templat...', 500)
ReflectionMethod->invokeArgs(Object(Kohana_Request_Client_InternalTest),
Array)
PHPUnit_Framework_TestCase->runTest()
PHPUnit_Framework_TestCase->runBare()
PHPUnit_Framework_TestResult->run(Object(Kohana_Request_Client_InternalTest))
PHPUnit_Framework_TestCase->run(Object(PHPUnit_Framework_TestResult))
PHPUnit_Framework_TestSuite->runTest(Object(Kohana_Request_Client_InternalTest),
Object(PHPUnit_Framework_TestResult))
PHPUnit_Framework_TestSuite->run(Object(PHPUnit_Framework_TestResult),
false, Array, Array, false)
PHPUnit_Framework_TestSuite->run(Object(PHPUnit_Framework_TestResult),
false, Array, Array, false)
PHPUnit_Framework_TestSuite->run(Object(PHPUnit_Framework_TestResult),
false, Array, Array, false)
Kohana_Unittest_TestSuite->run(Object(PHPUnit_Framework_TestResult),
false, Array, Array, false)
PHPUnit_TextUI_TestRunner->doRun(Object(Unittest_TestSuite), Array)
PHPUnit_TextUI_Command->run(Array, true)
PHPUnit_TextUI_Command::main()
```
