### PR TITLE
Add MIME type `text/cache-manifest`

### DIFF
--- a/config/mimes.php
+++ b/config/mimes.php
@@ -17,6 +17,7 @@ return array(
 	'aifc'     => array('audio/x-aiff'),
 	'aiff'     => array('audio/x-aiff'),
 	'amf'      => array('application/x-amf'),
+	'appcache' => array('text/cache-manifest'),
 	'asf'      => array('video/x-ms-asf'),
 	'asr'      => array('video/x-ms-asf'),
 	'asx'      => array('video/x-ms-asf'),


### PR DESCRIPTION
Add MIME type `text/cache-manifest` for the recommended `.appcache` file extension.

Closes #679. Related #682.

Thank you @saruman 
