### PR TITLE
Mastercard new numbers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ php:
 matrix:
   include:
     - php: 5.3
+      dist: precise
       env: 'COMPOSER_PHPUNIT="lowest"'
 
 before_script:

--- a/config/credit_cards.php
+++ b/config/credit_cards.php
@@ -47,7 +47,7 @@ return array(
 
 	'mastercard' => array(
 		'length' => '16',
-		'prefix' => '5[1-5]',
+		'prefix' => '5[1-5]|2[2-7]',
 		'luhn'   => TRUE,
 	),
 


### PR DESCRIPTION
Added Expansion to 2-series Bank Identification Numbers (BINs) for Mastercard. This applies to credit card validation.