### PR TITLE
when creating directories, use 0755 permissions

### DIFF
--- a/classes/Kohana/Core.php
+++ b/classes/Kohana/Core.php
@@ -905,10 +905,10 @@ class Kohana_Core {
 		if ( ! is_dir($dir))
 		{
 			// Create the cache directory
-			mkdir($dir, 0777, TRUE);
+			mkdir($dir, 0755, TRUE);
 
 			// Set permissions (must be manually set to fix umask issues)
-			chmod($dir, 0777);
+			chmod($dir, 0755);
 		}
 
 		// Force the data to be a string

--- a/classes/Kohana/Log/File.php
+++ b/classes/Kohana/Log/File.php
@@ -54,10 +54,10 @@ class Kohana_Log_File extends Log_Writer {
 		if ( ! is_dir($directory))
 		{
 			// Create the yearly directory
-			mkdir($directory, 02777);
+			mkdir($directory, 0755);
 
 			// Set permissions (must be manually set to fix umask issues)
-			chmod($directory, 02777);
+			chmod($directory, 0755);
 		}
 
 		// Add the month to the directory
@@ -66,10 +66,10 @@ class Kohana_Log_File extends Log_Writer {
 		if ( ! is_dir($directory))
 		{
 			// Create the monthly directory
-			mkdir($directory, 02777);
+			mkdir($directory, 0755);
 
 			// Set permissions (must be manually set to fix umask issues)
-			chmod($directory, 02777);
+			chmod($directory, 0755);
 		}
 
 		// Set the name of the log file


### PR DESCRIPTION
It is considered bad practice and often unneeded to have world
writable directories on a production server. Therefore don't create
cache and log directories with mode 0777 or with the setgid bit set.
