### PR TITLE
Remove deprecated Security::strip_image_tags method

### DIFF
--- a/classes/Kohana/Security.php
+++ b/classes/Kohana/Security.php
@@ -106,23 +106,6 @@ class Kohana_Security {
 
 
 	/**
-	 * Deprecated for security reasons.
-	 * See https://github.com/kohana/kohana/issues/107
-	 *
-	 * Remove image tags from a string.
-	 *
-	 *     $str = Security::strip_image_tags($str);
-	 *
-	 * @deprecated since version 3.3.6
-	 * @param   string  $str    string to sanitize
-	 * @return  string
-	 */
-	public static function strip_image_tags($str)
-	{
-		return preg_replace('#<img\s.*?(?:src\s*=\s*["\']?([^"\'<>\s]*)["\']?[^>]*)?>#is', '$1', $str);
-	}
-
-	/**
 	 * Encodes PHP tags in a string.
 	 *
 	 *     $str = Security::encode_php_tags($str);

--- a/guide/kohana/upgrading.md
+++ b/guide/kohana/upgrading.md
@@ -151,3 +151,9 @@ In addition to a new API to specify the log writers default format:
 $writer->get_format();
 $writer->set_format('body in file:line');
 ~~~
+
+### Security::strip_image_tags
+
+This method (which was deprecated in 3.3) has been removed for [security reasons](https://github.com/kohana/kohana/issues/107)
+as it is not reliable to parse and sanitise HTML with regular expressions. You should either encode HTML tags entirely, eg
+with HTML::chars, or use a more robust HTML filtering solution such as [HTMLPurifier](http://htmlpurifier.org/).

--- a/tests/Kohana/SecurityTest.php
+++ b/tests/Kohana/SecurityTest.php
@@ -37,30 +37,6 @@ class Kohana_SecurityTest extends Unittest_TestCase
 	}
 
 	/**
-	 * Provides test data for test_strip_image_tags()
-	 *
-	 * @return array Test data sets
-	 */
-	public function provider_strip_image_tags()
-	{
-		return array(
-			array('foo', '<img src="foo" />'),
-		);
-	}
-
-	/**
-	 * Tests Security::strip_image_tags()
-	 *
-	 * @test
-	 * @dataProvider provider_strip_image_tags
-	 * @covers Security::strip_image_tags
-	 */
-	public function test_strip_image_tags($expected, $input)
-	{
-		$this->assertSame($expected, Security::strip_image_tags($input));
-	}
-
-	/**
 	 * Provides test data for Security::token()
 	 *
 	 * @return array Test data sets


### PR DESCRIPTION
Related to https://github.com/kohana/kohana/issues/107
