### PR TITLE
PHPUnit_MAIN_METHOD not available in PHPUnit 4.0+

### DIFF
--- a/classes/Kohana/Kohana/Exception.php
+++ b/classes/Kohana/Kohana/Exception.php
@@ -248,7 +248,13 @@ class Kohana_Kohana_Exception extends Exception {
 			 * The error view ends up several GB in size, taking
 			 * serveral minutes to render.
 			 */
-			if (defined('PHPUnit_MAIN_METHOD'))
+			if (
+				defined('PHPUnit_MAIN_METHOD')
+				OR
+				defined('PHPUNIT_COMPOSER_INSTALL')
+				OR
+				defined('__PHPUNIT_PHAR__')
+			)
 			{
 				$trace = array_slice($trace, 0, 2);
 			}


### PR DESCRIPTION
Instead `PHPUNIT_COMPOSER_INSTALL` is available when PHPUnit is
installed through composer, and `__PHPUNIT_PHAR__` is available
when PHPUnit is installed by downloading the phar
