### PR TITLE
Attempt to resolve composer caching issues on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
       env: 'COMPOSER_PHPUNIT="lowest"'
 
 before_script:
+  - composer self-update
   - COMPOSER_ROOT_VERSION=3.3.x-dev composer install --prefer-dist --no-interaction
   - if [ "$COMPOSER_PHPUNIT" = "lowest" ]; then COMPOSER_ROOT_VERSION=3.3.x-dev composer update --prefer-lowest --with-dependencies phpunit/phpunit; fi;
   - vendor/bin/koharness

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ branches:
 
 cache:
   directories:
-    - vendor
-    - $HOME/.composer/cache
+    - $HOME/.composer/cache/files
 
 php:
   - 5.3
@@ -26,7 +25,7 @@ matrix:
       env: 'COMPOSER_PHPUNIT="lowest"'
 
 before_script:
-  - COMPOSER_ROOT_VERSION=3.3.x-dev composer install --prefer-dist
+  - COMPOSER_ROOT_VERSION=3.3.x-dev composer install --prefer-dist --no-interaction
   - if [ "$COMPOSER_PHPUNIT" = "lowest" ]; then COMPOSER_ROOT_VERSION=3.3.x-dev composer update --prefer-lowest --with-dependencies phpunit/phpunit; fi;
   - vendor/bin/koharness
 


### PR DESCRIPTION
As reported in #649, some travis builds are failing to install composer
packages - this appears to be since we added package caching.

https://github.com/travis-ci/travis-ci/issues/4579#issuecomment-138548147
suggests only caching composer's cached package archives, not metadata
and the checked out vendors, which may themselves be out of date.

Also try running with the --no-interaction flag, which should trigger it to fall
back to a git checkout when the travis API token has been rate limited.
