### PR TITLE
Make tests independent from OS and application locale

### DIFF
--- a/tests/kohana/DateTest.php
+++ b/tests/kohana/DateTest.php
@@ -17,6 +17,7 @@
 class Kohana_DateTest extends Unittest_TestCase
 {
 	protected $_original_timezone = NULL;
+	protected $default_locale;
 
 	/**
 	 * Ensures we have a consistant timezone for testing.
@@ -28,8 +29,10 @@ class Kohana_DateTest extends Unittest_TestCase
 		parent::setUp();
 
 		$this->_original_timezone = date_default_timezone_get();
+		$this->default_locale = setlocale(LC_ALL, 0);
 
 		date_default_timezone_set('America/Chicago');
+		setlocale(LC_ALL, 'en_US.utf8');
 	}
 
 	/**
@@ -40,6 +43,7 @@ class Kohana_DateTest extends Unittest_TestCase
 	// @codingStandardsIgnoreEnd
 	{
 		date_default_timezone_set($this->_original_timezone);
+		setlocale(LC_ALL, $this->default_locale);
 
 		parent::tearDown();
 	}

--- a/tests/kohana/NumTest.php
+++ b/tests/kohana/NumTest.php
@@ -26,6 +26,7 @@ class Kohana_NumTest extends Unittest_TestCase
 	{
 		parent::setUp();
 
+		$this->default_locale = setlocale(LC_ALL, 0);
 		setlocale(LC_ALL, 'en_US.utf8');
 	}
 


### PR DESCRIPTION
Some tests are written with specific locale in mind.

In https://github.com/kohana/core/commit/0eb2898b234d2201c7df0d6cb5dbbb719cf990ba, most-probably by mistake, we have removed a line that backups the original locale, before setting the locale used in the tests. Not being to be able to restore the locale, and instead setting the OS default locale, the `NumTest` is affecting other subsequent tests.

Similarly in `DateTest`, tests are written with specific locale in mind. When changing the application default locale in `bootstrap.php` to a different locale, `DateTest` tests fail.

Related to https://github.com/kohana/kohana/issues/106

cc @piotrgolasz, @acoulton, @rjd22 
