### PR TITLE
Patch Valid::ip to work with PHP v7.0.10+ AND v5.6.25+

### DIFF
--- a/classes/Kohana/Valid.php
+++ b/classes/Kohana/Valid.php
@@ -224,16 +224,27 @@ class Kohana_Valid {
 	 */
 	public static function ip($ip, $allow_private = TRUE)
 	{
-		// Do not allow reserved addresses
-		$flags = FILTER_FLAG_NO_RES_RANGE;
 
-		if ($allow_private === FALSE)
+		// In PHP v7.0.10+ AND v5.6.25+ FILTER_FLAG_NO_PRIV_RANGE ∈ FILTER_FLAG_NO_RES_RANGE
+		// However we have to combine both flags to support older versions
+		$flags = FILTER_FLAG_NO_RES_RANGE | FILTER_FLAG_NO_PRIV_RANGE;
+
+		$is_valid_public_ip = (bool) filter_var($ip, FILTER_VALIDATE_IP, $flags);
+
+		if ( ! $allow_private)
 		{
-			// Do not allow private or reserved addresses
-			$flags = $flags | FILTER_FLAG_NO_PRIV_RANGE;
+			return $is_valid_public_ip;
 		}
 
-		return (bool) filter_var($ip, FILTER_VALIDATE_IP, $flags);
+		// at this point we are allowing private IPs as well
+		return
+		(
+			$is_valid_public_ip OR
+			(
+				(bool) filter_var($ip, FILTER_VALIDATE_IP) AND
+				! (bool) filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE)
+			)
+		);
 	}
 
 	/**

--- a/classes/Kohana/Valid.php
+++ b/classes/Kohana/Valid.php
@@ -231,7 +231,7 @@ class Kohana_Valid {
 
 		$is_valid_public_ip = (bool) filter_var($ip, FILTER_VALIDATE_IP, $flags);
 
-		if ( ! $allow_private)
+		if ($allow_private === FALSE)
 		{
 			return $is_valid_public_ip;
 		}


### PR DESCRIPTION
In a breaking change, https://github.com/php/php-src/pull/1954 added `FILTER_FLAG_NO_PRIV_RANGE` to `FILTER_FLAG_NO_RES_RANGE`.

The patch looks awful. Let me know if there is any better way to fix this.

Cheers!
