### PR TITLE
Don't use short notatnion arg_separator

### DIFF
--- a/classes/Kohana/URL.php
+++ b/classes/Kohana/URL.php
@@ -195,7 +195,7 @@ class Kohana_URL {
 		}
 
 		// Note: http_build_query returns an empty string for a params array with only NULL values
-		$query = http_build_query($params, '', '&');
+		$query = http_build_query($params, '', '&amp;');
 
 		// Don't prepend '?' to an empty string
 		return ($query === '') ? '' : ('?'.$query);


### PR DESCRIPTION
When url is `?foo=&not_foo=` browsers interpret it as one value `?foo=&not;_foo=` --> `?foo=¬_foo=`
