### PR TITLE
Reset request `content-length` header during request execution

### DIFF
--- a/classes/Kohana/Request/Client/External.php
+++ b/classes/Kohana/Request/Client/External.php
@@ -127,6 +127,8 @@ abstract class Kohana_Request_Client_External extends Request_Client {
 				->headers('content-type', 'application/x-www-form-urlencoded; charset='.Kohana::$charset);
 		}
 
+		$request->headers('content-length', (string) $request->content_length());
+
 		// If Kohana expose, set the user-agent
 		if (Kohana::$expose)
 		{

--- a/tests/kohana/RequestTest.php
+++ b/tests/kohana/RequestTest.php
@@ -736,9 +736,47 @@ class Kohana_RequestTest extends Unittest_TestCase
 		$this->assertEquals($client->strict_redirect(), FALSE);
 	}
 
+	/**
+	 * Tests correctness request content-length header after calling render
+	 */
+	public function test_content_length_after_render()
+	{
+		$request = Request::factory('https://example.org/post')
+			->client(new Kohana_RequestTest_Header_Spying_Request_Client_External)
+			->method(Request::POST)
+			->post(array('aaa' => 'bbb'));
 
+		$request->render();
+
+		$request->execute();
+
+		$headers = $request->client()->get_received_request_headers();
+
+		$this->assertEquals(strlen($request->body()), $headers['content-length']);
+	}
 
 } // End Kohana_RequestTest
+
+/**
+ * A dummy Request_Client_External implementation, that spies on the headers
+ * of the request
+ */
+class Kohana_RequestTest_Header_Spying_Request_Client_External extends Request_Client_External
+{
+	private $headers;
+
+	protected function _send_message(\Request $request, \Response $response)
+	{
+		$this->headers = $request->headers();
+
+		return $response;
+	}
+
+	public function get_received_request_headers()
+	{
+		return $this->headers;
+	}
+}
 
 class Controller_Kohana_RequestTest_Dummy extends Controller
 {

--- a/tests/kohana/RequestTest.php
+++ b/tests/kohana/RequestTest.php
@@ -755,6 +755,28 @@ class Kohana_RequestTest extends Unittest_TestCase
 		$this->assertEquals(strlen($request->body()), $headers['content-length']);
 	}
 
+	/**
+	 * Tests correctness request content-length header after calling render
+	 * and changing post
+	 */
+	public function test_content_length_after_changing_post()
+	{
+		$request = Request::factory('https://example.org/post')
+			->client(new Kohana_RequestTest_Header_Spying_Request_Client_External)
+			->method(Request::POST)
+			->post(array('aaa' => 'bbb'));
+
+		$request->render();
+
+		$request->post(array('one' => 'one', 'two' => 'two', 'three' => 'three'));
+
+		$request->execute();
+
+		$headers = $request->client()->get_received_request_headers();
+
+		$this->assertEquals(strlen($request->body()), $headers['content-length']);
+	}
+
 } // End Kohana_RequestTest
 
 /**


### PR DESCRIPTION
Related to #653 #655 #661 #662

`Request::render` sets `content-length` header. This creates problems on subsequent changes to the request object.

cc @sunchuo, @pbardov, @acoulton 
