### PR TITLE
Throw exception in Valid::ip on some incompatible minor versions

### DIFF
--- a/classes/Kohana/Valid.php
+++ b/classes/Kohana/Valid.php
@@ -224,6 +224,15 @@ class Kohana_Valid {
 	 */
 	public static function ip($ip, $allow_private = TRUE)
 	{
+		$versions_to_skip = array('5.6.25', '5.6.26', '7.0.10', '7.0.11');
+		foreach ($versions_to_skip as $version)
+		{
+			if (version_compare(PHP_VERSION, $version, '=='))
+			{
+				throw new Kohana_Exception("Valid::ip not compatible with PHP $version");
+			}
+		}
+
 		// Do not allow reserved addresses
 		$flags = FILTER_FLAG_NO_RES_RANGE;
 

--- a/tests/kohana/ValidTest.php
+++ b/tests/kohana/ValidTest.php
@@ -593,6 +593,15 @@ class Kohana_ValidTest extends Unittest_TestCase
 	 */
 	public function test_ip($input_ip, $allow_private, $expected_result)
 	{
+		$versions_to_skip = array('5.6.25', '5.6.26', '7.0.10', '7.0.11');
+		foreach ($versions_to_skip as $version)
+		{
+			if (version_compare(PHP_VERSION, $version, '=='))
+			{
+				$this->setExpectedException('Kohana_Exception');
+			}
+		}
+
 		$this->assertEquals(
 			$expected_result,
 			Valid::ip($input_ip, $allow_private)


### PR DESCRIPTION
PHP 5.6.25, 5.6.26, 7.0.10, 7.0.11 include backward incompatible
bugfixes which later were reverted in the minor versions that followed.

See https://github.com/php/php-src/pull/1954
