### PR TITLE
[WIP] Remove global routing

### DIFF
--- a/classes/Kohana/Request.php
+++ b/classes/Kohana/Request.php
@@ -454,13 +454,11 @@ class Kohana_Request implements HTTP_Request {
 	 * @param   array   $routes  Route
 	 * @return  array
 	 */
-	public static function process(Request $request, $routes = NULL)
+	public static function process(Request $request, array $routes = [])
 	{
-		// Load routes
-		$routes = (empty($routes)) ? Route::all() : $routes;
 		$params = NULL;
 
-		foreach ($routes as $name => $route)
+		foreach ($routes as $route)
 		{
 			// Use external routes for reverse routing only
 			if ($route->is_external())
@@ -571,7 +569,7 @@ class Kohana_Request implements HTTP_Request {
 	protected $_route;
 
 	/**
-	 * @var  Route       array of routes to manually look at instead of the global namespace
+	 * @var  array  array of routes to manually look at instead of the global namespace
 	 */
 	protected $_routes;
 
@@ -799,6 +797,29 @@ class Kohana_Request implements HTTP_Request {
 
 		// Act as a setter
 		$this->_referrer = (string) $referrer;
+
+		return $this;
+	}
+
+	/**
+	 * Gets injected/set routes from the request.
+	 *
+	 * @return  array injected routes
+	 */
+	public function get_routes()
+	{
+		return $this->_routes;
+	}
+
+	/**
+	 * Set routes to the request. Overrides injected routes.
+	 *
+	 * @param array $routes routes to override injected routes
+	 * @return self
+	 */
+	public function set_routes(array $routes)
+	{
+		$this->_routes = $routes;
 
 		return $this;
 	}

--- a/classes/Kohana/Request/Client.php
+++ b/classes/Kohana/Request/Client.php
@@ -406,11 +406,13 @@ abstract class Kohana_Request_Client {
 			}
 
 			// Prepare the additional request, copying any follow_headers that were present on the original request
+			$orig_routes = $request->get_routes();
 			$orig_headers = $request->headers()->getArrayCopy();
 			$follow_header_keys = array_intersect(array_keys($orig_headers), $client->follow_headers());
 			$follow_headers = \Arr::extract($orig_headers, $follow_header_keys);
 
 			$follow_request = Request::factory($response->headers('Location'))
+			                         ->set_routes($orig_routes)
 			                         ->method($follow_method)
 			                         ->headers($follow_headers);
 

--- a/classes/Kohana/Route.php
+++ b/classes/Kohana/Route.php
@@ -69,137 +69,7 @@ class Kohana_Route {
 	 */
 	public static $cache = FALSE;
 
-	/**
-	 * @var  array
-	 */
-	protected static $_routes = array();
-
-	/**
-	 * Stores a named route and returns it. The "action" will always be set to
-	 * "index" if it is not defined.
-	 *
-	 *     Route::set('default', '(<controller>(/<action>(/<id>)))')
-	 *         ->defaults(array(
-	 *             'controller' => 'welcome',
-	 *         ));
-	 *
-	 * @param   string  $name           route name
-	 * @param   string  $uri            URI pattern
-	 * @param   array   $regex          regex patterns for route keys
-	 * @return  Route
-	 */
-	public static function set($name, $uri = NULL, $regex = NULL)
-	{
-		return Route::$_routes[$name] = new Route($uri, $regex);
-	}
-
-	/**
-	 * Retrieves a named route.
-	 *
-	 *     $route = Route::get('default');
-	 *
-	 * @param   string  $name   route name
-	 * @return  Route
-	 * @throws  Kohana_Exception
-	 */
-	public static function get($name)
-	{
-		if ( ! isset(Route::$_routes[$name]))
-		{
-			throw new Kohana_Exception('The requested route does not exist: :route',
-				array(':route' => $name));
-		}
-
-		return Route::$_routes[$name];
-	}
-
-	/**
-	 * Retrieves all named routes.
-	 *
-	 *     $routes = Route::all();
-	 *
-	 * @return  array  routes by name
-	 */
-	public static function all()
-	{
-		return Route::$_routes;
-	}
-
-	/**
-	 * Get the name of a route.
-	 *
-	 *     $name = Route::name($route)
-	 *
-	 * @param   Route   $route  instance
-	 * @return  string
-	 */
-	public static function name(Route $route)
-	{
-		return array_search($route, Route::$_routes);
-	}
-
-	/**
-	 * Saves or loads the route cache. If your routes will remain the same for
-	 * a long period of time, use this to reload the routes from the cache
-	 * rather than redefining them on every page load.
-	 *
-	 *     if ( ! Route::cache())
-	 *     {
-	 *         // Set routes here
-	 *         Route::cache(TRUE);
-	 *     }
-	 *
-	 * @param   boolean $save   cache the current routes
-	 * @param   boolean $append append, rather than replace, cached routes when loading
-	 * @return  void    when saving routes
-	 * @return  boolean when loading routes
-	 * @uses    Kohana::cache
-	 */
-	public static function cache($save = FALSE, $append = FALSE)
-	{
-		if ($save === TRUE)
-		{
-			try
-			{
-				// Cache all defined routes
-				Kohana::cache('Route::cache()', Route::$_routes);
-			}
-			catch (Exception $e)
-			{
-				// We most likely have a lambda in a route, which cannot be cached
-				throw new Kohana_Exception('One or more routes could not be cached (:message)', array(
-						':message' => $e->getMessage(),
-					), 0, $e);
-			}
-		}
-		else
-		{
-			if ($routes = Kohana::cache('Route::cache()'))
-			{
-				if ($append)
-				{
-					// Append cached routes
-					Route::$_routes += $routes;
-				}
-				else
-				{
-					// Replace existing routes
-					Route::$_routes = $routes;
-				}
-
-				// Routes were cached
-				return Route::$cache = TRUE;
-			}
-			else
-			{
-				// Routes were not cached
-				return Route::$cache = FALSE;
-			}
-		}
-	}
-
-	/**
-	 * Create a URL from a route name. This is a shortcut for:
+	/**	 * Create a URL from a route name. This is a shortcut for:
 	 *
 	 *     echo URL::site(Route::get($name)->uri($params), $protocol);
 	 *
@@ -210,15 +80,13 @@ class Kohana_Route {
 	 * @since   3.0.7
 	 * @uses    URL::site
 	 */
-	public static function url($name, array $params = NULL, $protocol = NULL)
+	public function url(array $params = NULL, $protocol = NULL)
 	{
-		$route = Route::get($name);
-
 		// Create a URI with the route and convert it to a URL
-		if ($route->is_external())
-			return $route->uri($params);
+		if ($this->is_external())
+			return $this->uri($params);
 		else
-			return URL::site($route->uri($params), $protocol);
+			return URL::site($this->uri($params), $protocol);
 	}
 
 	/**

--- a/classes/Kohana/Route.php
+++ b/classes/Kohana/Route.php
@@ -69,6 +69,14 @@ class Kohana_Route {
 	 */
 	public static $cache = FALSE;
 
+	/**
+	 * A shim to make the tests run
+	 */
+	public static function set($name, $uri = NULL, $regex = NULL)
+	{
+		return new Route($uri, $regex);
+	}
+
 	/**	 * Create a URL from a route name. This is a shortcut for:
 	 *
 	 *     echo URL::site(Route::get($name)->uri($params), $protocol);

--- a/tests/kohana/RequestTest.php
+++ b/tests/kohana/RequestTest.php
@@ -183,7 +183,7 @@ class Kohana_RequestTest extends Unittest_TestCase
 	 */
 	public function test_route()
 	{
-		$request = Request::factory(''); // This should always match something, no matter what changes people make
+		$request = Request::factory('', [], TRUE, [new Route('')]); // This should always match something, no matter what changes people make
 
 		// We need to execute the request before it has matched a route
 		try

--- a/tests/kohana/RouteTest.php
+++ b/tests/kohana/RouteTest.php
@@ -46,126 +46,6 @@ class Kohana_RouteTest extends Unittest_TestCase
 	}
 
 	/**
-	 * If Route::get() is asked for a route that does not exist then
-	 * it should throw a Kohana_Exception
-	 *
-	 * Note use of @expectedException
-	 *
-	 * @test
-	 * @covers Route::get
-	 * @expectedException Kohana_Exception
-	 */
-	public function test_get_throws_exception_if_route_dnx()
-	{
-		Route::get('HAHAHAHAHAHAHAHAHA');
-	}
-
-	/**
-	 * Route::all() should return all routes defined via Route::set()
-	 * and not through new Route()
-	 *
-	 * @test
-	 * @covers Route::all
-	 */
-	public function test_all_returns_all_defined_routes()
-	{
-		$defined_routes = self::readAttribute('Route', '_routes');
-
-		$this->assertSame($defined_routes, Route::all());
-	}
-
-	/**
-	 * Route::name() should fetch the name of a passed route
-	 * If route is not found then it should return FALSE
-	 *
-	 * @TODO: This test needs to segregate the Route::$_routes singleton
-	 * @test
-	 * @covers Route::name
-	 */
-	public function test_name_returns_routes_name_or_false_if_dnx()
-	{
-		$route = Route::set('flamingo_people', 'flamingo/dance');
-
-		$this->assertSame('flamingo_people', Route::name($route));
-
-		$route = new Route('dance/dance');
-
-		$this->assertFalse(Route::name($route));
-	}
-
-	/**
-	 * If Route::cache() was able to restore routes from the cache then
-	 * it should return TRUE and load the cached routes
-	 *
-	 * @test
-	 * @covers Route::cache
-	 */
-	public function test_cache_stores_route_objects()
-	{
-		$routes = Route::all();
-
-		// First we create the cache
-		Route::cache(TRUE);
-
-		// Now lets modify the "current" routes
-		Route::set('nonsensical_route', 'flabbadaga/ding_dong');
-
-		// Then try and load said cache
-		$this->assertTrue(Route::cache());
-
-		// Check the route cache flag
-		$this->assertTrue(Route::$cache);
-
-		// And if all went ok the nonsensical route should be gone...
-		$this->assertEquals($routes, Route::all());
-	}
-
-	/**
-	 * Check appending cached routes. See http://dev.kohanaframework.org/issues/4347
-	 *
-	 * @test
-	 * @covers Route::cache
-	 */
-	public function test_cache_append_routes()
-	{
-		$cached = Route::all();
-
-		// First we create the cache
-		Route::cache(TRUE);
-
-		// Now lets modify the "current" routes
-		Route::set('nonsensical_route', 'flabbadaga/ding_dong');
-
-		$modified = Route::all();
-
-		// Then try and load said cache
-		$this->assertTrue(Route::cache(NULL, TRUE));
-
-		// Check the route cache flag
-		$this->assertTrue(Route::$cache);
-
-		// And if all went ok the nonsensical route should exist with the other routes...
-		$this->assertEquals(Route::all(), $cached + $modified);
-	}
-
-	/**
-	 * Route::cache() should return FALSE if cached routes could not be found
-	 *
-	 * The cache is cleared before and after each test in setUp tearDown
-	 * by cleanCacheDir()
-	 *
-	 * @test
-	 * @covers Route::cache
-	 */
-	public function test_cache_returns_false_if_cache_dnx()
-	{
-		$this->assertSame(FALSE, Route::cache(), 'Route cache was not empty');
-
-		// Check the route cache flag
-		$this->assertFalse(Route::$cache);
-	}
-
-	/**
 	 * If the constructor is passed a NULL uri then it should assume it's
 	 * being loaded from the cache & therefore shouldn't override the cached attributes
 	 *
@@ -738,11 +618,10 @@ class Kohana_RouteTest extends Unittest_TestCase
 	 */
 	public function test_composing_url_from_route($expected, $params = NULL, $protocol = NULL)
 	{
-		Route::set('foobar', '(<controller>(/<action>(/<id>)))')
-			->defaults(array(
-				'controller' => 'welcome',
-			)
-		);
+		$route = (new Route('(<controller>(/<action>(/<id>)))'))
+		  ->defaults(array(
+			'controller' => 'welcome',
+		  ));
 
 		$this->setEnvironment(array(
 			'_SERVER' => array('HTTP_HOST' => 'kohanaframework.org'),
@@ -750,7 +629,7 @@ class Kohana_RouteTest extends Unittest_TestCase
 			'Kohana::$index_file' => '',
 		));
 
-		$this->assertSame($expected, Route::url('foobar', $params, $protocol));
+		$this->assertSame($expected, $route->url($params, $protocol));
 	}
 
 	/**
@@ -781,7 +660,7 @@ class Kohana_RouteTest extends Unittest_TestCase
 	public function test_is_external_route_from_host()
 	{
 		// Setup local route
-		Route::set('internal', 'local/test/route')
+		$internal = (new Route('local/test/route'))
 			->defaults(array(
 				'controller' => 'foo',
 				'action'     => 'bar'
@@ -789,7 +668,7 @@ class Kohana_RouteTest extends Unittest_TestCase
 			);
 
 		// Setup external route
-		Route::set('external', 'local/test/route')
+		$external = (new Route('local/test/route'))
 			->defaults(array(
 				'controller' => 'foo',
 				'action'     => 'bar',
@@ -798,10 +677,10 @@ class Kohana_RouteTest extends Unittest_TestCase
 			);
 
 		// Test internal route
-		$this->assertFalse(Route::get('internal')->is_external());
+		$this->assertFalse($internal->is_external());
 
 		// Test external route
-		$this->assertTrue(Route::get('external')->is_external());
+		$this->assertTrue($external->is_external());
 	}
 
 	/**
@@ -848,10 +727,10 @@ class Kohana_RouteTest extends Unittest_TestCase
 	 */
 	public function test_external_route_includes_params_in_uri($route, $defaults, $expected_uri)
 	{
-		Route::set('test', $route)
+		$route = (new Route($route))
 			->defaults($defaults);
 
-		$this->assertSame($expected_uri, Route::get('test')->uri());
+		$this->assertSame($expected_uri, $route->uri());
 	}
 
 	/**
@@ -915,7 +794,6 @@ class Kohana_RouteTest extends Unittest_TestCase
 	{
 		return array(
 			array(
-				'article',
 				'blog/article/<article_name>',
 				array(
 					'controller' => 'home',
@@ -936,11 +814,11 @@ class Kohana_RouteTest extends Unittest_TestCase
 	 * @ticket 4079
 	 * @dataProvider provider_route_uri_encode_parameters
 	 */
-	public function test_route_uri_encode_parameters($name, $uri_callback, $defaults, $uri_key, $uri_value, $expected)
+	public function test_route_uri_encode_parameters($uri_callback, $defaults, $uri_key, $uri_value, $expected)
 	{
-		Route::set($name, $uri_callback)->defaults($defaults);
+		$route = (new Route($uri_callback))->defaults($defaults);
 
-		$get_route_uri = Route::get($name)->uri(array($uri_key => $uri_value));
+		$get_route_uri = $route->uri(array($uri_key => $uri_value));
 
 		$this->assertSame($expected, $get_route_uri);
 	}


### PR DESCRIPTION
This is a tentative PR to remove global routing, i.e. the use of `Route::set`, while relying only on injecting the routes when constructing `Request`s or overriding injected ones via `set_routes`.

This will solve #524 as well as go forward with #499.

I am also in favor of config routing. I think we had routing based on config files in Kohana 2? But never used Kohana 2 so I am not sure.

I am awaiting your comments regarding this.

Cheers!
