### PR TITLE
Deprecate Security::strip_image_tags

### DIFF
--- a/classes/Kohana/Security.php
+++ b/classes/Kohana/Security.php
@@ -106,10 +106,14 @@ class Kohana_Security {
 
 
 	/**
+	 * Deprecated for security reasons.
+	 * See https://github.com/kohana/kohana/issues/107
+	 *
 	 * Remove image tags from a string.
 	 *
 	 *     $str = Security::strip_image_tags($str);
 	 *
+	 * @deprecated since version 3.3.6
 	 * @param   string  $str    string to sanitize
 	 * @return  string
 	 */


### PR DESCRIPTION
Deprecated for security reasons.
See https://github.com/kohana/kohana/issues/107

Users must be encouraged to use more secure and better maintained external libraries to strip image tags.
