### PR TITLE
HTTP::request_headers trim 'HTTP_' only at the beginning

### DIFF
--- a/classes/Kohana/HTTP.php
+++ b/classes/Kohana/HTTP.php
@@ -192,8 +192,8 @@ abstract class Kohana_HTTP {
 				continue;
 			}
 
-			// This is a dirty hack to ensure HTTP_X_FOO_BAR becomes x-foo-bar
-			$headers[str_replace(array('HTTP_', '_'), array('', '-'), $key)] = $value;
+			// This is a dirty hack to ensure HTTP_X_FOO_BAR becomes X-FOO-BAR
+			$headers[str_replace('_', '-', substr($key, 5))] = $value;
 		}
 
 		return new HTTP_Header($headers);

--- a/tests/kohana/HTTPTest.php
+++ b/tests/kohana/HTTPTest.php
@@ -96,4 +96,70 @@ class Kohana_HTTPTest extends Unittest_TestCase {
 
 		$this->fail('HTTP_Exception_Redirect not thrown');
 	}
+
+	/**
+	 * Provides test data for test_request_headers
+	 *
+	 * @return array
+	 */
+	public function provider_request_headers()
+	{
+		return array(
+			array(
+				array(
+					'CONTENT_TYPE' => 'text/html; charset=utf-8',
+					'CONTENT_LENGTH' => '3547',
+					'HTTP_ACCEPT' => 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+					'HTTP_ACCEPT_ENCODING' => 'gzip, deflate, sdch',
+					'HTTP_ACCEPT_LANGUAGE' => 'en-US,en;q=0.8,fr;q=0.6,hy;q=0.4',
+				),
+				array(
+					'content-type' => 'text/html; charset=utf-8',
+					'content-length' => '3547',
+					'accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+					'accept-encoding'=>'gzip, deflate, sdch',
+					'accept-language'=>'en-US,en;q=0.8,fr;q=0.6,hy;q=0.4',
+				)
+			),
+			array(
+				array(
+					'HTTP_WEIRD_HTTP_HEADER' => 'A weird value for a weird header',
+				),
+				array(
+					'weird-http-header' => 'A weird value for a weird header',
+				)
+			),
+		);
+	}
+
+	/**
+	 * Tests HTTP::request_headers()
+	 *
+	 * HTTP::request_headers relies on the $_SERVER superglobal if the function
+	 * `apache_request_headers` or the PECL `http` extension are not available.
+	 *
+	 * The test feeds the $_SERVER superglobal with the test cases' datasets
+	 * and then restores the $_SERVER superglobal so that it does not affect
+	 * other tests.
+	 *
+	 * @test
+	 * @dataProvider provider_request_headers
+	 * @param array  $server_globals      globals to feed $_SERVER
+	 * @param array  $expected_headers    Expected, cleaned HTTP headers
+	 */
+	public function test_request_headers(array $server_globals, array $expected_headers)
+	{
+		// save the $_SERVER super-global into temporary local var
+		$tmp_server = $_SERVER;
+
+		$_SERVER = array_replace_recursive($_SERVER, $server_globals);
+		$headers = HTTP::request_headers();
+
+		$actual_headers = array_intersect_key($headers->getArrayCopy(), $expected_headers);
+
+		$this->assertSame($expected_headers, $actual_headers);
+
+		// revert the super-global to its previous state
+		$_SERVER = $tmp_server;
+	}
 }


### PR DESCRIPTION
A bug fix by @WinterSilence at #614, with failing tests.

Thanks.
