### PR TITLE
Error, delete method called by get method

### DIFF
--- a/classes/Kohana/Cookie.php
+++ b/classes/Kohana/Cookie.php
@@ -181,7 +181,22 @@ class Kohana_Cookie {
 	 */
 	protected static function _setcookie($name, $value, $expire, $path, $domain, $secure, $httponly)
 	{
-		return setcookie($name, $value, $expire, $path, $domain, $secure, $httponly);
+		$deleted = FALSE;
+		try
+		{
+			// Remove the cookie
+			unset($_COOKIE[$name]);
+			// Nullify the cookie and make it expire
+			setcookie($name, NULL, -86400, Cookie::$path, Cookie::$domain, Cookie::$secure, Cookie::$httponly);
+			
+			$deleted = TRUE;
+		}
+		catch (Exception $e)
+		{
+			Kohana::$log->add(Log::ERROR, $e->getMessage());
+		}
+
+		return $deleted;
 	}
 
 	/**


### PR DESCRIPTION
ErrorException [ 2 ]: Cookie names cannot contain any of the following '=,; \t\r\n\013\014' ~ SYSPATH/classes/Kohana/Cookie.php
