### PR TITLE
Fatal error when redirecting with no URI

### DIFF
--- a/classes/Kohana/HTTP.php
+++ b/classes/Kohana/HTTP.php
@@ -30,6 +30,9 @@ abstract class Kohana_HTTP {
 	 */
 	public static function redirect($uri = '', $code = 302)
 	{
+		if ( ! $uri)
+			return;
+
 		$e = HTTP_Exception::factory($code);
 
 		if ( ! $e instanceof HTTP_Exception_Redirect)


### PR DESCRIPTION
Easy fix, if no uri is passed then return from the function.  I ran into this problem having some dynamic code for users that'll redirect to there profile if already logged in, the problem is t he error generated from this fatal error doesn't generate a call stack.  Thus I had to debug my code from starting from seeing what was being passed to this function which was an empty string then starting from the master controller and working my way to the called url controller/action.  http://i.imgur.com/qUdrELS.png
