### PR TITLE
Avoid Request::factory() calls in test providers

### DIFF
--- a/classes/Kohana/Request.php
+++ b/classes/Kohana/Request.php
@@ -668,7 +668,7 @@ class Kohana_Request implements HTTP_Request {
 		$uri = array_shift($split_uri);
 
 		// Initial request has global $_GET already applied
-		if (Request::$initial !== NULL)
+		if (Request::$initial === NULL)
 		{
 			if ($split_uri)
 			{

--- a/tests/kohana/HTTPTest.php
+++ b/tests/kohana/HTTPTest.php
@@ -15,6 +15,8 @@
  */
 class Kohana_HTTPTest extends Unittest_TestCase {
 
+	protected $_inital_request;
+
 	/**
 	 * Sets up the environment
 	 */
@@ -24,8 +26,21 @@ class Kohana_HTTPTest extends Unittest_TestCase {
 	{
 		parent::setUp();
 		Kohana::$config->load('url')->set('trusted_hosts', array('www\.example\.com'));
+		$this->_initial_request = Request::$initial;
+		Request::$initial = new Request('/');
 	}
 
+	/**
+	 * Tears down whatever is setUp
+	 */
+	// @codingStandardsIgnoreStart
+	public function tearDown()
+	// @codingStandardsIgnoreEnd
+	{
+		Request::$initial = $this->_initial_request;
+		parent::tearDown();
+	}
+	// @codingStandardsIgnoreStart
 
 	/**
 	 * Defaults for this test

--- a/tests/kohana/RequestTest.php
+++ b/tests/kohana/RequestTest.php
@@ -523,18 +523,18 @@ class Kohana_RequestTest extends Unittest_TestCase
 	{
 		$x_powered_by = 'Kohana Unit Test';
 		$content_type = 'application/x-www-form-urlencoded';
+		$request = new Request('foo/bar', array(), TRUE, array());
 
 		return array(
 			array(
-				$request = Request::factory('foo/bar')
-					->headers(array(
+				$request->headers(array(
 						'x-powered-by' => $x_powered_by,
 						'content-type' => $content_type
 					)
 				),
-			array(
-				'x-powered-by' => $x_powered_by,
-				'content-type' => $content_type
+				array(
+					'x-powered-by' => $x_powered_by,
+					'content-type' => $content_type
 				)
 			)
 		);
@@ -566,7 +566,6 @@ class Kohana_RequestTest extends Unittest_TestCase
 	{
 		return array(
 			array(
-				Request::factory(),
 				array(
 					'content-type'  => 'application/x-www-form-urlencoded',
 					'x-test-header' => 'foo'
@@ -574,7 +573,6 @@ class Kohana_RequestTest extends Unittest_TestCase
 				"Content-Type: application/x-www-form-urlencoded\r\nX-Test-Header: foo\r\n\r\n"
 			),
 			array(
-				Request::factory(),
 				array(
 					'content-type'  => 'application/json',
 					'x-powered-by'  => 'kohana'
@@ -589,13 +587,13 @@ class Kohana_RequestTest extends Unittest_TestCase
 	 * 
 	 * @dataProvider provider_headers_set
 	 *
-	 * @param   Request    request object
 	 * @param   array      header(s) to set to the request object
 	 * @param   string     expected http header
 	 * @return  void
 	 */
-	public function test_headers_set(Request $request, $headers, $expected)
+	public function test_headers_set($headers, $expected)
 	{
+		$request = new Request(TRUE, array(), TRUE, array());
 		$request->headers($headers);
 		$this->assertSame($expected, (string) $request->headers());
 	}


### PR DESCRIPTION
Hello all,

It is funny, sad and frustrating at the same time to know why Kohana is not marking 100% in the official [HHVM OSS frameworks tests suite](http://hhvm.com/frameworks/).
### Background

I [requested a pull](https://github.com/facebook/hhvm/pull/5568) to update the tested Kohana framework version in HHVM framework tests to v3.3.4. It was surprising for me to see it passing only at 99.85%. `HTTPTest::test_redirect` was the failing test. However, when running PHPUnit tests from within the Kohana folder, the standard way, all was OK and tests were passing.

I had hard time to figure out the real cause. Took me around 3 days, with a cumulative 12 hours. Even when I run `HTTPTest` alone with the `--filter=HTTPTest` flag from within the standard Kohana installation folder, the test always passed. I tried in vain to find ways to debug this. At some point, I was furious enough to delete all other test files from the disk except `HTTPTest.php`, in order to "force" PHPUnit to run with only `HTTPTest.php` phisically available. It was only then, to my surprise, that the test failed. **A clear indication that some tests are affecting others.** I hunted down and found out the culprit. It was the `RequestTest` that was affecting `HTTPTest`.
### Cause

`Request::factory()` calls in test "provider" methods initializes the `Request::$initial` static variable, affecting other test methods, even if those "provider" methods are not the direct providers of those other test methods.

In our case the `HTTPTest::test_redirect` is affected because the `HTTP::redirect` method needs the `Request::$initial` static variable to be available. Here's the pseudo call stack:

---

`HTTP::redirect()` :arrow_forward: `HTTP_Exception_Redirect::location()` :arrow_forward: `URL::site()` :arrow_forward: `URL::base()` which uses `Request::$initial`

---

This becomes problematic because `HTTPTest::test_redirect` is now dependant of the `RequestTest` "providers", **as those `RequestTest` "providers" change the global state in favor of `HTTPTest`'s needs**. Once `RequestTest` "providers" are not available -- ex: by deleting RequestTest.php file from disk -- `HTTPTest::test_redirect` test cases fail.
### Solution (well... for the moment)

This is a [reported issue](https://github.com/kohana/core/issues/499) and we lengthily discussed this elsewhere already... For the moment, however, this is what I am proposing for v3.3:

In order to not alter the global state, and to not affect other tests: static variables initialization, and calls to methods that affect static variables **should not be made in test case providers**. Rather, these calls should be done carefully in `setUp` and `tearDown` methods, as well as within the test methods themselves.

In this case, I have removed `Request::factory()` calls from providers and restructured the tests.

Note that:
- a bug was found and fixed at 70b88e8 after restructuring the tests.
- without c37cf6f `HTTP::redirect()` redirects with protocol `cli` ex: `cli://www.example.com/kohana/index.php/page_two`
- In c37cf6f it is probably better use `NULL` instead of using `$this->_initial_request`. But preferred to keep things along the way it's done in `RequestTest`.

This is ready for merge, please review thoroughly, cc @acoulton.

Thanks!
