### PR TITLE
Fix uri with falsey strings eg '/0' [fixes kohana/kohana#94]

### DIFF
--- a/classes/Kohana/Request.php
+++ b/classes/Kohana/Request.php
@@ -681,7 +681,7 @@ class Kohana_Request implements HTTP_Request {
 		// being able to proxy external pages.
 		if ( ! $allow_external OR strpos($uri, '://') === FALSE)
 		{
-			// Remove trailing slashes from the URI
+			// Remove leading and trailing slashes from the URI
 			$this->_uri = trim($uri, '/');
 
 			// Apply the client
@@ -732,7 +732,7 @@ class Kohana_Request implements HTTP_Request {
 		if ($uri === NULL)
 		{
 			// Act as a getter
-			return empty($this->_uri) ? '/' : $this->_uri;
+			return ($this->_uri === '') ? '/' : $this->_uri;
 		}
 
 		// Act as a setter

--- a/tests/kohana/RequestTest.php
+++ b/tests/kohana/RequestTest.php
@@ -274,6 +274,11 @@ class Kohana_RequestTest extends Unittest_TestCase
 				'http',
 				'http://www.google.com'
 			),
+			array(
+				'0',
+				'http',
+				'http://localhost/kohana/0'
+			)
 		);
 	}
 
@@ -434,6 +439,14 @@ class Kohana_RequestTest extends Unittest_TestCase
 			array(
 				new Request('foo/bar'),
 				'foo/bar'
+			),
+			array(
+				new Request('/0'),
+				'0'
+			),
+			array(
+				new Request('0'),
+				'0'
 			),
 			array(
 				new Request('/'),


### PR DESCRIPTION
Calling `(new Request('/0'))->uri()` should return '0' but
was previously returning '/' because the '0' was incorrectly
treated as empty.

Note that this is in part because `Request::_construct`
always trims the leading '/' from internal requests - the
previous comment implies the original intention was just to
remove trailing '/' so this may not actually be desired but
has been standard Kohana behaviour for a long time.

Thanks to @sergiozia for the report and proposed patch in kohana/kohana#94

Amended the comment to clarify.
