### PR TITLE
Fixing #623: Arr::map doesn't work with multidimensional array and keys

### DIFF
--- a/classes/Kohana/Arr.php
+++ b/classes/Kohana/Arr.php
@@ -393,7 +393,7 @@ class Kohana_Arr {
 		{
 			if (is_array($val))
 			{
-				$array[$key] = Arr::map($callbacks, $array[$key]);
+				$array[$key] = Arr::map($callbacks, $array[$key], $keys);
 			}
 			elseif ( ! is_array($keys) OR in_array($key, $keys))
 			{

--- a/tests/kohana/ArrTest.php
+++ b/tests/kohana/ArrTest.php
@@ -655,6 +655,22 @@ class Kohana_ArrTest extends Unittest_TestCase
 					'bar' => 'foobar',
 				),
 			),
+			array(
+				'strip_tags',
+				array(
+					array(
+						'foo' => '<p>foobar</p>',
+						'bar' => '<p>foobar</p>',
+					),
+				),
+				array('foo'),
+				array(
+					array(
+						'foo' => 'foobar',
+						'bar' => '<p>foobar</p>',
+					),
+				),
+			),
 		);
 	}
 


### PR DESCRIPTION
Arr::map didn't pass the $keys array on to itself when doing the
recursive call. This resulted at $callbacks being run on every element
in multidimensional arrays.
