### PR TITLE
Make logs more automatic-parse friendly

### DIFF
--- a/classes/Kohana/Log.php
+++ b/classes/Kohana/Log.php
@@ -161,7 +161,7 @@ class Kohana_Log {
 			'level'      => $level,
 			'body'       => $message,
 			'trace'      => $trace,
-			'file'       => isset($trace[0]['file']) ? $trace[0]['file'] : NULL,
+			'file'       => isset($trace[0]['file']) ? Debug::path($trace[0]['file']) : NULL,
 			'line'       => isset($trace[0]['line']) ? $trace[0]['line'] : NULL,
 			'class'      => isset($trace[0]['class']) ? $trace[0]['class'] : NULL,
 			'function'   => isset($trace[0]['function']) ? $trace[0]['function'] : NULL,

--- a/classes/Kohana/Log/Writer.php
+++ b/classes/Kohana/Log/Writer.php
@@ -73,13 +73,15 @@ abstract class Kohana_Log_Writer {
 	 * @param   string  $format
 	 * @return  string
 	 */
-	public function format_message(array $message, $format = "time --- level: body in file:line")
+	public function format_message(array $message, $format = "time --- level: body ~ file [ line ]")
 	{
 		$message['time'] = Date::formatted_time('@'.$message['time'], Log_Writer::$timestamp, Log_Writer::$timezone, TRUE);
 		$message['level'] = $this->_log_levels[$message['level']];
 
 		$string = strtr($format, array_filter($message, 'is_scalar'));
 
+		if (substr($string,-16)===' ~ file [ line ]')
+			$string=substr($string,0,-16);
 		if (isset($message['additional']['exception']))
 		{
 			// Re-use as much as possible, just resetting the body to the trace


### PR DESCRIPTION
>>> system/classes/Kohana/Log.php
- shortens path using Debug::path to prevent site owner (viewing logs) from long (sometimes, very long) paths;
>>> system/classes/Kohana/Log/Writer.php
- unify log filenames for regular logs (from normal application execution) and from exception handling (regular log procedure call generate log in form "message in file.php:123", but excptions generate log in format "message ~ file.php [123]"). I use automatic log's analyzer, so it's quite inconvinient to create different patterns for different log's messages;